### PR TITLE
Adds prop.none as counterpart of Html.none

### DIFF
--- a/Feliz/Properties.fs
+++ b/Feliz/Properties.fs
@@ -40,6 +40,8 @@ type AriaRelevant =
 
 /// Represents the native Html properties.
 type prop =
+    /// The empty property, adds no attribute to element.
+    static member inline none = Interop.mkAttr "" ""
     /// Often used with CSS to style a specific element. The value of this attribute must be unique.
     static member inline id(value: string) = Interop.mkAttr "id" value
     /// Used to reference a DOM element or class component from within a parent component.


### PR DESCRIPTION
Can be hand when generating props based on some model (sometimes you don't need yield any, e.g. when validation is ok)

I am not sure if needs to be `inline` though.