### PR TITLE
Add sizes and srcset props

### DIFF
--- a/src/Properties.fs
+++ b/src/Properties.fs
@@ -241,6 +241,8 @@ type prop =
     static member inline onAnimationIteration (handler: AnimationEvent -> unit) = Interop.mkAttr "onAnimationIteration" handler
     static member inline onTransitionEnd (handler: TransitionEvent -> unit) = Interop.mkAttr "onTransitionEnd" handler
     static member inline style (properties: IStyleAttribute list) = Interop.mkAttr "style" (keyValueList CaseRules.LowerFirst properties)
+    static member inline sizes (value: string) = Interop.mkAttr "sizes" value
+    static member inline srcset (value: string) = Interop.mkAttr "srcset" value
 
 module prop =
     let styleList (properties: (bool * IStyleAttribute list) list) =


### PR DESCRIPTION
Fixes #20 

Just thin string wrappers, because there are so many variants of the syntax, particularly for `sizes`.