### PR TITLE
Remove height entry in pigeonmaps.fs

### DIFF
--- a/Feliz.PigeonMaps/PigeonMaps.fs
+++ b/Feliz.PigeonMaps/PigeonMaps.fs
@@ -18,7 +18,7 @@ type PigeonMaps =
         let defaults = createObj [
             "center" ==> [| 40.416775; -3.703790 |]
             "zoom" ==> 3
-            "height" ==> 200
+
         ]
 
         Interop.reactApi.createElement(importDefault "pigeon-maps", Interop.objectAssign defaults (createObj !!properties))


### PR DESCRIPTION
While working with a pigeonMaps map in a div, I wanted to size the map according to parent div. (which is based on length.vh(80))

Desired behaviour: resize map according to parent div

Current behaviour: Map sizes to 200px height (the default in PigeonMaps.fs)

The default height property of 200 interferes with the inherited height of the parent div, see image below.

![afbeelding](https://user-images.githubusercontent.com/48645611/75328516-7331f980-587e-11ea-968b-546a4612fe47.png)
