### PR TITLE
WIP Add React.useCallback, React.useMemo, React.memo

### DIFF
--- a/Feliz/React.fs
+++ b/Feliz/React.fs
@@ -8,6 +8,44 @@ module internal ReactInterop =
     let useEffectWithDeps (effect:  obj) (deps: obj) : unit = import "useEffectWithDeps" "./ReactInterop.js"
     let useEffect (effect: obj) : unit =  import "useEffect" "./ReactInterop.js"
 
+type internal Internal() =
+    static let propsWithKey (withKey: ('props -> string) option) props =
+        match withKey with
+        | Some f ->
+            props?key <- f props
+            props
+        | None -> props
+    static member
+        functionComponent
+        (
+            renderElement: 'props -> Fable.React.ReactElement,
+            ?name: string,
+            ?withKey: 'props -> string
+        )
+        : Fable.React.FunctionComponent<'props> =
+            let functionElementType = Fable.React.ReactElementType.ofFunction renderElement
+            name |> Option.iter (fun name -> functionElementType?displayName <- name)
+            fun props ->
+                let props = props |> propsWithKey withKey
+                Fable.React.ReactElementType.create functionElementType props []
+    static member
+        memo
+        (
+            renderElement: 'props -> Fable.React.ReactElement,
+            ?name: string,
+            ?areEqual: 'props -> 'props -> bool,
+            ?withKey: 'props -> string
+        )
+        : Fable.React.FunctionComponent<'props> =
+            let memoElementType =
+                match areEqual with
+                | Some areEqual -> Fable.React.ReactElementType.memoWith areEqual renderElement
+                | None -> Fable.React.ReactElementType.memo renderElement
+            name |> Option.iter (fun name -> memoElementType?displayName <- name)
+            fun props ->
+                let props = props |> propsWithKey withKey
+                Fable.React.ReactElementType.create memoElementType props []
+
 type React =
     /// The `useState` hook that create a state variable for React function components.
     static member useState<'t>(initial: 't) = Interop.reactApi.useState(initial)
@@ -34,22 +72,271 @@ type React =
             (fun _ ->
                 effect()
                 React.createDisposable(ignore))
+
+    /// <summary>
+    /// The `useCallback` hook. Returns a memoized callback. Pass an inline callback and an array of dependencies.
+    /// `useCallback` will return a memoized version of the callback that only changes if one of the dependencies has changed.
+    /// </summary>
+    /// <param name='callbackFunction'>A callback function to be memoized.</param>
+    /// <param name='dependencies'>An array of dependencies upon which the callback function depends.
+    /// If not provided, defaults to empty array, representing dependencies that never change.</param>
+    static member useCallback(callbackFunction: 'a -> 'b, ?dependencies: obj array) =
+      Interop.reactApi.useCallback callbackFunction (defaultArg dependencies [||])
+
+    /// <summary>
+    /// The `useMemo` hook. Returns a memoized value. Pass a "create" function and an array of dependencies.
+    /// `useMemo` will only recompute the memoized value when one of the dependencies has changed.
+    /// </summary>
+    /// <param name='createFunction'>A create function returning a value to be memoized.</param>
+    /// <param name='dependencies'>An array of dependencies upon which the create function depends.
+    /// If not provided, defaults to empty array, representing dependencies that never change.</param>
+    static member useMemo(createFunction: unit -> 'a, ?dependencies: obj array) =
+      Interop.reactApi.useMemo createFunction (defaultArg dependencies [||])
+
+    //
+    // React.functionComponent
+    //
+
+    /// <summary>
+    /// Creates a React function component from a function that accepts a "props" object and renders a result.
+    /// A component key can be provided in the props object, or a custom `withKey` function can be provided.
+    /// </summary>
+    /// <param name='render'>A render function that returns an element.</param>
     static member functionComponent(render: 'props -> Fable.React.ReactElement) =
-        Fable.React.FunctionComponent.Of(render=render)
+        Internal.functionComponent(render)
+
+    /// <summary>
+    /// Creates a React function component from a function that accepts a "props" object and renders a result.
+    /// A component key can be provided in the props object, or a custom `withKey` function can be provided.
+    /// </summary>
+    /// <param name='name'>The component name to display in the React dev tools.</param>
+    /// <param name='render'>A render function that returns an element.</param>
     static member functionComponent(name: string, render: 'props -> Fable.React.ReactElement) =
-        Fable.React.FunctionComponent.Of(displayName=name, render=render)
-    /// The `useCallback` hook. Returns a memoized callback. Pass an inline callback and an array of dependencies. `useCallback` will return a memoized version of the callback that only changes if one of the dependencies has changed.
-    static member useCallback(callbackFunction: 'a -> 'b, dependencies: obj array) = Interop.reactApi.useCallback callbackFunction dependencies
-    /// The `useMemo` hook. Returns a memoized value. Pass a "create" function and an array of dependencies. `useMemo` will only recompute the memoized value when one of the dependencies has changed.
-    static member useMemo(createFunction: unit -> 'a, dependencies: obj array) = Interop.reactApi.useMemo createFunction dependencies
-    /// `React.memo` is a higher order component for function components.
-    /// If your function component renders the same result given the same props, you can wrap it in a call to `React.memo` for a performance boost in some cases by memoizing the result. This means that React will skip rendering the component, and reuse the last rendered result.
-    /// By default it will only shallowly compare complex objects in the props object. If you want control over the comparison, you can also provide a custom comparison function as the second argument.
-    static member memo(render: 'props -> Fable.React.ReactElement, ?areEqual: 'props -> 'props -> bool, ?displayName : string) : Fable.React.FunctionComponent<'props> =
-        let memoElementType =
-            match areEqual with
-            | Some areEqual -> Fable.React.ReactElementType.memoWith areEqual render
-            | None -> Fable.React.ReactElementType.memo render
-        displayName |> Option.iter (fun name -> memoElementType?displayName <- name)
-        fun props ->
-          Fable.React.ReactElementType.create memoElementType props []
+        Internal.functionComponent(render, name)
+
+    /// <summary>
+    /// Creates a React function component from a function that accepts a "props" object and renders a result.
+    /// A component key can be provided in the props object, or a custom `withKey` function can be provided.
+    /// </summary>
+    /// <param name='withKey'>A function to derive a component key from the props.</param>
+    /// <param name='render'>A render function that returns an element.</param>
+    static member functionComponent(withKey: 'props -> string, render: 'props -> Fable.React.ReactElement) =
+        Internal.functionComponent(render, withKey=withKey)
+
+    /// <summary>
+    /// Creates a React function component from a function that accepts a "props" object and renders a result.
+    /// A component key can be provided in the props object, or a custom `withKey` function can be provided.
+    /// </summary>
+    /// <param name='name'>The component name to display in the React dev tools.</param>
+    /// <param name='withKey'>A function to derive a component key from the props.</param>
+    /// <param name='render'>A render function that returns an element.</param>
+    static member functionComponent(name: string, withKey: 'props -> string, render: 'props -> Fable.React.ReactElement) =
+        Internal.functionComponent(render, name, withKey=withKey)
+
+    /// <summary>
+    /// Creates a React function component from a function that accepts a "props" object and renders a result.
+    /// A component key can be provided in the props object, or a custom `withKey` function can be provided.
+    /// </summary>
+    /// <param name='render'>A render function that returns a list of elements.</param>
+    static member functionComponent(render: 'props -> #seq<Fable.React.ReactElement>) =
+        Internal.functionComponent(render >> Html.fragment)
+
+    /// <summary>
+    /// Creates a React function component from a function that accepts a "props" object and renders a result.
+    /// A component key can be provided in the props object, or a custom `withKey` function can be provided.
+    /// </summary>
+    /// <param name='name'>The component name to display in the React dev tools.</param>
+    /// <param name='render'>A render function that returns a list of elements.</param>
+    static member functionComponent(name: string, render: 'props -> #seq<Fable.React.ReactElement>) =
+        Internal.functionComponent(render >> Html.fragment, name)
+
+    /// <summary>
+    /// Creates a React function component from a function that accepts a "props" object and renders a result.
+    /// A component key can be provided in the props object, or a custom `withKey` function can be provided.
+    /// </summary>
+    /// <param name='withKey'>A function to derive a component key from the props.</param>
+    /// <param name='render'>A render function that returns a list of elements.</param>
+    static member functionComponent(withKey: 'props -> string, render: 'props -> #seq<Fable.React.ReactElement>) =
+        Internal.functionComponent(render >> Html.fragment, withKey=withKey)
+
+    /// <summary>
+    /// Creates a React function component from a function that accepts a "props" object and renders a result.
+    /// A component key can be provided in the props object, or a custom `withKey` function can be provided.
+    /// </summary>
+    /// <param name='name'>The component name to display in the React dev tools.</param>
+    /// <param name='withKey'>A function to derive a component key from the props.</param>
+    /// <param name='render'>A render function that returns a list of elements.</param>
+    static member functionComponent(name: string, withKey: 'props -> string, render: 'props -> #seq<Fable.React.ReactElement>) =
+        Internal.functionComponent(render >> Html.fragment, name, withKey=withKey)
+
+    //
+    // React.memo
+    //
+
+    /// <summary>
+    /// `React.memo` memoizes the result of a function component. Given the same props, React will skip rendering the component, and reuse the last rendered result.
+    /// By default it will only shallowly compare complex objects in the props object. For more control, a custom `areEqual` function can be provided.
+    /// A component key can be provided in the props object, or a custom `withKey` function can be provided.
+    /// </summary>
+    /// <param name='render'>A render function or a React.functionComponent.</param>
+    static member memo(render: 'props -> Fable.React.ReactElement) =
+        Internal.memo(render)
+
+    /// <summary>
+    /// `React.memo` memoizes the result of a function component. Given the same props, React will skip rendering the component, and reuse the last rendered result.
+    /// By default it will only shallowly compare complex objects in the props object. For more control, a custom `areEqual` function can be provided.
+    /// A component key can be provided in the props object, or a custom `withKey` function can be provided.
+    /// </summary>
+    /// <param name='name'>The component name to display in the React dev tools.</param>
+    /// <param name='render'>A render function or a React.functionComponent.</param>
+    static member memo(name: string, render: 'props -> Fable.React.ReactElement) =
+        Internal.memo(render, name)
+
+    /// <summary>
+    /// `React.memo` memoizes the result of a function component. Given the same props, React will skip rendering the component, and reuse the last rendered result.
+    /// By default it will only shallowly compare complex objects in the props object. For more control, a custom `areEqual` function can be provided.
+    /// A component key can be provided in the props object, or a custom `withKey` function can be provided.
+    /// </summary>
+    /// <param name='areEqual'>A custom comparison function to use instead of React's default shallow compare.</param>
+    /// <param name='render'>A render function or a React.functionComponent.</param>
+    static member memo(areEqual: 'props -> 'props -> bool, render: 'props -> Fable.React.ReactElement) =
+        Internal.memo(render, areEqual=areEqual)
+
+    /// <summary>
+    /// `React.memo` memoizes the result of a function component. Given the same props, React will skip rendering the component, and reuse the last rendered result.
+    /// By default it will only shallowly compare complex objects in the props object. For more control, a custom `areEqual` function can be provided.
+    /// A component key can be provided in the props object, or a custom `withKey` function can be provided.
+    /// </summary>
+    /// <param name='withKey'>A function to derive a component key from the props.</param>
+    /// <param name='render'>A render function or a React.functionComponent.</param>
+    static member memo(withKey: 'props -> string, render: 'props -> Fable.React.ReactElement) =
+        Internal.memo(render, withKey=withKey)
+
+    /// <summary>
+    /// `React.memo` memoizes the result of a function component. Given the same props, React will skip rendering the component, and reuse the last rendered result.
+    /// By default it will only shallowly compare complex objects in the props object. For more control, a custom `areEqual` function can be provided.
+    /// A component key can be provided in the props object, or a custom `withKey` function can be provided.
+    /// </summary>
+    /// <param name='name'>The component name to display in the React dev tools.</param>
+    /// <param name='areEqual'>A custom comparison function to use instead of React's default shallow compare.</param>
+    /// <param name='render'>A render function or a React.functionComponent.</param>
+    static member memo(name: string, areEqual: 'props -> 'props -> bool, render: 'props -> Fable.React.ReactElement) =
+        Internal.memo(render, name, areEqual=areEqual)
+
+    /// <summary>
+    /// `React.memo` memoizes the result of a function component. Given the same props, React will skip rendering the component, and reuse the last rendered result.
+    /// By default it will only shallowly compare complex objects in the props object. For more control, a custom `areEqual` function can be provided.
+    /// A component key can be provided in the props object, or a custom `withKey` function can be provided.
+    /// </summary>
+    /// <param name='name'>The component name to display in the React dev tools.</param>
+    /// <param name='withKey'>A function to derive a component key from the props.</param>
+    /// <param name='render'>A render function or a React.functionComponent.</param>
+    static member memo(name: string, withKey: 'props -> string, render: 'props -> Fable.React.ReactElement) =
+        Internal.memo(render, name, withKey=withKey)
+
+    /// <summary>
+    /// `React.memo` memoizes the result of a function component. Given the same props, React will skip rendering the component, and reuse the last rendered result.
+    /// By default it will only shallowly compare complex objects in the props object. For more control, a custom `areEqual` function can be provided.
+    /// A component key can be provided in the props object, or a custom `withKey` function can be provided.
+    /// </summary>
+    /// <param name='areEqual'>A custom comparison function to use instead of React's default shallow compare.</param>
+    /// <param name='withKey'>A function to derive a component key from the props.</param>
+    /// <param name='render'>A render function or a React.functionComponent.</param>
+    static member memo(areEqual: 'props -> 'props -> bool, withKey: 'props -> string, render: 'props -> Fable.React.ReactElement) =
+        Internal.memo(render, areEqual=areEqual, withKey=withKey)
+
+    /// <summary>
+    /// `React.memo` memoizes the result of a function component. Given the same props, React will skip rendering the component, and reuse the last rendered result.
+    /// By default it will only shallowly compare complex objects in the props object. For more control, a custom `areEqual` function can be provided.
+    /// A component key can be provided in the props object, or a custom `withKey` function can be provided.
+    /// </summary>
+    /// <param name='name'>The component name to display in the React dev tools.</param>
+    /// <param name='areEqual'>A custom comparison function to use instead of React's default shallow compare.</param>
+    /// <param name='withKey'>A function to derive a component key from the props.</param>
+    /// <param name='render'>A render function or a React.functionComponent.</param>
+    static member memo(name: string, areEqual: 'props -> 'props -> bool, withKey: 'props -> string, render: 'props -> Fable.React.ReactElement) =
+        Internal.memo(render, name, areEqual=areEqual, withKey=withKey)
+
+    /// <summary>
+    /// `React.memo` memoizes the result of a function component. Given the same props, React will skip rendering the component, and reuse the last rendered result.
+    /// By default it will only shallowly compare complex objects in the props object. For more control, a custom `areEqual` function can be provided.
+    /// A component key can be provided in the props object, or a custom `withKey` function can be provided.
+    /// </summary>
+    /// <param name='render'>A render function that returns a list of elements.</param>
+    static member memo(render: 'props -> #seq<Fable.React.ReactElement>) =
+        Internal.memo(render >> Html.fragment)
+
+    /// <summary>
+    /// `React.memo` memoizes the result of a function component. Given the same props, React will skip rendering the component, and reuse the last rendered result.
+    /// By default it will only shallowly compare complex objects in the props object. For more control, a custom `areEqual` function can be provided.
+    /// A component key can be provided in the props object, or a custom `withKey` function can be provided.
+    /// </summary>
+    /// <param name='name'>The component name to display in the React dev tools.</param>
+    /// <param name='render'>A render function that returns a list of elements.</param>
+    static member memo(name: string, render: 'props -> #seq<Fable.React.ReactElement>) =
+        Internal.memo(render >> Html.fragment, name)
+
+    /// <summary>
+    /// `React.memo` memoizes the result of a function component. Given the same props, React will skip rendering the component, and reuse the last rendered result.
+    /// By default it will only shallowly compare complex objects in the props object. For more control, a custom `areEqual` function can be provided.
+    /// A component key can be provided in the props object, or a custom `withKey` function can be provided.
+    /// </summary>
+    /// <param name='areEqual'>A custom comparison function to use instead of React's default shallow compare.</param>
+    /// <param name='render'>A render function that returns a list of elements.</param>
+    static member memo(areEqual: 'props -> 'props -> bool, render: 'props -> #seq<Fable.React.ReactElement>) =
+        Internal.memo(render >> Html.fragment, areEqual=areEqual)
+
+    /// <summary>
+    /// `React.memo` memoizes the result of a function component. Given the same props, React will skip rendering the component, and reuse the last rendered result.
+    /// By default it will only shallowly compare complex objects in the props object. For more control, a custom `areEqual` function can be provided.
+    /// A component key can be provided in the props object, or a custom `withKey` function can be provided.
+    /// </summary>
+    /// <param name='withKey'>A function to derive a component key from the props.</param>
+    /// <param name='render'>A render function that returns a list of elements.</param>
+    static member memo(withKey: 'props -> string, render: 'props -> #seq<Fable.React.ReactElement>) =
+        Internal.memo(render >> Html.fragment, withKey=withKey)
+
+    /// <summary>
+    /// `React.memo` memoizes the result of a function component. Given the same props, React will skip rendering the component, and reuse the last rendered result.
+    /// By default it will only shallowly compare complex objects in the props object. For more control, a custom `areEqual` function can be provided.
+    /// A component key can be provided in the props object, or a custom `withKey` function can be provided.
+    /// </summary>
+    /// <param name='name'>The component name to display in the React dev tools.</param>
+    /// <param name='areEqual'>A custom comparison function to use instead of React's default shallow compare.</param>
+    /// <param name='render'>A render function that returns a list of elements.</param>
+    static member memo(name: string, areEqual: 'props -> 'props -> bool, render: 'props -> #seq<Fable.React.ReactElement>) =
+        Internal.memo(render >> Html.fragment, name, areEqual=areEqual)
+
+    /// <summary>
+    /// `React.memo` memoizes the result of a function component. Given the same props, React will skip rendering the component, and reuse the last rendered result.
+    /// By default it will only shallowly compare complex objects in the props object. For more control, a custom `areEqual` function can be provided.
+    /// A component key can be provided in the props object, or a custom `withKey` function can be provided.
+    /// </summary>
+    /// <param name='name'>The component name to display in the React dev tools.</param>
+    /// <param name='withKey'>A function to derive a component key from the props.</param>
+    /// <param name='render'>A render function that returns a list of elements.</param>
+    static member memo(name: string, withKey: 'props -> string, render: 'props -> #seq<Fable.React.ReactElement>) =
+        Internal.memo(render >> Html.fragment, name, withKey=withKey)
+
+    /// <summary>
+    /// `React.memo` memoizes the result of a function component. Given the same props, React will skip rendering the component, and reuse the last rendered result.
+    /// By default it will only shallowly compare complex objects in the props object. For more control, a custom `areEqual` function can be provided.
+    /// A component key can be provided in the props object, or a custom `withKey` function can be provided.
+    /// </summary>
+    /// <param name='areEqual'>A custom comparison function to use instead of React's default shallow compare.</param>
+    /// <param name='withKey'>A function to derive a component key from the props.</param>
+    /// <param name='render'>A render function that returns a list of elements.</param>
+    static member memo(areEqual: 'props -> 'props -> bool, withKey: 'props -> string, render: 'props -> #seq<Fable.React.ReactElement>) =
+        Internal.memo(render >> Html.fragment, areEqual=areEqual, withKey=withKey)
+
+    /// <summary>
+    /// `React.memo` memoizes the result of a function component. Given the same props, React will skip rendering the component, and reuse the last rendered result.
+    /// By default it will only shallowly compare complex objects in the props object. For more control, a custom `areEqual` function can be provided.
+    /// A component key can be provided in the props object, or a custom `withKey` function can be provided.
+    /// </summary>
+    /// <param name='name'>The component name to display in the React dev tools.</param>
+    /// <param name='areEqual'>A custom comparison function to use instead of React's default shallow compare.</param>
+    /// <param name='withKey'>A function to derive a component key from the props.</param>
+    /// <param name='render'>A render function that returns a list of elements.</param>
+    static member memo(name: string, areEqual: 'props -> 'props -> bool, withKey: 'props -> string, render: 'props -> #seq<Fable.React.ReactElement>) =
+        Internal.memo(render >> Html.fragment, name, areEqual=areEqual, withKey=withKey)

--- a/Feliz/React.fs
+++ b/Feliz/React.fs
@@ -38,3 +38,18 @@ type React =
         Fable.React.FunctionComponent.Of(render=render)
     static member functionComponent(name: string, render: 'props -> Fable.React.ReactElement) =
         Fable.React.FunctionComponent.Of(displayName=name, render=render)
+    /// The `useCallback` hook. Returns a memoized callback. Pass an inline callback and an array of dependencies. `useCallback` will return a memoized version of the callback that only changes if one of the dependencies has changed.
+    static member useCallback(callbackFunction: 'a -> 'b, dependencies: obj array) = Interop.reactApi.useCallback callbackFunction dependencies
+    /// The `useMemo` hook. Returns a memoized value. Pass a "create" function and an array of dependencies. `useMemo` will only recompute the memoized value when one of the dependencies has changed.
+    static member useMemo(createFunction: unit -> 'a, dependencies: obj array) = Interop.reactApi.useMemo createFunction dependencies
+    /// `React.memo` is a higher order component for function components.
+    /// If your function component renders the same result given the same props, you can wrap it in a call to `React.memo` for a performance boost in some cases by memoizing the result. This means that React will skip rendering the component, and reuse the last rendered result.
+    /// By default it will only shallowly compare complex objects in the props object. If you want control over the comparison, you can also provide a custom comparison function as the second argument.
+    static member memo(render: 'props -> Fable.React.ReactElement, ?areEqual: 'props -> 'props -> bool, ?displayName : string) : Fable.React.FunctionComponent<'props> =
+        let memoElementType =
+            match areEqual with
+            | Some areEqual -> Fable.React.ReactElementType.memoWith areEqual render
+            | None -> Fable.React.ReactElementType.memo render
+        displayName |> Option.iter (fun name -> memoElementType?displayName <- name)
+        fun props ->
+          Fable.React.ReactElementType.create memoElementType props []

--- a/Feliz/ReactTypes.fs
+++ b/Feliz/ReactTypes.fs
@@ -16,3 +16,5 @@ type IReactApi =
     abstract createElement: comp: obj * props: obj -> ReactElement
     abstract createElement: comp: obj * props: obj * [<ParamList>] children: ReactElement seq -> ReactElement
     abstract Children : ReactChildren
+    abstract useCallback : callbackFunction: ('a -> 'b) -> dependencies: obj array -> ('a -> 'b)
+    abstract useMemo : createFunction: (unit -> 'a) -> dependencies: obj array -> 'a


### PR DESCRIPTION
`useCallback` and `useMemo` are fairly straightforward.

`React.memo` deserves some discussion.

Currently this essentially matches the [React API](https://reactjs.org/docs/react-api.html#reactmemo) (`React.memo(render, areEqual)`) using optional params: `React.memo(render, ?areEqual, ?displayName)`. (Display name is exclusive to Fable, to provide debug component names for function values.)

It works either for wrapping a React.functionComponent, or as a complete replacement:

```fs
// Wrapping
let counter =
    React.functionComponent("Counter", fun props ->
        Html.div [
            // ...
        ]
    )
let memoWrapCounter = React.memo(counter, displayName="memoWrapCounter")

// Replacement
let memoCounter =
    React.memo(fun props ->
        Html.div [
            // ...
        ]
    , areEqual=myCustomEqualityFn // optional
    , displayName="memoCounter" // optional
    )
```

By default (omitting the `areEqual` param) it is just letting React use its own default internal equality compare. I'm not sure if the `(memo)EqualsButFunctions` functions from Fable.React are very necessary by default for this library. Possibly users can instead use `useCallback` to create stable function references that won't break default equality. In a quick test it seemed to work fine for composed Elmish dispatchers e.g. `{ props.childDispatch = React.useCallback((ChildMsg >> dispatch), [||]) }`.

This current argument order however is inconsistent with the existing `React.functionComponent` which has an overload for display name first. So probably a maintainer decision regarding internal consistency vs. API conformity.

There is also the question whether to keep it as a separate `React.memo`, or be more like the Fable.React approach and have it combined with the `React.functionComponent` using additional overloads and/or optional params.