### PR TITLE
Complete HTML elements and attributes

### DIFF
--- a/Feliz/BorderStyle.fs
+++ b/Feliz/BorderStyle.fs
@@ -5,18 +5,14 @@ open Feliz.Styles
 
 [<Erase>]
 type borderStyle =
-    /// Specifies a dotted border.
-    ///
-    /// See example https://www.w3schools.com/cssref/playit.asp?filename=playcss_border-style&preval=dotted
-    static member inline dotted : IBorderStyle = unbox "dotted"
     /// Specifies a dashed border.
     ///
     /// See example https://www.w3schools.com/cssref/playit.asp?filename=playcss_border-style&preval=dotted
     static member inline dashed : IBorderStyle = unbox "dashed"
-    /// Specifies a solid border.
+    /// Specifies a dotted border.
     ///
     /// See example https://www.w3schools.com/cssref/playit.asp?filename=playcss_border-style&preval=dotted
-    static member inline solid : IBorderStyle = unbox "solid"
+    static member inline dotted : IBorderStyle = unbox "dotted"
     /// Specifies a double border.
     ///
     /// See example https://www.w3schools.com/cssref/playit.asp?filename=playcss_border-style&preval=dotted
@@ -25,35 +21,39 @@ type borderStyle =
     ///
     /// See example https://www.w3schools.com/cssref/playit.asp?filename=playcss_border-style&preval=dotted
     static member inline groove : IBorderStyle = unbox "groove"
-    /// Specifies a 3D ridged border. The effect depends on the border-color value.
-    ///
-    /// See example https://www.w3schools.com/cssref/playit.asp?filename=playcss_border-style&preval=dotted
-    static member inline ridge : IBorderStyle = unbox "ridge"
-    /// Specifies a 3D inset border. The effect depends on the border-color value.
-    ///
-    /// See example https://www.w3schools.com/cssref/playit.asp?filename=playcss_border-style&preval=dotted
-    static member inline inset : IBorderStyle = unbox "inset"
-    /// Specifies a 3D outset border. The effect depends on the border-color value.
-    ///
-    /// See example https://www.w3schools.com/cssref/playit.asp?filename=playcss_border-style&preval=dotted
-    static member inline outset : IBorderStyle = unbox "outset"
-    /// Default value. Specifies no border.
-    ///
-    /// See example https://www.w3schools.com/cssref/playit.asp?filename=playcss_border-style&preval=dotted
-    static member inline none : IBorderStyle = unbox "none"
     /// The same as "none", except in border conflict resolution for table elements.
     ///
     /// See example https://www.w3schools.com/cssref/playit.asp?filename=playcss_border-style&preval=hidden
     static member inline hidden : IBorderStyle = unbox "hidden"
-    /// Sets this property to its default value.
-    ///
-    /// See example https://www.w3schools.com/cssref/playit.asp?filename=playcss_border-style&preval=hidden
-    ///
-    /// Read about initial value https://www.w3schools.com/cssref/css_initial.asp
-    static member inline initial : IBorderStyle = unbox "initial"
     /// Inherits this property from its parent element.
     ///
     /// See example https://www.w3schools.com/cssref/playit.asp?filename=playcss_border-style&preval=hidden
     ///
     /// Read about inherit https://www.w3schools.com/cssref/css_inherit.asp
     static member inline inheritFromParent : IBorderStyle = unbox "inherit"
+    /// Sets this property to its default value.
+    ///
+    /// See example https://www.w3schools.com/cssref/playit.asp?filename=playcss_border-style&preval=hidden
+    ///
+    /// Read about initial value https://www.w3schools.com/cssref/css_initial.asp
+    static member inline initial : IBorderStyle = unbox "initial"
+    /// Specifies a 3D inset border. The effect depends on the border-color value.
+    ///
+    /// See example https://www.w3schools.com/cssref/playit.asp?filename=playcss_border-style&preval=dotted
+    static member inline inset : IBorderStyle = unbox "inset"
+    /// Default value. Specifies no border.
+    ///
+    /// See example https://www.w3schools.com/cssref/playit.asp?filename=playcss_border-style&preval=dotted
+    static member inline none : IBorderStyle = unbox "none"
+    /// Specifies a 3D outset border. The effect depends on the border-color value.
+    ///
+    /// See example https://www.w3schools.com/cssref/playit.asp?filename=playcss_border-style&preval=dotted
+    static member inline outset : IBorderStyle = unbox "outset"
+    /// Specifies a 3D ridged border. The effect depends on the border-color value.
+    ///
+    /// See example https://www.w3schools.com/cssref/playit.asp?filename=playcss_border-style&preval=dotted
+    static member inline ridge : IBorderStyle = unbox "ridge"
+    /// Specifies a solid border.
+    ///
+    /// See example https://www.w3schools.com/cssref/playit.asp?filename=playcss_border-style&preval=dotted
+    static member inline solid : IBorderStyle = unbox "solid"

--- a/Feliz/Fonts.fs
+++ b/Feliz/Fonts.fs
@@ -238,4 +238,3 @@ module font =
     let [<Literal>] yuGothicUI = "Yu Gothic UI"
     let [<Literal>] yuMincho = "Yu Mincho"
     let [<Literal>] zapfChancery = "Zapf Chancery"
-

--- a/Feliz/Html.fs
+++ b/Feliz/Html.fs
@@ -7,250 +7,639 @@ open System
 
 [<Erase>]
 type Html =
-    /// The empty element, renders nothing on screen
-    static member inline none : ReactElement = unbox null
+    static member inline a xs = Interop.createElement "a" xs
+    static member inline a (children: #seq<ReactElement>) = Interop.reactElementWithChildren "a" children
+    
+    static member inline abbr xs = Interop.createElement "abbr" xs
+    static member inline abbr (value: float) = Interop.reactElementWithChild "abbr" value
+    static member inline abbr (value: int) = Interop.reactElementWithChild "abbr" value
+    static member inline abbr (value: ReactElement) = Interop.reactElementWithChild "abbr" value
+    static member inline abbr (value: string) = Interop.reactElementWithChild "abbr" value
+    static member inline abbr (children: #seq<ReactElement>) = Interop.reactElementWithChildren "abbr" children
+
+    static member inline address xs = Interop.createElement "address" xs
+    static member inline address (value: float) = Interop.reactElementWithChild "address" value
+    static member inline address (value: int) = Interop.reactElementWithChild "address" value
+    static member inline address (value: ReactElement) = Interop.reactElementWithChild "address" value
+    static member inline address (value: string) = Interop.reactElementWithChild "address" value
+    static member inline address (children: #seq<ReactElement>) = Interop.reactElementWithChildren "address" children
+
+    static member inline anchor xs = Interop.createElement "a" xs
+    static member inline anchor (children: #seq<ReactElement>) = Interop.reactElementWithChildren "a" children
+
+    static member inline area xs = Interop.createElement "area" xs
+
+    static member inline article xs = Interop.createElement "article" xs
+    static member inline article (children: #seq<ReactElement>) = Interop.reactElementWithChildren "article" children
+
+    static member inline aside xs = Interop.createElement "aside" xs
+    static member inline aside (children: #seq<ReactElement>) = Interop.reactElementWithChildren "aside" children
+    
+    static member inline audio xs = Interop.createElement "audio" xs
+    static member inline audio (children: #seq<ReactElement>) = Interop.reactElementWithChildren "audio" children
+    
+    static member inline b xs = Interop.createElement "b" xs
+    static member inline b (value: float) = Interop.reactElementWithChild "b" value
+    static member inline b (value: int) = Interop.reactElementWithChild "b" value
+    static member inline b (value: ReactElement) = Interop.reactElementWithChild "b" value
+    static member inline b (value: string) = Interop.reactElementWithChild "b" value
+    static member inline b (children: #seq<ReactElement>) = Interop.reactElementWithChildren "b" children
+
+    static member inline base' xs = Interop.createElement "base" xs
+
+    static member inline bdi xs = Interop.createElement "bdi" xs
+    static member inline bdi (value: float) = Interop.reactElementWithChild "bdi" value
+    static member inline bdi (value: int) = Interop.reactElementWithChild "bdi" value
+    static member inline bdi (value: ReactElement) = Interop.reactElementWithChild "bdi" value
+    static member inline bdi (value: string) = Interop.reactElementWithChild "bdi" value
+    static member inline bdi (children: #seq<ReactElement>) = Interop.reactElementWithChildren "bdi" children
+
+    static member inline bdo xs = Interop.createElement "bdo" xs
+    static member inline bdo (value: float) = Interop.reactElementWithChild "bdo" value
+    static member inline bdo (value: int) = Interop.reactElementWithChild "bdo" value
+    static member inline bdo (value: ReactElement) = Interop.reactElementWithChild "bdo" value
+    static member inline bdo (value: string) = Interop.reactElementWithChild "bdo" value
+    static member inline bdo (children: #seq<ReactElement>) = Interop.reactElementWithChildren "bdo" children
+
+    static member inline blockquote xs = Interop.createElement "blockquote" xs
+    static member inline blockquote (value: float) = Interop.reactElementWithChild "blockquote" value
+    static member inline blockquote (value: int) = Interop.reactElementWithChild "blockquote" value
+    static member inline blockquote (value: ReactElement) = Interop.reactElementWithChild "blockquote" value
+    static member inline blockquote (value: string) = Interop.reactElementWithChild "blockquote" value
+    static member inline blockquote (children: #seq<ReactElement>) = Interop.reactElementWithChildren "blockquote" children
+
+    static member inline body xs = Interop.createElement "body" xs
+    static member inline body (value: float) = Interop.reactElementWithChild "body" value
+    static member inline body (value: int) = Interop.reactElementWithChild "body" value
+    static member inline body (value: ReactElement) = Interop.reactElementWithChild "body" value
+    static member inline body (value: string) = Interop.reactElementWithChild "body" value
+    static member inline body (children: #seq<ReactElement>) = Interop.reactElementWithChildren "body" children
+
+    static member inline br xs = Interop.createElement "br" xs
+
+    static member inline button xs = Interop.createElement "button" xs
+    static member inline button (children: #seq<ReactElement>) = Interop.reactElementWithChildren "button" children
+
+    static member inline canvas xs = Interop.createElement "canvas" xs
+
+    static member inline caption xs = Interop.createElement "caption" xs
+    static member inline caption (value: float) = Interop.reactElementWithChild "caption" value
+    static member inline caption (value: int) = Interop.reactElementWithChild "caption" value
+    static member inline caption (value: ReactElement) = Interop.reactElementWithChild "caption" value
+    static member inline caption (value: string) = Interop.reactElementWithChild "caption" value
+    static member inline caption (children: #seq<ReactElement>) = Interop.reactElementWithChildren "caption" children
+
+    static member inline cite xs = Interop.createElement "cite" xs
+    static member inline cite (value: float) = Interop.reactElementWithChild "cite" value
+    static member inline cite (value: int) = Interop.reactElementWithChild "cite" value
+    static member inline cite (value: ReactElement) = Interop.reactElementWithChild "cite" value
+    static member inline cite (value: string) = Interop.reactElementWithChild "cite" value
+    static member inline cite (children: #seq<ReactElement>) = Interop.reactElementWithChildren "cite" children
+
+    static member inline circle xs = Interop.createElement "circle" xs
+    static member inline circle (children: #seq<ReactElement>) = Interop.reactElementWithChildren "circle" children
+    
+    static member inline clipPath xs = Interop.createElement "clipPath" xs
+    static member inline clipPath (children: #seq<ReactElement>) = Interop.reactElementWithChildren "clipPath" children
+
+    static member inline code xs = Interop.createElement "code" xs
+    static member inline code (value: bool) = Interop.reactElementWithChild "code" value
+    static member inline code (value: float) = Interop.reactElementWithChild "code" value
+    static member inline code (value: int) = Interop.reactElementWithChild "code" value
+    static member inline code (value: ReactElement) = Interop.reactElementWithChild "code" value
+    static member inline code (value: string) = Interop.reactElementWithChild "code" value
+    static member inline code (children: #seq<ReactElement>) = Interop.reactElementWithChildren "code" children
+
+    static member inline col xs = Interop.createElement "col" xs
+
+    static member inline colgroup xs = Interop.createElement "colgroup" xs
+    static member inline colgroup (children: #seq<ReactElement>) = Interop.reactElementWithChildren "colgroup" children
+
+    [<Obsolete("This deprecated API should no longer be used, but will probably still work.")>]
+    static member inline content (value: float) : ReactElement = unbox value
+    [<Obsolete("This deprecated API should no longer be used, but will probably still work.")>]
+    static member inline content (value: int) : ReactElement = unbox value
+    [<Obsolete("This deprecated API should no longer be used, but will probably still work.")>]
+    static member inline content (value: string) : ReactElement = unbox value
+
+    static member inline data xs = Interop.createElement "data" xs
+    static member inline data (value: float) = Interop.reactElementWithChild "data" value
+    static member inline data (value: int) = Interop.reactElementWithChild "data" value
+    static member inline data (value: ReactElement) = Interop.reactElementWithChild "data" value
+    static member inline data (value: string) = Interop.reactElementWithChild "data" value
+    static member inline data (children: #seq<ReactElement>) = Interop.reactElementWithChildren "data" children
+
+    static member inline datalist xs = Interop.createElement "datalist" xs
+    static member inline datalist (value: float) = Interop.reactElementWithChild "datalist" value
+    static member inline datalist (value: int) = Interop.reactElementWithChild "datalist" value
+    static member inline datalist (value: ReactElement) = Interop.reactElementWithChild "datalist" value
+    static member inline datalist (value: string) = Interop.reactElementWithChild "datalist" value
+    static member inline datalist (children: #seq<ReactElement>) = Interop.reactElementWithChildren "datalist" children
+
+    static member inline dd xs = Interop.createElement "dd" xs
+    static member inline dd (value: float) = Interop.reactElementWithChild "dd" value
+    static member inline dd (value: int) = Interop.reactElementWithChild "dd" value
+    static member inline dd (value: ReactElement) = Interop.reactElementWithChild "dd" value
+    static member inline dd (value: string) = Interop.reactElementWithChild "dd" value
+    static member inline dd (children: #seq<ReactElement>) = Interop.reactElementWithChildren "dd" children
+
+    static member inline defs xs = Interop.createElement "defs" xs
+    static member inline defs (children: #seq<ReactElement>) = Interop.reactElementWithChildren "defs" children
+
+    static member inline del xs = Interop.createElement "del" xs
+    static member inline del (value: float) = Interop.reactElementWithChild "del" value
+    static member inline del (value: int) = Interop.reactElementWithChild "del" value
+    static member inline del (value: ReactElement) = Interop.reactElementWithChild "del" value
+    static member inline del (value: string) = Interop.reactElementWithChild "del" value
+    static member inline del (children: #seq<ReactElement>) = Interop.reactElementWithChildren "del" children
+
+    static member inline details xs = Interop.createElement "details" xs
+    static member inline details (children: #seq<ReactElement>) = Interop.reactElementWithChildren "details" children
+
+    static member inline dfn xs = Interop.createElement "ins" xs
+    static member inline dfn (value: float) = Interop.reactElementWithChild "dfn" value
+    static member inline dfn (value: int) = Interop.reactElementWithChild "dfn" value
+    static member inline dfn (value: ReactElement) = Interop.reactElementWithChild "dfn" value
+    static member inline dfn (value: string) = Interop.reactElementWithChild "dfn" value
+    static member inline dfn (children: #seq<ReactElement>) = Interop.reactElementWithChildren "dfn" children
+
+    static member inline dialog xs = Interop.createElement "dialog" xs
+    static member inline dialog (value: float) = Interop.reactElementWithChild "dialog" value
+    static member inline dialog (value: int) = Interop.reactElementWithChild "dialog" value
+    static member inline dialog (value: ReactElement) = Interop.reactElementWithChild "dialog" value
+    static member inline dialog (value: string) = Interop.reactElementWithChild "dialog" value
+    static member inline dialog (children: #seq<ReactElement>) = Interop.reactElementWithChildren "dialog" children
+
     /// The `<div>` tag defines a division or a section in an HTML document
     static member inline div xs = Interop.createElement "div" xs
+    static member inline div (value: float) = Interop.reactElementWithChild "div" value
+    static member inline div (value: int) = Interop.reactElementWithChild "div" value
+    static member inline div (value: ReactElement) = Interop.reactElementWithChild "div" value
+    static member inline div (value: string) = Interop.reactElementWithChild "div" value
+    static member inline div (children: #seq<ReactElement>) = Interop.reactElementWithChildren "div" children
+
+    static member inline dl xs = Interop.createElement "dl" xs
+    static member inline dl (children: #seq<ReactElement>) = Interop.reactElementWithChildren "dl" children
+
+    static member inline dt xs = Interop.createElement "dt" xs
+    static member inline dt (value: float) = Interop.reactElementWithChild "dt" value
+    static member inline dt (value: int) = Interop.reactElementWithChild "dt" value
+    static member inline dt (value: ReactElement) = Interop.reactElementWithChild "dt" value
+    static member inline dt (value: string) = Interop.reactElementWithChild "dt" value
+    static member inline dt (children: #seq<ReactElement>) = Interop.reactElementWithChildren "dt" children
+
+    static member inline ellipse xs = Interop.createElement "ellipse" xs
+    static member inline ellipse (children: #seq<ReactElement>) = Interop.reactElementWithChildren "ellipse" children
+
+    static member inline em xs = Interop.createElement "em" xs
+    static member inline em (value: float) = Interop.reactElementWithChild "em" value
+    static member inline em (value: int) = Interop.reactElementWithChild "em" value
+    static member inline em (value: ReactElement) = Interop.reactElementWithChild "em" value
+    static member inline em (value: string) = Interop.reactElementWithChild "em" value
+    static member inline em (children: #seq<ReactElement>) = Interop.reactElementWithChildren "em" children
+
+    static member inline embed xs = Interop.createElement "embed" xs
+
+    static member inline fieldSet xs = Interop.createElement "fieldset" xs
+    static member inline fieldSet (children: #seq<ReactElement>) = Interop.reactElementWithChildren "fieldset" children
+    
+    static member inline figcaption xs = Interop.createElement "figcaption" xs
+    static member inline figcaption (children: #seq<ReactElement>) = Interop.reactElementWithChildren "figcaption" children
+    
+    static member inline figure xs = Interop.createElement "figure" xs
+    static member inline figure (children: #seq<ReactElement>) = Interop.reactElementWithChildren "figure" children
+
+    static member inline footer xs = Interop.createElement "footer" xs
+    static member inline footer (children: #seq<ReactElement>) = Interop.reactElementWithChildren "footer" children
+    
+    static member inline form xs = Interop.createElement "form" xs
+    static member inline form (children: #seq<ReactElement>) = Interop.reactElementWithChildren "form" children
+    
     [<Obsolete("Html.fragment is obsolete, use React.fragment instead. This function will be removed in the coming v1.0 release")>]
     static member inline fragment xs = Fable.React.Helpers.fragment [] xs
-    [<Obsolete("Html.keyedFragment is obsolete, use React.keyedFragment instead. This function will be removed in the coming v1.0 release")>]
-    static member inline keyedFragment(key: int, xs) = Fable.React.Helpers.fragment [ !!("key", key) ] xs
-    [<Obsolete("Html.keyedFragment is obsolete, use React.keyedFragment instead. This function will be removed in the coming v1.0 release")>]
-    static member inline keyedFragment(key: string, xs) = Fable.React.Helpers.fragment [ !!("key", key) ] xs
-    [<Obsolete("Html.keyedFragment is obsolete, use React.keyedFragment instead. This function will be removed in the coming v1.0 release")>]
-    static member inline keyedFragment(key: System.Guid, xs) = Fable.React.Helpers.fragment [ !!("key", string key) ] xs
-    static member inline em xs = Interop.createElement "em" xs
-    static member inline iframe xs = Interop.createElement "iframe" xs
-    static member inline article xs = Interop.createElement "article" xs
-    static member inline article (children: #seq<ReactElement>) = Interop.reactElement "article" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline aside xs = Interop.createElement "aside" xs
-    static member inline aside (children: #seq<ReactElement>) = Interop.reactElement "aside" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline footer xs = Interop.createElement "footer" xs
-    static member inline footer (children: #seq<ReactElement>) = Interop.reactElement "footer" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline progress xs = Interop.createElement "progress" xs
-    static member inline progress (children: #seq<ReactElement>) = Interop.reactElement "progress" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline nav xs = Interop.createElement "nav" xs
-    static member inline nav (children: #seq<ReactElement>) = Interop.reactElement "nav" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline label xs = Interop.createElement "label" xs
-    static member inline label (children: #seq<ReactElement>) = Interop.reactElement "label" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline fieldSet xs = Interop.createElement "fieldset" xs
-    static member inline fieldSet (children: #seq<ReactElement>) = Interop.reactElement "fieldset" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline section xs = Interop.createElement "section" xs
-    static member inline section (children: #seq<ReactElement>) = Interop.reactElement "section" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline figure xs = Interop.createElement "figure" xs
-    static member inline figure (children: #seq<ReactElement>) = Interop.reactElement "figure" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline figcaption xs = Interop.createElement "figcaption" xs
-    static member inline figcaption (children: #seq<ReactElement>) = Interop.reactElement "figcaption" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline select xs = Interop.createElement "select" xs
-    static member inline select (children: #seq<ReactElement>) = Interop.reactElement "select" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline option xs = Interop.createElement "option" xs
-    static member inline option (children: #seq<ReactElement>) = Interop.reactElement "option" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline strong xs = Interop.createElement "strong" xs
-    static member inline table xs = Interop.createElement "table" xs
-    static member inline tbody xs = Interop.createElement "tbody" xs
-    static member inline tbody (children: #seq<ReactElement>) = Interop.reactElement "tbody" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline tableBody xs = Interop.createElement "tbody" xs
-    static member inline tableBody (children: #seq<ReactElement>) = Interop.reactElement "tbody" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline tableRow xs = Interop.createElement "tr" xs
-    static member inline tr xs = Interop.createElement "tr" xs
-    static member inline tr (children: #seq<ReactElement>) = Interop.reactElement "tr" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline del xs = Interop.createElement "del" xs
-    static member inline ins xs = Interop.createElement "ins" xs
-    static member inline dfn xs = Interop.createElement "ins" xs
-    static member inline dialog xs = Interop.createElement "dialog" xs
-    static member inline tableCell xs = Interop.createElement "td" xs
-    static member inline details xs = Interop.createElement "details" xs
-    static member inline details (children: #seq<ReactElement>) = Interop.reactElement "details" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline summary xs = Interop.createElement "summary" xs
-    static member inline summary (children: #seq<ReactElement>) = Interop.reactElement "summary" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline main xs = Interop.createElement "main" xs
-    static member inline main (children: #seq<ReactElement>) = Interop.reactElement "main" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline canvas xs = Interop.createElement "canvas" xs
-    static member inline td xs = Interop.createElement "td" xs
-    static member inline th xs = Interop.createElement "th" xs
-    static member inline tableHeader xs = Interop.createElement "th" xs
-    static member inline tableHeader (children: #seq<ReactElement>) = Interop.reactElement "th" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline thead xs = Interop.createElement "thead" xs
-    static member inline thead (children: #seq<ReactElement>) = Interop.reactElement "thead" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline tfoot xs = Interop.createElement "tfoot" xs
-    static member inline tfoot (children: #seq<ReactElement>) = Interop.reactElement "tfoot" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline textarea xs = Interop.createElement "textarea" xs
-    static member inline textarea (children: #seq<ReactElement>) = Interop.reactElement "textarea" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline video xs = Interop.createElement "video" xs
-    static member inline video (children: #seq<ReactElement>) = Interop.reactElement "video" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline h1 xs = Interop.createElement "h1" xs
-    static member inline h2 xs = Interop.createElement "h2" xs
-    static member inline h3 xs = Interop.createElement "h3" xs
-    static member inline h4 xs = Interop.createElement "h4" xs
-    static member inline h5 xs = Interop.createElement "h5" xs
-    static member inline h6 xs = Interop.createElement "h6" xs
-    static member inline button xs = Interop.createElement "button" xs
-    static member inline button (children: #seq<ReactElement>) = Interop.reactElement "button" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline span xs = Interop.createElement "span" xs
-    static member inline li xs = Interop.createElement "li" xs
-    static member inline ul xs = Interop.createElement "ul" xs
-    static member inline ul (children: #seq<ReactElement>) = Interop.reactElement "ul" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline ol xs = Interop.createElement "ol" xs
-    static member inline ol (children: #seq<ReactElement>) = Interop.reactElement "ol" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline a xs = Interop.createElement "a" xs
-    static member inline a (children: #seq<ReactElement>) = Interop.reactElement "a" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline anchor xs = Interop.createElement "a" xs
-    static member inline anchor (children: #seq<ReactElement>) = Interop.reactElement "a" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline img xs = Interop.createElement "img" xs
-    static member inline br xs = Interop.createElement "br" xs
-    static member inline hr xs = Interop.createElement "hr" xs
-    static member inline input xs = Interop.createElement "input" xs
-    static member inline form xs = Interop.createElement "form" xs
-    static member inline form (children: #seq<ReactElement>) = Interop.reactElement "form" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline i xs = Interop.createElement "i" xs
-    static member inline p xs = Interop.createElement "p" xs
-    static member inline paragraph xs = Interop.createElement "p" xs
-    static member inline listItem xs = Interop.createElement "li" xs
-    static member inline unorderedList xs = Interop.createElement "ul" xs
-    static member inline unorderedList (children: #seq<ReactElement>) = Interop.reactElement "ul" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline orderedList xs = Interop.createElement "ol" xs
-    static member inline orderedList (children: #seq<ReactElement>) = Interop.reactElement "ol" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline svg xs = Interop.createElement "svg" xs
-    static member inline svg (children: #seq<ReactElement>) = Interop.reactElement "svg" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline circle xs = Interop.createElement "circle" xs
-    static member inline circle (children: #seq<ReactElement>) = Interop.reactElement "circle" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline text xs = Interop.createElement "text" xs
+
     static member inline g xs = Interop.createElement "g" xs
-    static member inline g (children: #seq<ReactElement>) = Interop.reactElement "g" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline line xs = Interop.createElement "line" xs
-    static member inline line (children: #seq<ReactElement>) = Interop.reactElement "line" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline rect xs = Interop.createElement "rect" xs
-    static member inline rect (children: #seq<ReactElement>) = Interop.reactElement "rect" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline polygon xs = Interop.createElement "polygon" xs
-    static member inline polygon (children: #seq<ReactElement>) = Interop.reactElement "polygon" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline ellipse xs = Interop.createElement "ellipse" xs
-    static member inline ellipse (children: #seq<ReactElement>) = Interop.reactElement "ellipse" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline defs xs = Interop.createElement "defs" xs
-    static member inline defs (children: #seq<ReactElement>) = Interop.reactElement "defs" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline radialGradient xs = Interop.createElement "radialGradient" xs
-    static member inline radialGradient (children: #seq<ReactElement>) = Interop.reactElement "radialGradient" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline polyline xs = Interop.createElement "polyline" xs
-    static member inline polyline (children: #seq<ReactElement>) = Interop.reactElement "polyline" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline path xs = Interop.createElement "path" xs
-    static member inline path (children: #seq<ReactElement>) = Interop.reactElement "path" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline pre xs = Interop.createElement "pre" xs
-    static member inline code xs = Interop.createElement "code" xs
-    static member inline meta xs = Interop.createElement "meta" xs
+    static member inline g (children: #seq<ReactElement>) = Interop.reactElementWithChildren "g" children
+
+    static member inline h1 xs = Interop.createElement "h1" xs
+    static member inline h1 (value: float) = Interop.reactElementWithChild "h1" value
+    static member inline h1 (value: int) = Interop.reactElementWithChild "h1" value
+    static member inline h1 (value: ReactElement) = Interop.reactElementWithChild "h1" value
+    static member inline h1 (value: string) = Interop.reactElementWithChild "h1" value
+    static member inline h1 (children: #seq<ReactElement>) = Interop.reactElementWithChildren "h1" children
+
+    static member inline h2 xs = Interop.createElement "h2" xs
+    static member inline h2 (value: float) =  Interop.reactElementWithChild "h2" value
+    static member inline h2 (value: int) =  Interop.reactElementWithChild "h2" value
+    static member inline h2 (value: ReactElement) =  Interop.reactElementWithChild "h2" value
+    static member inline h2 (value: string) =  Interop.reactElementWithChild "h2" value
+    static member inline h2 (children: #seq<ReactElement>) = Interop.reactElementWithChildren "h2" children
+
+    static member inline h3 xs = Interop.createElement "h3" xs
+    static member inline h3 (value: float) =  Interop.reactElementWithChild "h3" value
+    static member inline h3 (value: int) =  Interop.reactElementWithChild "h3" value
+    static member inline h3 (value: ReactElement) =  Interop.reactElementWithChild "h3" value
+    static member inline h3 (value: string) =  Interop.reactElementWithChild "h3" value
+    static member inline h3 (children: #seq<ReactElement>) = Interop.reactElementWithChildren "h3" children
+
+    static member inline h4 xs = Interop.createElement "h4" xs
+    static member inline h4 (value: float) = Interop.reactElementWithChild "h4" value
+    static member inline h4 (value: int) = Interop.reactElementWithChild "h4" value
+    static member inline h4 (value: ReactElement) = Interop.reactElementWithChild "h4" value
+    static member inline h4 (value: string) = Interop.reactElementWithChild "h4" value
+    static member inline h4 (children: #seq<ReactElement>) = Interop.reactElementWithChildren "h4" children
+
+    static member inline h5 xs = Interop.createElement "h5" xs
+    static member inline h5 (value: float) = Interop.reactElementWithChild "h5" value
+    static member inline h5 (value: int) = Interop.reactElementWithChild "h5" value
+    static member inline h5 (value: ReactElement) = Interop.reactElementWithChild "h5" value
+    static member inline h5 (value: string) = Interop.reactElementWithChild "h5" value
+    static member inline h5 (children: #seq<ReactElement>) = Interop.reactElementWithChildren "h5" children
+
+    static member inline h6 xs = Interop.createElement "h6" xs
+    static member inline h6 (value: float) = Interop.reactElementWithChild "h6" value
+    static member inline h6 (value: int) = Interop.reactElementWithChild "h6" value
+    static member inline h6 (value: ReactElement) = Interop.reactElementWithChild "h6" value
+    static member inline h6 (value: string) = Interop.reactElementWithChild "h6" value
+    static member inline h6 (children: #seq<ReactElement>) = Interop.reactElementWithChildren "h6" children
+
     static member inline head xs = Interop.createElement "head" xs
-    static member inline head (children: #seq<ReactElement>) = Interop.reactElement "head" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline header xs = Interop.createElement "header" xs
-    static member inline header (children: #seq<ReactElement>) = Interop.reactElement "header" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline body xs = Interop.createElement "body" xs
-    static member inline body (children: #seq<ReactElement>) = Interop.reactElement "body" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline clipPath xs = Interop.createElement "clipPath" xs
-    static member inline clipPath (children: #seq<ReactElement>) = Interop.reactElement "clipPath" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline linearGradient xs = Interop.createElement "linearGradient" xs
-    static member inline linearGradient (children: #seq<ReactElement>) = Interop.reactElement "linearGradient" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline content (value: string) : ReactElement = unbox value
-    static member inline content (value: int) : ReactElement = unbox value
-    static member inline text (value: string) : ReactElement = unbox value
-    static member inline text (value: int) : ReactElement = unbox value
-    static member inline text (value: System.Guid) : ReactElement = unbox (string value)
-    static member inline stop xs = Interop.createElement "stop" xs
-    static member inline stop (children: #seq<ReactElement>) = Interop.reactElement "stop" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline div (value: ReactElement) = Interop.reactElement "div" (createObj [ "children" ==> [| value |] ])
-    static member inline div (children: #seq<ReactElement>) = Interop.reactElement "div" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline span (value: ReactElement)  = Interop.reactElement "span" (createObj [ "children" ==> [| value |] ])
-    static member inline span (children: #seq<ReactElement>) = Interop.reactElement "span" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline h1 (value: ReactElement)  = Interop.reactElement "h1" (createObj [ "children" ==> [| value |] ])
-    static member inline h1 (children: #seq<ReactElement>) = Interop.reactElement "h1" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline h2 (value: ReactElement)  =  Interop.reactElement "h2" (createObj [ "children" ==> [| value |] ])
-    static member inline h2 (children: #seq<ReactElement>) = Interop.reactElement "h2" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline h3 (value: ReactElement)  =  Interop.reactElement "h3" (createObj [ "children" ==> [| value |] ])
-    static member inline h3 (children: #seq<ReactElement>) = Interop.reactElement "h3" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline h4 (value: ReactElement)  = Interop.reactElement "h4" (createObj [ "children" ==> [| value |] ])
-    static member inline h4 (children: #seq<ReactElement>) = Interop.reactElement "h4" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline h5 (value: ReactElement)  = Interop.reactElement "h5" (createObj [ "children" ==> [| value |] ])
-    static member inline h5 (children: #seq<ReactElement>) = Interop.reactElement "h5" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline h6 (value: ReactElement)  = Interop.reactElement "h6" (createObj [ "children" ==> [| value |] ])
-    static member inline h6 (children: #seq<ReactElement>) = Interop.reactElement "h6" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline strong(value: ReactElement)  = Interop.reactElement "strong" (createObj [ "children" ==> [| value |] ])
-    static member inline strong (children: #seq<ReactElement>) = Interop.reactElement "strong" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline p(value: ReactElement) = Interop.reactElement "p" (createObj [ "children" ==> [| value |] ])
-    static member inline p (children: #seq<ReactElement>) = Interop.reactElement "p" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline paragraph(value: ReactElement)  = Interop.reactElement "p" (createObj [ "children" ==> [| value |] ])
-    static member inline paragraph (children: #seq<ReactElement>) = Interop.reactElement "p" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline td(value: ReactElement) = Interop.reactElement "td" (createObj [ "children" ==> [| value |] ])
-    static member inline td (children: #seq<ReactElement>) = Interop.reactElement "td" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline th(value: ReactElement)  = Interop.reactElement "th" (createObj [ "children" ==> [| value |] ])
-    static member inline th (children: #seq<ReactElement>) = Interop.reactElement "th" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline pre(value: ReactElement)  = Interop.reactElement "pre" (createObj [ "children" ==> [| value |] ])
-    static member inline pre (children: #seq<ReactElement>) = Interop.reactElement "pre" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline pre(value: string)  = Interop.reactElement "pre" (createObj [ "children" ==> [| value |] ])
-    static member inline pre(value: int)  = Interop.reactElement "pre" (createObj [ "children" ==> [| value |] ])
-    static member inline pre(value: bool)  = Interop.reactElement "pre" (createObj [ "children" ==> [| value |] ])
-    static member inline pre(value: float)  = Interop.reactElement "pre" (createObj [ "children" ==> [| value |] ])
-    static member inline code(value: ReactElement)  = Interop.reactElement "code" (createObj [ "children" ==> [| value |] ])
-    static member inline code (children: #seq<ReactElement>) = Interop.reactElement "code" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline code(value: string)  = Interop.reactElement "code" (createObj [ "children" ==> [| value |] ])
-    static member inline code(value: int)  = Interop.reactElement "code" (createObj [ "children" ==> [| value |] ])
-    static member inline code(value: bool)  = Interop.reactElement "code" (createObj [ "children" ==> [| value |] ])
-    static member inline li(value: ReactElement) = Interop.reactElement "li" (createObj [ "children" ==> [| value |] ])
-    static member inline li (children: #seq<ReactElement>) = Interop.reactElement "li" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline listItem(value: ReactElement) = Interop.reactElement "li" (createObj [ "children" ==> [| value |] ])
-    static member inline listItem (children: #seq<ReactElement>) = Interop.reactElement "li" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline div (value: string) = Interop.reactElement "div" (createObj [ "children" ==> [| value |] ])
-    static member inline div (value: int)  = Interop.reactElement "div" (createObj [ "children" ==> [| value |] ])
-    static member inline span (value: string) = Interop.reactElement "span" (createObj [ "children" ==> [| value |] ])
-    static member inline span (value: int)  = Interop.reactElement "span" (createObj [ "children" ==> [| value |] ])
-    static member inline h1 (value: string)  = Interop.reactElement "h1" (createObj [ "children" ==> [| value |] ])
-    static member inline h1 (value: int)  = Interop.reactElement "h1" (createObj [ "children" ==> [| value |] ])
-    static member inline h2 (value: string)  =  Interop.reactElement "h2" (createObj [ "children" ==> [| value |] ])
-    static member inline h2 (value: int)  =  Interop.reactElement "h2" (createObj [ "children" ==> [| value |] ])
-    static member inline h3 (value: string)  =  Interop.reactElement "h3" (createObj [ "children" ==> [| value |] ])
-    static member inline h3 (value: int)  =  Interop.reactElement "h3" (createObj [ "children" ==> [| value |] ])
-    static member inline h4 (value: string)  = Interop.reactElement "h4" (createObj [ "children" ==> [| value |] ])
-    static member inline h4 (value: int)  = Interop.reactElement "h4" (createObj [ "children" ==> [| value |] ])
-    static member inline h5 (value: string)  = Interop.reactElement "h5" (createObj [ "children" ==> [| value |] ])
-    static member inline h5 (value: int)  = Interop.reactElement "h5" (createObj [ "children" ==> [| value |] ])
-    static member inline h6 (value: string)  = Interop.reactElement "h6" (createObj [ "children" ==> [| value |] ])
-    static member inline h6 (value: int) = Interop.reactElement "h6" (createObj [ "children" ==> [| value |] ])
-    static member inline strong(value: string)  = Interop.reactElement "strong" (createObj [ "children" ==> [| value |] ])
-    static member inline strong(value: int) = Interop.reactElement "strong" (createObj [ "children" ==> [| value |] ])
-    static member inline p(value: string) = Interop.reactElement "p" (createObj [ "children" ==> [| value |] ])
-    static member inline p(value: int) = Interop.reactElement "p" (createObj [ "children" ==> [| value |] ])
-    static member inline paragraph(value: string)  = Interop.reactElement "p" (createObj [ "children" ==> [| value |] ])
-    static member inline paragraph(value: int)  = Interop.reactElement "p" (createObj [ "children" ==> [| value |] ])
-    static member inline td(value: string) = Interop.reactElement "td" (createObj [ "children" ==> [| value |] ])
-    static member inline td(value: int)  = Interop.reactElement "td" (createObj [ "children" ==> [| value |] ])
-    static member inline th(value: string)  = Interop.reactElement "th" (createObj [ "children" ==> [| value |] ])
-    static member inline th(value: int)  = Interop.reactElement "th" (createObj [ "children" ==> [| value |] ])
-    static member inline li(value: int) = Interop.reactElement "li" (createObj [ "children" ==> [| value |] ])
-    static member inline li(value: string) = Interop.reactElement "li" (createObj [ "children" ==> [| value |] ])
-    static member inline listItem(value: int) = Interop.reactElement "li" (createObj [ "children" ==> [| value |] ])
-    static member inline listItem(value: string) = Interop.reactElement "li" (createObj [ "children" ==> [| value |] ])
-    static member inline del(value: string) = Interop.reactElement "del" (createObj [ "children" ==> [| value |] ])
-    static member inline del(value: int) = Interop.reactElement "del" (createObj [ "children" ==> [| value |] ])
-    static member inline del(value: ReactElement) = Interop.reactElement "del" (createObj [ "children" ==> [| value |] ])
-    static member inline del (children: #seq<ReactElement>) = Interop.reactElement "del" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline ins(value: int) = Interop.reactElement "ins" (createObj [ "children" ==> [| value |] ])
-    static member inline ins(value: string) = Interop.reactElement "ins" (createObj [ "children" ==> [| value |] ])
-    static member inline ins (children: #seq<ReactElement>) = Interop.reactElement "ins" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline ins(value: ReactElement) = Interop.reactElement "ins" (createObj [ "children" ==> [| value |] ])
-    static member inline dfn (children: #seq<ReactElement>) = Interop.reactElement "dfn" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline dfn(value: int) = Interop.reactElement "dfn" (createObj [ "children" ==> [| value |] ])
-    static member inline dfn(value: string) = Interop.reactElement "dfn" (createObj [ "children" ==> [| value |] ])
-    static member inline dfn(value: ReactElement) = Interop.reactElement "dfn" (createObj [ "children" ==> [| value |] ])
-    static member inline dialog (children: #seq<ReactElement>) = Interop.reactElement "dialog" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline dialog(value: int) = Interop.reactElement "dialog" (createObj [ "children" ==> [| value |] ])
-    static member inline dialog(value: string) = Interop.reactElement "dialog" (createObj [ "children" ==> [| value |] ])
-    static member inline dialog(value: ReactElement) = Interop.reactElement "dialog" (createObj [ "children" ==> [| value |] ])
-    static member inline em (children: #seq<ReactElement>) = Interop.reactElement "em" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline em(value: int) = Interop.reactElement "em" (createObj [ "children" ==> [| value |] ])
-    static member inline em(value: string) = Interop.reactElement "em" (createObj [ "children" ==> [| value |] ])
-    static member inline em(value: ReactElement) = Interop.reactElement "em" (createObj [ "children" ==> [| value |] ])
-    static member inline i(value: int) = Interop.reactElement "i" (createObj [ "children" ==> [| value |] ])
-    static member inline i(value: string) = Interop.reactElement "i" (createObj [ "children" ==> [| value |] ])
-    static member inline i(value: ReactElement) = Interop.reactElement "i" (createObj [ "children" ==> [| value |] ])
-    static member inline i (children: #seq<ReactElement>) = Interop.reactElement "i" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
-    static member inline u xs = Interop.createElement "u" xs
-    static member inline u (value: int) = Interop.reactElement "u" (createObj [ "children" ==> [| value |] ])
-    static member inline u (value: string) = Interop.reactElement "u" (createObj [ "children" ==> [| value |] ])
-    static member inline u (value: ReactElement) = Interop.reactElement "u" (createObj [ "children" ==> [| value |] ])
-    static member inline u (children: #seq<ReactElement>) = Interop.reactElement "u" (createObj [ "children" ==> Interop.reactApi.Children.toArray (unbox<ReactElement list> children) ])
+    static member inline head (children: #seq<ReactElement>) = Interop.reactElementWithChildren "head" children
     
+    static member inline header xs = Interop.createElement "header" xs
+    static member inline header (children: #seq<ReactElement>) = Interop.reactElementWithChildren "header" children
+
+    static member inline hr xs = Interop.createElement "hr" xs
+
+    static member inline html xs = Interop.createElement "html" xs
+    static member inline html (children: #seq<ReactElement>) = Interop.reactElementWithChildren "html" children
+
+    static member inline i xs = Interop.createElement "i" xs
+    static member inline i (value: float) = Interop.reactElementWithChild "i" value
+    static member inline i (value: int) = Interop.reactElementWithChild "i" value
+    static member inline i (value: ReactElement) = Interop.reactElementWithChild "i" value
+    static member inline i (value: string) = Interop.reactElementWithChild "i" value
+    static member inline i (children: #seq<ReactElement>) = Interop.reactElementWithChildren "i" children
+
+    static member inline iframe xs = Interop.createElement "iframe" xs
+
+    static member inline img xs = Interop.createElement "img" xs
+
+    static member inline input xs = Interop.createElement "input" xs
+
+    static member inline ins xs = Interop.createElement "ins" xs
+    static member inline ins (value: float) = Interop.reactElementWithChild "ins" value
+    static member inline ins (value: int) = Interop.reactElementWithChild "ins" value
+    static member inline ins (value: ReactElement) = Interop.reactElementWithChild "ins" value
+    static member inline ins (value: string) = Interop.reactElementWithChild "ins" value
+    static member inline ins (children: #seq<ReactElement>) = Interop.reactElementWithChildren "ins" children
+
+    static member inline kbd xs = Interop.createElement "kbd" xs
+    static member inline kbd (value: float) = Interop.reactElementWithChild "kbd" value
+    static member inline kbd (value: int) = Interop.reactElementWithChild "kbd" value
+    static member inline kbd (value: ReactElement) = Interop.reactElementWithChild "kbd" value
+    static member inline kbd (value: string) = Interop.reactElementWithChild "kbd" value
+    static member inline kbd (children: #seq<ReactElement>) = Interop.reactElementWithChildren "kbd" children
+
+    [<Obsolete("Html.keyedFragment is obsolete, use React.keyedFragment instead. This function will be removed in the coming v1.0 release")>]
+    static member inline keyedFragment (key: int, xs) = Fable.React.Helpers.fragment [ !!("key", key) ] xs
+    [<Obsolete("Html.keyedFragment is obsolete, use React.keyedFragment instead. This function will be removed in the coming v1.0 release")>]
+    static member inline keyedFragment (key: string, xs) = Fable.React.Helpers.fragment [ !!("key", key) ] xs
+    [<Obsolete("Html.keyedFragment is obsolete, use React.keyedFragment instead. This function will be removed in the coming v1.0 release")>]
+    static member inline keyedFragment (key: System.Guid, xs) = Fable.React.Helpers.fragment [ !!("key", string key) ] xs
+
+    static member inline label xs = Interop.createElement "label" xs
+    static member inline label (children: #seq<ReactElement>) = Interop.reactElementWithChildren "label" children
+    
+    static member inline legend xs = Interop.createElement "legend" xs
+    static member inline legend (value: float) = Interop.reactElementWithChild "legend" value
+    static member inline legend (value: int) = Interop.reactElementWithChild "legend" value
+    static member inline legend (value: ReactElement) = Interop.reactElementWithChild "legend" value
+    static member inline legend (value: string) = Interop.reactElementWithChild "legend" value
+    static member inline legend (children: #seq<ReactElement>) = Interop.reactElementWithChildren "legend" children
+
+    static member inline li xs = Interop.createElement "li" xs
+    static member inline li (value: float) = Interop.reactElementWithChild "li" value
+    static member inline li (value: int) = Interop.reactElementWithChild "li" value
+    static member inline li (value: ReactElement) = Interop.reactElementWithChild "li" value
+    static member inline li (value: string) = Interop.reactElementWithChild "li" value
+    static member inline li (children: #seq<ReactElement>) = Interop.reactElementWithChildren "li" children
+
+    static member inline line xs = Interop.createElement "line" xs
+    static member inline line (children: #seq<ReactElement>) = Interop.reactElementWithChildren "line" children
+    
+    static member inline linearGradient xs = Interop.createElement "linearGradient" xs
+    static member inline linearGradient (children: #seq<ReactElement>) = Interop.reactElementWithChildren "linearGradient" children
+
+    static member inline link xs = Interop.createElement "link" xs
+    static member inline link (children: #seq<ReactElement>) = Interop.reactElementWithChildren "link" children
+
+    static member inline listItem xs = Interop.createElement "li" xs
+    static member inline listItem (value: float) = Interop.reactElementWithChild "li" value
+    static member inline listItem (value: int) = Interop.reactElementWithChild "li" value
+    static member inline listItem (value: ReactElement) = Interop.reactElementWithChild "li" value
+    static member inline listItem (value: string) = Interop.reactElementWithChild "li" value
+    static member inline listItem (children: #seq<ReactElement>) = Interop.reactElementWithChildren "li" children
+
+    static member inline main xs = Interop.createElement "main" xs
+    static member inline main (children: #seq<ReactElement>) = Interop.reactElementWithChildren "main" children
+    
+    static member inline map xs = Interop.createElement "map" xs
+    static member inline map (children: #seq<ReactElement>) = Interop.reactElementWithChildren "map" children
+
+    static member inline mark xs = Interop.createElement "mark" xs
+    static member inline mark (value: float) = Interop.reactElementWithChild "mark" value
+    static member inline mark (value: int) = Interop.reactElementWithChild "mark" value
+    static member inline mark (value: ReactElement) = Interop.reactElementWithChild "mark" value
+    static member inline mark (value: string) = Interop.reactElementWithChild "mark" value
+    static member inline mark (children: #seq<ReactElement>) = Interop.reactElementWithChildren "mark" children
+
+    static member inline meta xs = Interop.createElement "meta" xs
+
+    static member inline meter xs = Interop.createElement "meter" xs
+    static member inline meter (value: float) = Interop.reactElementWithChild "meter" value
+    static member inline meter (value: int) = Interop.reactElementWithChild "meter" value
+    static member inline meter (value: ReactElement) = Interop.reactElementWithChild "meter" value
+    static member inline meter (value: string) = Interop.reactElementWithChild "meter" value
+    static member inline meter (children: #seq<ReactElement>) = Interop.reactElementWithChildren "meter" children
+
+    static member inline nav xs = Interop.createElement "nav" xs
+    static member inline nav (children: #seq<ReactElement>) = Interop.reactElementWithChildren "nav" children
+
+    /// The empty element, renders nothing on screen
+    static member inline none : ReactElement = unbox null
+
+    static member inline noscript xs = Interop.createElement "noscript" xs
+    static member inline noscript (children: #seq<ReactElement>) = Interop.reactElementWithChildren "noscript" children
+
+    static member inline object xs = Interop.createElement "object" xs
+    static member inline object (children: #seq<ReactElement>) = Interop.reactElementWithChildren "object" children
+
+    static member inline ol xs = Interop.createElement "ol" xs
+    static member inline ol (children: #seq<ReactElement>) = Interop.reactElementWithChildren "ol" children
+
+    static member inline option xs = Interop.createElement "option" xs
+    static member inline option (value: float) = Interop.reactElementWithChild "option" value
+    static member inline option (value: int) = Interop.reactElementWithChild "option" value
+    static member inline option (value: ReactElement) = Interop.reactElementWithChild "option" value
+    static member inline option (value: string) = Interop.reactElementWithChild "option" value
+    static member inline option (children: #seq<ReactElement>) = Interop.reactElementWithChildren "option" children
+
+    static member inline optgroup xs = Interop.createElement "optgroup" xs
+    static member inline optgroup (children: #seq<ReactElement>) = Interop.reactElementWithChildren "optgroup" children
+    
+    static member inline orderedList xs = Interop.createElement "ol" xs
+    static member inline orderedList (children: #seq<ReactElement>) = Interop.reactElementWithChildren "ol" children
+
+    static member inline output xs = Interop.createElement "output" xs
+    static member inline output (value: float) = Interop.reactElementWithChild "output" value
+    static member inline output (value: int) = Interop.reactElementWithChild "output" value
+    static member inline output (value: ReactElement) = Interop.reactElementWithChild "output" value
+    static member inline output (value: string) = Interop.reactElementWithChild "output" value
+    static member inline output (children: #seq<ReactElement>) = Interop.reactElementWithChildren "output" children
+
+    static member inline p xs = Interop.createElement "p" xs
+    static member inline p (value: float) = Interop.reactElementWithChild "p" value
+    static member inline p (value: int) = Interop.reactElementWithChild "p" value
+    static member inline p (value: ReactElement) = Interop.reactElementWithChild "p" value
+    static member inline p (value: string) = Interop.reactElementWithChild "p" value
+    static member inline p (children: #seq<ReactElement>) = Interop.reactElementWithChildren "p" children
+
+    static member inline paragraph xs = Interop.createElement "p" xs
+    static member inline paragraph (value: float) = Interop.reactElementWithChild "p" value
+    static member inline paragraph (value: int) = Interop.reactElementWithChild "p" value
+    static member inline paragraph (value: ReactElement) = Interop.reactElementWithChild "p" value
+    static member inline paragraph (value: string) = Interop.reactElementWithChild "p" value
+    static member inline paragraph (children: #seq<ReactElement>) = Interop.reactElementWithChildren "p" children
+
+    static member inline param xs = Interop.createElement "param" xs
+
+    static member inline path xs = Interop.createElement "path" xs
+    static member inline path (children: #seq<ReactElement>) = Interop.reactElementWithChildren "path" children
+
+    static member inline picture xs = Interop.createElement "picture" xs
+    static member inline picture (children: #seq<ReactElement>) = Interop.reactElementWithChildren "picture" children
+
+    static member inline polygon xs = Interop.createElement "polygon" xs
+    static member inline polygon (children: #seq<ReactElement>) = Interop.reactElementWithChildren "polygon" children
+    
+    static member inline polyline xs = Interop.createElement "polyline" xs
+    static member inline polyline (children: #seq<ReactElement>) = Interop.reactElementWithChildren "polyline" children
+    
+    static member inline pre xs = Interop.createElement "pre" xs
+    static member inline pre (value: bool) = Interop.reactElementWithChild "pre" value
+    static member inline pre (value: float) = Interop.reactElementWithChild "pre" value
+    static member inline pre (value: int) = Interop.reactElementWithChild "pre" value
+    static member inline pre (value: ReactElement) = Interop.reactElementWithChild "pre" value
+    static member inline pre (value: string) = Interop.reactElementWithChild "pre" value
+    static member inline pre (children: #seq<ReactElement>) = Interop.reactElementWithChildren "pre" children
+
+    static member inline progress xs = Interop.createElement "progress" xs
+    static member inline progress (children: #seq<ReactElement>) = Interop.reactElementWithChildren "progress" children
+
+    static member inline q xs = Interop.createElement "q" xs
+    static member inline q (children: #seq<ReactElement>) = Interop.reactElementWithChildren "q" children
+
+    static member inline radialGradient xs = Interop.createElement "radialGradient" xs
+    static member inline radialGradient (children: #seq<ReactElement>) = Interop.reactElementWithChildren "radialGradient" children
+
+    static member inline rb xs = Interop.createElement "rb" xs
+    static member inline rb (value: float) = Interop.reactElementWithChild "rb" value
+    static member inline rb (value: int) = Interop.reactElementWithChild "rb" value
+    static member inline rb (value: ReactElement) = Interop.reactElementWithChild "rb" value
+    static member inline rb (value: string) = Interop.reactElementWithChild "rb" value
+    static member inline rb (children: #seq<ReactElement>) = Interop.reactElementWithChildren "rb" children
+
+    static member inline rect xs = Interop.createElement "rect" xs
+    static member inline rect (children: #seq<ReactElement>) = Interop.reactElementWithChildren "rect" children
+
+    static member inline rp xs = Interop.createElement "rp" xs
+    static member inline rp (value: float) = Interop.reactElementWithChild "rp" value
+    static member inline rp (value: int) = Interop.reactElementWithChild "rp" value
+    static member inline rp (value: ReactElement) = Interop.reactElementWithChild "rp" value
+    static member inline rp (value: string) = Interop.reactElementWithChild "rp" value
+    static member inline rp (children: #seq<ReactElement>) = Interop.reactElementWithChildren "rp" children
+
+    static member inline rt xs = Interop.createElement "rt" xs
+    static member inline rt (value: float) = Interop.reactElementWithChild "rt" value
+    static member inline rt (value: int) = Interop.reactElementWithChild "rt" value
+    static member inline rt (value: ReactElement) = Interop.reactElementWithChild "rt" value
+    static member inline rt (value: string) = Interop.reactElementWithChild "rt" value
+    static member inline rt (children: #seq<ReactElement>) = Interop.reactElementWithChildren "rt" children
+
+    static member inline rtc xs = Interop.createElement "rtc" xs
+    static member inline rtc (value: float) = Interop.reactElementWithChild "rtc" value
+    static member inline rtc (value: int) = Interop.reactElementWithChild "rtc" value
+    static member inline rtc (value: ReactElement) = Interop.reactElementWithChild "rtc" value
+    static member inline rtc (value: string) = Interop.reactElementWithChild "rtc" value
+    static member inline rtc (children: #seq<ReactElement>) = Interop.reactElementWithChildren "rtc" children
+
+    static member inline ruby xs = Interop.createElement "ruby" xs
+    static member inline ruby (value: float) = Interop.reactElementWithChild "ruby" value
+    static member inline ruby (value: int) = Interop.reactElementWithChild "ruby" value
+    static member inline ruby (value: ReactElement) = Interop.reactElementWithChild "ruby" value
+    static member inline ruby (value: string) = Interop.reactElementWithChild "ruby" value
+    static member inline ruby (children: #seq<ReactElement>) = Interop.reactElementWithChildren "ruby" children
+
+    static member inline s xs = Interop.createElement "s" xs
+    static member inline s (value: float) = Interop.reactElementWithChild "s" value
+    static member inline s (value: int) = Interop.reactElementWithChild "s" value
+    static member inline s (value: ReactElement) = Interop.reactElementWithChild "s" value
+    static member inline s (value: string) = Interop.reactElementWithChild "s" value
+    static member inline s (children: #seq<ReactElement>) = Interop.reactElementWithChildren "s" children
+
+    static member inline samp xs = Interop.createElement "samp" xs
+    static member inline samp (value: float) = Interop.reactElementWithChild "samp" value
+    static member inline samp (value: int) = Interop.reactElementWithChild "samp" value
+    static member inline samp (value: ReactElement) = Interop.reactElementWithChild "samp" value
+    static member inline samp (value: string) = Interop.reactElementWithChild "samp" value
+    static member inline samp (children: #seq<ReactElement>) = Interop.reactElementWithChildren "samp" children
+
+    static member inline script xs = Interop.createElement "script" xs
+    static member inline script (children: #seq<ReactElement>) = Interop.reactElementWithChildren "script" children
+
+    static member inline section xs = Interop.createElement "section" xs
+    static member inline section (children: #seq<ReactElement>) = Interop.reactElementWithChildren "section" children
+    
+    static member inline select xs = Interop.createElement "select" xs
+    static member inline select (children: #seq<ReactElement>) = Interop.reactElementWithChildren "select" children
+    
+    static member inline small xs = Interop.createElement "small" xs
+    static member inline small (value: float) = Interop.reactElementWithChild "small" value
+    static member inline small (value: int) = Interop.reactElementWithChild "small" value
+    static member inline small (value: ReactElement) = Interop.reactElementWithChild "small" value
+    static member inline small (value: string) = Interop.reactElementWithChild "small" value
+    static member inline small (children: #seq<ReactElement>) = Interop.reactElementWithChildren "small" children
+
+    static member inline source xs = Interop.createElement "source" xs
+    
+    static member inline span xs = Interop.createElement "span" xs
+    static member inline span (value: float) = Interop.reactElementWithChild "span" value
+    static member inline span (value: int) = Interop.reactElementWithChild "span" value
+    static member inline span (value: ReactElement) = Interop.reactElementWithChild "span" value
+    static member inline span (value: string) = Interop.reactElementWithChild "span" value
+    static member inline span (children: #seq<ReactElement>) = Interop.reactElementWithChildren "span" children
+
+    static member inline stop xs = Interop.createElement "stop" xs
+    static member inline stop (children: #seq<ReactElement>) = Interop.reactElementWithChildren "stop" children
+
+    static member inline strong xs = Interop.createElement "strong" xs
+    static member inline strong (value: float) = Interop.reactElementWithChild "strong" value
+    static member inline strong (value: int) = Interop.reactElementWithChild "strong" value
+    static member inline strong (value: ReactElement) = Interop.reactElementWithChild "strong" value
+    static member inline strong (value: string) = Interop.reactElementWithChild "strong" value
+    static member inline strong (children: #seq<ReactElement>) = Interop.reactElementWithChildren "strong" children
+    
+    static member inline style xs = Interop.createElement "style" xs
+    static member inline style (value: string) = Interop.reactElementWithChild "style" value
+
+    static member inline sub xs = Interop.createElement "sub" xs
+    static member inline sub (value: float) = Interop.reactElementWithChild "sub" value
+    static member inline sub (value: int) = Interop.reactElementWithChild "sub" value
+    static member inline sub (value: ReactElement) = Interop.reactElementWithChild "sub" value
+    static member inline sub (value: string) = Interop.reactElementWithChild "sub" value
+    static member inline sub (children: #seq<ReactElement>) = Interop.reactElementWithChildren "sub" children
+
+    static member inline summary xs = Interop.createElement "summary" xs
+    static member inline summary (value: float) = Interop.reactElementWithChild "summary" value
+    static member inline summary (value: int) = Interop.reactElementWithChild "summary" value
+    static member inline summary (value: ReactElement) = Interop.reactElementWithChild "summary" value
+    static member inline summary (value: string) = Interop.reactElementWithChild "summary" value
+    static member inline summary (children: #seq<ReactElement>) = Interop.reactElementWithChildren "summary" children
+    
+    static member inline sup xs = Interop.createElement "sup" xs
+    static member inline sup (value: float) = Interop.reactElementWithChild "sup" value
+    static member inline sup (value: int) = Interop.reactElementWithChild "sup" value
+    static member inline sup (value: ReactElement) = Interop.reactElementWithChild "sup" value
+    static member inline sup (value: string) = Interop.reactElementWithChild "sup" value
+    static member inline sup (children: #seq<ReactElement>) = Interop.reactElementWithChildren "sup" children
+
+    static member inline svg xs = Interop.createElement "svg" xs
+    static member inline svg (children: #seq<ReactElement>) = Interop.reactElementWithChildren "svg" children
+
+    static member inline table xs = Interop.createElement "table" xs
+
+    static member inline tableBody xs = Interop.createElement "tbody" xs
+    static member inline tableBody (children: #seq<ReactElement>) = Interop.reactElementWithChildren "tbody" children
+
+    static member inline tableCell xs = Interop.createElement "td" xs
+
+    static member inline tableHeader xs = Interop.createElement "th" xs
+    static member inline tableHeader (children: #seq<ReactElement>) = Interop.reactElementWithChildren "th" children
+    
+    static member inline tableRow xs = Interop.createElement "tr" xs
+
+    static member inline tbody xs = Interop.createElement "tbody" xs
+    static member inline tbody (children: #seq<ReactElement>) = Interop.reactElementWithChildren "tbody" children
+    
+    static member inline td xs = Interop.createElement "td" xs
+    static member inline td (value: float) = Interop.reactElementWithChild "td" value
+    static member inline td (value: int) = Interop.reactElementWithChild "td" value
+    static member inline td (value: ReactElement) = Interop.reactElementWithChild "td" value
+    static member inline td (value: string) = Interop.reactElementWithChild "td" value
+    static member inline td (children: #seq<ReactElement>) = Interop.reactElementWithChildren "td" children
+
+    static member inline template xs = Interop.createElement "template" xs
+    static member inline template (children: #seq<ReactElement>) = Interop.reactElementWithChildren "template" children
+
+    static member inline text xs = Interop.createElement "text" xs
+    static member inline text (value: float) : ReactElement = unbox value
+    static member inline text (value: int) : ReactElement = unbox value
+    static member inline text (value: string) : ReactElement = unbox value
+    static member inline text (value: System.Guid) : ReactElement = unbox (string value)
+
+    static member inline textarea xs = Interop.createElement "textarea" xs
+    static member inline textarea (children: #seq<ReactElement>) = Interop.reactElementWithChildren "textarea" children
+
+    static member inline tfoot xs = Interop.createElement "tfoot" xs
+    static member inline tfoot (children: #seq<ReactElement>) = Interop.reactElementWithChildren "tfoot" children
+
+    static member inline th xs = Interop.createElement "th" xs
+    static member inline th (value: float) = Interop.reactElementWithChild "th" value
+    static member inline th (value: int) = Interop.reactElementWithChild "th" value
+    static member inline th (value: ReactElement) = Interop.reactElementWithChild "th" value
+    static member inline th (value: string) = Interop.reactElementWithChild "th" value
+    static member inline th (children: #seq<ReactElement>) = Interop.reactElementWithChildren "th" children
+
+    static member inline thead xs = Interop.createElement "thead" xs
+    static member inline thead (children: #seq<ReactElement>) = Interop.reactElementWithChildren "thead" children
+
+    static member inline time xs = Interop.createElement "time" xs
+    static member inline time (children: #seq<ReactElement>) = Interop.reactElementWithChildren "time" children
+
+    static member inline title xs = Interop.createElement "title" xs
+    static member inline title (value: float) = Interop.reactElementWithChild "title" value
+    static member inline title (value: int) = Interop.reactElementWithChild "title" value
+    static member inline title (value: ReactElement) = Interop.reactElementWithChild "title" value
+    static member inline title (value: string) = Interop.reactElementWithChild "title" value
+    static member inline title (children: #seq<ReactElement>) = Interop.reactElementWithChildren "title" children
+
+    static member inline tr xs = Interop.createElement "tr" xs
+    static member inline tr (children: #seq<ReactElement>) = Interop.reactElementWithChildren "tr" children
+    
+    static member inline track xs = Interop.createElement "track" xs
+
+    static member inline u xs = Interop.createElement "u" xs
+    static member inline u (value: float) = Interop.reactElementWithChild "u" value
+    static member inline u (value: int) = Interop.reactElementWithChild "u" value
+    static member inline u (value: ReactElement) = Interop.reactElementWithChild "u" value
+    static member inline u (value: string) = Interop.reactElementWithChild "u" value
+    static member inline u (children: #seq<ReactElement>) = Interop.reactElementWithChildren "u" children
+
+    static member inline ul xs = Interop.createElement "ul" xs
+    static member inline ul (children: #seq<ReactElement>) = Interop.reactElementWithChildren "ul" children
+    
+    static member inline unorderedList xs = Interop.createElement "ul" xs
+    static member inline unorderedList (children: #seq<ReactElement>) = Interop.reactElementWithChildren "ul" children
+
+    static member inline var xs = Interop.createElement "var" xs
+    static member inline var (value: float) = Interop.reactElementWithChild "var" value
+    static member inline var (value: int) = Interop.reactElementWithChild "var" value
+    static member inline var (value: ReactElement) = Interop.reactElementWithChild "var" value
+    static member inline var (value: string) = Interop.reactElementWithChild "var" value
+    static member inline var (children: #seq<ReactElement>) = Interop.reactElementWithChildren "var" children
+
+    static member inline video xs = Interop.createElement "video" xs
+    static member inline video (children: #seq<ReactElement>) = Interop.reactElementWithChildren "video" children
+    
+    static member inline wbr xs = Interop.createElement "wbr" xs

--- a/Feliz/Interop.fs
+++ b/Feliz/Interop.fs
@@ -11,5 +11,9 @@ module Interop =
     let reactElement (name: string) (props: 'a) : ReactElement = import "createElement" "react"
     let mkAttr (key: string) (value: obj) : IReactProperty = unbox (key, value)
     let mkStyle (key: string) (value: obj) : IStyleAttribute = unbox (key, value)
+    let inline reactElementWithChild (name: string) (child: 'a) =
+        reactElement name (createObj [ "children" ==> [| child |] ])
+    let inline reactElementWithChildren (name: string) (children: #seq<ReactElement>) = 
+        reactElement name (createObj [ "children" ==> reactApi.Children.toArray (unbox<ReactElement list> children) ])
     let inline createElement name (properties: IReactProperty list) : ReactElement =
         reactElement name (createObj !!properties)

--- a/Feliz/Properties.fs
+++ b/Feliz/Properties.fs
@@ -1337,6 +1337,17 @@ module prop =
         /// Applies to Worker and SharedWorker.
         static member inline worker = Interop.mkAttr "as" "worker"
 
+    [<Erase>]
+    type autoCapitalize =
+        /// All letters should default to uppercase
+        static member inline characters = Interop.mkAttr "autoCapitalize" "characters"
+        /// No autocapitalization is applied (all letters default to lowercase)
+        static member inline off = Interop.mkAttr "autoCapitalize" "off"
+        /// The first letter of each sentence defaults to a capital letter; all other letters default to lowercase
+        static member inline on' = Interop.mkAttr "autoCapitalize" "on"
+        /// The first letter of each word defaults to a capital letter; all other letters default to lowercase
+        static member inline words = Interop.mkAttr "autoCapitalize" "words"
+
     /// A set of values specifying the coordinates of the hot-spot region. 
     ///
     /// The number and meaning of the values depend upon the value specified for the shape attribute
@@ -2029,14 +2040,3 @@ module prop =
         static member inline url = Interop.mkAttr "type" "url"
         /// Defines a week and year control (no timezone)
         static member inline week = Interop.mkAttr "type" "week"
-
-    [<Erase>]
-    type autoCapitalize =
-        /// No autocapitalization is applied (all letters default to lowercase)
-        static member inline off = Interop.mkAttr "autoCapitalize" "off"
-        /// The first letter of each sentence defaults to a capital letter; all other letters default to lowercase
-        static member inline on' = Interop.mkAttr "autoCapitalize" "on"
-        /// The first letter of each word defaults to a capital letter; all other letters default to lowercase
-        static member inline words = Interop.mkAttr "autoCapitalize" "words"
-        /// All letters should default to uppercase
-        static member inline characters = Interop.mkAttr "autoCapitalize" "characters"

--- a/Feliz/Properties.fs
+++ b/Feliz/Properties.fs
@@ -40,33 +40,277 @@ type AriaRelevant =
 
 /// Represents the native Html properties.
 type prop =
-    /// Often used with CSS to style a specific element. The value of this attribute must be unique.
-    static member inline id(value: string) = Interop.mkAttr "id" value
-    /// Used to reference a DOM element or class component from within a parent component.
-    static member inline ref(handler: Element -> unit) = Interop.mkAttr "ref" handler
-    /// Used to reference a DOM element or class component from within a parent component.
-    static member inline ref(ref: Fable.React.IRefValue<HTMLElement option>) = Interop.mkAttr "ref" ref
-    /// Sets the inner Html content of the element.
-    static member inline dangerouslySetInnerHTML(content: string) = Interop.mkAttr "dangerouslySetInnerHTML" (createObj [ "__html" ==> content ])
-    /// Alias for `dangerouslySetInnerHTML`, sets the inner Html content of the element.
-    static member inline innerHtml (content: string) = Interop.mkAttr "dangerouslySetInnerHTML" (createObj [ "__html" ==> content ])
-    /// `prop.ref` callback that sets the value of an input after DOM element is created.
-    /// Can be used instead of `prop.defaultValue` and `prop.value` props to override input box value.
-    static member inline valueOrDefault(value: string) =
-        prop.ref (fun e -> if e |> isNull |> not && !!e?value <> !!value then e?value <- !!value)
-    /// `prop.ref` callback that sets the value of an input after DOM element is created.
-    /// Can be used instead of `prop.defaultValue` and `prop.value` props to override input value.
-    static member inline valueOrDefault(value: int) =
-        prop.ref (fun e -> if e |> isNull |> not && !!e?value <> !!value then e?value <- !!value)
-    /// `prop.ref` callback that sets the value of an input after DOM element is created.
-    /// Can be used instead of `prop.defaultValue` and `prop.value` props to override input value.
-    static member inline valueOrDefault(value: bool) =
-        prop.ref (fun e -> if e |> isNull |> not && !!e?value <> !!value then e?value <- !!value)
-    /// Often used with CSS to style a specific element. The value of this attribute must be unique.
-    static member inline id(value: int) = Interop.mkAttr "id" (string value)
+    /// List of types the server accepts, typically a file type.
+    static member inline accept (value: string) = Interop.mkAttr "accept" value
+
+    /// List of supported charsets.
+    static member inline acceptCharset (value: string) = Interop.mkAttr "acceptCharset" value
+
+    /// Defines a keyboard shortcut to activate or add focus to the element.
+    static member inline accessKey (value: string) = Interop.mkAttr "accessKey" value
+
+    /// The URI of a program that processes the information submitted via the form.
+    static member inline action (value: string) = Interop.mkAttr "action" value
+
+    /// Alternative text in case an image can't be displayed.
+    static member inline alt (value: string) = Interop.mkAttr "alt" value
+
+    /// Identifies the currently active descendant of a `composite` widget.
+    ///
+    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-activedescendant
+    static member inline ariaActiveDescendant (id: string) = Interop.mkAttr "aria-activedescendant" id
+
+    /// Indicates whether assistive technologies will present all, or only parts
+    /// of, the changed region based on the change notifications defined by the
+    /// `aria-relevant` attribute.
+    ///
+    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-atomic
+    static member inline ariaAtomic (value: bool) = Interop.mkAttr "aria-atomic" value
+
+    /// Indicates whether an element, and its subtree, are currently being
+    /// updated.
+    ///
+    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-busy
+    static member inline ariaBusy (value: bool) = Interop.mkAttr "aria-busy" value
+
+    /// Indicates the current "checked" state of checkboxes, radio buttons, and
+    /// other widgets. See related `aria-pressed` and `aria-selected`.
+    ///
+    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-checked
+    static member inline ariaChecked (value: bool) = Interop.mkAttr "aria-checked" value
+
+    /// Identifies the element (or elements) whose contents or presence are
+    /// controlled by the current element. See related `aria-owns`.
+    ///
+    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-controls
+    static member inline ariaControls ([<System.ParamArray>] ids: string []) = Interop.mkAttr "aria-controls" (String.concat " " ids)
+
+    /// Specifies a URI referencing content that describes the object. See
+    /// related `aria-describedby`.
+    ///
+    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-describedat
+    static member inline ariaDescribedAt (uri: string) = Interop.mkAttr "aria-describedat" uri
+
+    /// Identifies the element (or elements) that describes the object. See
+    /// related `aria-describedat` and `aria-labelledby`.
+    ///
+    /// The `aria-labelledby` attribute is similar to `aria-describedby` in that
+    /// both reference other elements to calculate a text alternative, but a
+    /// label should be concise, where a description is intended to provide more
+    /// verbose information.
+    ///
+    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-describedby
+    static member inline ariaDescribedBy ([<System.ParamArray>] ids: string []) = Interop.mkAttr "aria-describedby" (String.concat " " ids)
+
+    /// Indicates that the element is perceivable but disabled, so it is not
+    /// editable or otherwise operable. See related `aria-hidden` and
+    /// `aria-readonly`.
+    ///
+    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-disabled
+    static member inline ariaDisabled (value: bool) = Interop.mkAttr "aria-disabled" value
+
+    /// Indicates what functions can be performed when the dragged object is
+    /// released on the drop target. This allows assistive technologies to
+    /// convey the possible drag options available to users, including whether a
+    /// pop-up menu of choices is provided by the application. Typically, drop
+    /// effect functions can only be provided once an object has been grabbed
+    /// for a drag operation as the drop effect functions available are
+    /// dependent on the object being dragged.
+    ///
+    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-dropeffect
+    static member inline ariaDropEffect ([<System.ParamArray>] values: AriaDropEffect []) = Interop.mkAttr "aria-dropeffect" (values |> unbox<string []> |> String.concat " ")
+
+    /// Indicates whether the element, or another grouping element it controls,
+    /// is currently expanded or collapsed.
+    ///
+    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-expanded
+    static member inline ariaExpanded (value: bool) = Interop.mkAttr "aria-expanded" value
+
+    /// Identifies the next element (or elements) in an alternate reading order
+    /// of content which, at the user's discretion, allows assistive technology
+    /// to override the general default of reading in document source order.
+    ///
+    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-flowto
+    static member inline ariaFlowTo ([<System.ParamArray>] ids: string []) = Interop.mkAttr "aria-flowto" (String.concat " " ids)
+
+    /// Indicates an element's "grabbed" state in a drag-and-drop operation.
+    ///
+    /// When it is set to true it has been selected for dragging, false
+    /// indicates that the element can be grabbed for a drag-and-drop operation,
+    /// but is not currently grabbed, and undefined (or no value) indicates the
+    /// element cannot be grabbed (default).
+    ///
+    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-grabbed
+    static member inline ariaGrabbed (value: bool) = Interop.mkAttr "aria-grabbed" value
+
+    /// Indicates that the element has a popup context menu or sub-level menu.
+    ///
+    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-haspopup
+    static member inline ariaHasPopup (value: bool) = Interop.mkAttr "aria-haspopup" value
+
+    /// Indicates that the element and all of its descendants are not visible or
+    /// perceivable to any user as implemented by the author. See related
+    /// `aria-disabled`.
+    ///
+    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-hidden
+    static member inline ariaHidden (value: bool) = Interop.mkAttr "aria-hidden" value
+
+    /// Indicates the entered value does not conform to the format expected by
+    /// the application.
+    ///
+    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-invalid
+    static member inline ariaInvalid (value: bool) = Interop.mkAttr "aria-invalid" value
+
+    /// Defines a string value that labels the current element. See related
+    /// `aria-labelledby`.
+    ///
+    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-label
+    static member inline ariaLabel (value: string) = Interop.mkAttr "aria-label" value
+
+    /// Defines the hierarchical level of an element within a structure.
+    ///
+    /// This can be applied inside trees to tree items, to headings inside a
+    /// document, to nested grids, nested tablists and to other structural items
+    /// that may appear inside a container or participate in an ownership
+    /// hierarchy. The value for `aria-level` is an integer greater than or
+    /// equal to 1.
+    ///
+    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-level
+    static member inline ariaLevel (value: int) = Interop.mkAttr "aria-level" value
+
+    /// Identifies the element (or elements) that labels the current element.
+    /// See related `aria-label` and `aria-describedby`.
+    ///
+    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-labelledby
+    static member inline ariaLabelledBy ([<System.ParamArray>] ids: string []) = Interop.mkAttr "aria-labelledby" (String.concat " " ids)
+
+    /// Indicates whether a text box accepts multiple lines of input or only a
+    /// single line.
+    ///
+    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-multiline
+    static member inline ariaMultiLine (value: bool) = Interop.mkAttr "aria-multiline" value
+
+    /// Indicates that the user may select more than one item from the current
+    /// selectable descendants.
+    ///
+    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-multiselectable
+    static member inline ariaMultiSelectable (value: bool) = Interop.mkAttr "aria-multiselectable" value
+
+    /// Identifies an element (or elements) in order to define a visual,
+    /// functional, or contextual parent/child relationship between DOM elements
+    /// where the DOM hierarchy cannot be used to represent the relationship.
+    /// See related `aria-controls`.
+    ///
+    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-owns
+    static member inline ariaOwns ([<System.ParamArray>] ids: string []) = Interop.mkAttr "aria-owns" (String.concat " " ids)
+
+    /// Indicates the current "pressed" state of toggle buttons. See related
+    /// `aria-checked` and `aria-selected`.
+    ///
+    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-pressed
+    static member inline ariaPressed (value: bool) = Interop.mkAttr "aria-pressed" value
+
+    /// Defines an element's number or position in the current set of listitems
+    /// or treeitems. Not required if all elements in the set are present in the
+    /// DOM. See related `aria-setsize`.
+    ///
+    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-posinset
+    static member inline ariaPosInSet (value: int) = Interop.mkAttr "aria-posinset" value
+
+    /// Indicates that the element is not editable, but is otherwise operable.
+    /// See related `aria-disabled`.
+    ///
+    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-readonly
+    static member inline ariaReadOnly (value: bool) = Interop.mkAttr "aria-readonly" value
+
+    /// Indicates what user agent change notifications (additions, removals,
+    /// etc.) assistive technologies will receive within a live region. See
+    /// related `aria-atomic`.
+    ///
+    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-relevant
+    static member inline ariaRelevant ([<System.ParamArray>] values: AriaRelevant []) = Interop.mkAttr "aria-relevant" (values |> unbox<string []> |> String.concat " ")
+
+    /// Indicates that user input is required on the element before a form may
+    /// be submitted.
+    ///
+    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-required
+    static member inline ariaRequired (value: bool) = Interop.mkAttr "aria-required" value
+    
+    /// Indicates the current "selected" state of various widgets. See related
+    /// `aria-checked` and `aria-pressed`.
+    ///
+    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-selected
+    static member inline ariaSelected (value: bool) = Interop.mkAttr "aria-selected" value
+    
+    /// Defines the maximum allowed value for a range widget.
+    ///
+    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-valuemax
+    static member inline ariaValueMax (value: float) = Interop.mkAttr "aria-valuemax" value
+    /// Defines the maximum allowed value for a range widget.
+    ///
+    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-valuemax
+    static member inline ariaValueMax (value: int) = Interop.mkAttr "aria-valuemax" value
+    
+    /// Defines the minimum allowed value for a range widget.
+    ///
+    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-valuemin
+    static member inline ariaValueMin (value: float) = Interop.mkAttr "aria-valuemin" value
+    /// Defines the minimum allowed value for a range widget.
+    ///
+    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-valuemin
+    static member inline ariaValueMin (value: int) = Interop.mkAttr "aria-valuemin" value
+
+    /// Defines the current value for a range widget. See related
+    /// `aria-valuetext`.
+    ///
+    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-valuenow
+    static member inline ariaValueNow (value: float) = Interop.mkAttr "aria-valuenow" value
+    /// Defines the current value for a range widget. See related
+    /// `aria-valuetext`.
+    ///
+    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-valuenow
+    static member inline ariaValueNow (value: int) = Interop.mkAttr "aria-valuenow" value
+
+    /// Defines the human readable text alternative of `aria-valuenow` for a
+    /// range widget.
+    ///
+    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-valuetext
+    static member inline ariaValueText (value: string) = Interop.mkAttr "aria-valuetext" value
+    
+    /// Defines the number of items in the current set of listitems or
+    /// treeitems. Not required if all elements in the set are present in the
+    /// DOM. See related `aria-posinset`.
+    ///
+    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-setsize
+    static member inline ariaSetSize (value: int) = Interop.mkAttr "aria-setsize" value
+
+    /// Indicates that the script should be executed asynchronously.
+    static member inline async (value: bool) = Interop.mkAttr "async" value
+
+    /// Indicates whether controls in this form can by default have their values automatically completed by the browser.
+    static member inline autoComplete (value: string) = Interop.mkAttr "autoComplete" value
+
+    /// The element should be automatically focused after the page loaded.
+    static member inline autoFocus (value: bool) = Interop.mkAttr "autoFocus" value
+
+    /// The audio or video should play as soon as possible.
+    static member inline autoPlay (value: bool) = Interop.mkAttr "autoPlay" value
+
+    static member inline capture (value: bool) = Interop.mkAttr "capture" value
+
+    /// Children of this React element.
+    static member inline children (value: Fable.React.ReactElement) = Interop.mkAttr "children" value
+    /// Children of this React element.
+    static member inline children (elems: Fable.React.ReactElement seq) = Interop.mkAttr "children" (Interop.reactApi.Children.toArray elems)
+
+    /// A URL that designates a source document or message for the information quoted. This attribute is intended to 
+    /// point to information explaining the context or the reference for the quote.
+    static member inline cite (value: string) = Interop.mkAttr "cite" value
+
     /// Specifies a CSS class for this element.
-    static member inline className(value: string) = Interop.mkAttr "className" value
-    /// Takes a list of conditional classes (`predicate:bool` * `className:string`), filters out the ones where the `predicate` is false and joins the rest of them using a space to combine the classses into a single class property.
+    static member inline className (value: string) = Interop.mkAttr "className" value
+    /// Takes a list of conditional classes (`predicate:bool` * `className:string`), filters out the ones where the 
+    /// `predicate` is false and joins the rest of them using a space to combine the classses into a single class property.
     ///
     ///`prop.className [ true, "one";  false, "two" ]`
     ///
@@ -80,14 +324,6 @@ type prop =
         |> Seq.map snd
         |> String.concat " "
         |> Interop.mkAttr "className"
-
-    /// Sets the `type` attribute for the element.
-    static member inline type' (value: string) = Interop.mkAttr "type" value
-
-    /// Takes a `seq<string>` and joins them using a space to combine the classses into a single class property.
-    ///
-    /// `prop.classes [ "one"; "two" ]` => `prop.className "one two"`
-    static member inline classes(names: seq<string>) = Interop.mkAttr "className" (String.concat " " names)
     /// Takes a `seq<string>` and joins them using a space to combine the classses into a single class property.
     ///
     /// `prop.className [ "one"; "two" ]`
@@ -95,95 +331,109 @@ type prop =
     /// is the same as
     ///
     /// `prop.className "one two"`
-    static member inline className(names: seq<string>) = Interop.mkAttr "className" (String.concat " " names)
-    /// Defines the text content of the element. Alias for `children [ Html.text value ]`
-    static member inline text (value: string) = Interop.mkAttr "children" value
-    /// Defines the text content of the element. Alias for `children [ Html.text value ]`
-    static member inline text (value: int) = Interop.mkAttr "children" value
-    /// Defines the text content of the element. Alias for `children [ Html.text value ]`
-    static member inline text (value: float) = Interop.mkAttr "children" value
-    /// A special string attribute you need to include when creating arrays of elements. Keys help React identify which 
-    /// items have changed, are added, or are removed. Keys should be given to the elements inside an array to give the elements a stable identity.
+    static member inline className (names: seq<string>) = Interop.mkAttr "className" (String.concat " " names)
+
+    /// Takes a `seq<string>` and joins them using a space to combine the classses into a single class property.
+    ///
+    /// `prop.classes [ "one"; "two" ]` => `prop.className "one two"`
+    static member inline classes (names: seq<string>) = Interop.mkAttr "className" (String.concat " " names)
+
+    /// Defines the number of columns in a textarea.
+    static member inline cols (value: int) = Interop.mkAttr "cols" value
+
+    /// Defines the number of columns a cell should span.
+    static member inline colSpan (value: int) = Interop.mkAttr "colSpan" value
+
+    /// A value associated with http-equiv or name depending on the context.
+    static member inline content (value: string) = Interop.mkAttr "content" value
+
+    /// Indicates whether the element's content is editable.
+    static member inline contentEditable (value: bool) = Interop.mkAttr "contenteditable" value
+
+    /// If true, the browser will offer controls to allow the user to control video playback, 
+    /// including volume, seeking, and pause/resume playback.
+    static member inline controls (value: bool) = Interop.mkAttr "controls" value
+
+    static member inline custom (key: string, value: 't) = Interop.mkAttr key value
+
+    /// The SVG cx attribute define the x-axis coordinate of a center point.
     /// 
-    /// Keys only need to be unique among sibling elements in the same array. They don’t need to be unique across the whole application or even a single component.
-    static member inline key(value: string) = Interop.mkAttr "key" value
-    /// A special string attribute you need to include when creating arrays of elements. Keys help React identify which 
-    /// items have changed, are added, or are removed. Keys should be given to the elements inside an array to give the elements a stable identity.
+    /// Three elements are using this attribute: <circle>, <ellipse>, and <radialGradient>
+    static member inline cx (value: float) = Interop.mkAttr "cx" value
+    /// The SVG cx attribute define the x-axis coordinate of a center point.
     /// 
-    /// Keys only need to be unique among sibling elements in the same array. They don’t need to be unique across the whole application or even a single component.
-    static member inline key(value: int) = Interop.mkAttr "key" value
-    /// A special string attribute you need to include when creating arrays of elements. Keys help React identify which 
-    /// items have changed, are added, or are removed. Keys should be given to the elements inside an array to give the elements a stable identity.
+    /// Three elements are using this attribute: <circle>, <ellipse>, and <radialGradient>
+    static member inline cx (value: ICssUnit) = Interop.mkAttr "cx" value
+    /// The SVG cx attribute define the x-axis coordinate of a center point.
     /// 
-    /// Keys only need to be unique among sibling elements in the same array. They don’t need to be unique across the whole application or even a single component.
-    static member inline key(value: System.Guid) = Interop.mkAttr "value" (string value)
+    /// Three elements are using this attribute: <circle>, <ellipse>, and <radialGradient>
+    static member inline cx (value: int) = Interop.mkAttr "cx" value
+    
+    /// The SVG cy attribute define the y-axis coordinate of a center point.
+    ///
+    /// Three elements are using this attribute: <circle>, <ellipse>, and <radialGradient>
+    static member inline cy (value: float) = Interop.mkAttr "cy" value
+    /// The SVG cy attribute define the y-axis coordinate of a center point.
+    ///
+    /// Three elements are using this attribute: <circle>, <ellipse>, and <radialGradient>
+    static member inline cy (value: ICssUnit) = Interop.mkAttr "cy" value
+    /// The SVG cy attribute define the y-axis coordinate of a center point.
+    ///
+    /// Three elements are using this attribute: <circle>, <ellipse>, and <radialGradient>
+    static member inline cy (value: int) = Interop.mkAttr "cy" value
+
+    /// Sets the inner Html content of the element.
+    static member inline dangerouslySetInnerHTML (content: string) = Interop.mkAttr "dangerouslySetInnerHTML" (createObj [ "__html" ==> content ])
+
+    /// This attribute indicates the time and/or date of the element.
+    static member inline dateTime (value: string) = Interop.mkAttr "datetime" value
+
     /// Sets the DOM defaultChecked value when initially rendered.
     ///
     /// Typically only used with uncontrolled components.
-    static member inline defaultChecked(value: bool) = Interop.mkAttr "defaultChecked" value
+    static member inline defaultChecked (value: bool) = Interop.mkAttr "defaultChecked" value
+
     /// Sets the DOM defaultValue value when initially rendered.
     ///
     /// Typically only used with uncontrolled components.
-    static member inline defaultValue(value: string) = Interop.mkAttr "defaultValue" value
+    static member inline defaultValue (value: bool) = Interop.mkAttr "defaultValue" value
     /// Sets the DOM defaultValue value when initially rendered.
     ///
     /// Typically only used with uncontrolled components.
-    static member inline defaultValue(value: int) = Interop.mkAttr "defaultValue" value
+    static member inline defaultValue (value: float) = Interop.mkAttr "defaultValue" value
     /// Sets the DOM defaultValue value when initially rendered.
     ///
     /// Typically only used with uncontrolled components.
-    static member inline defaultValue(value: bool) = Interop.mkAttr "defaultValue" value
+    static member inline defaultValue (value: int) = Interop.mkAttr "defaultValue" value
     /// Sets the DOM defaultValue value when initially rendered.
     ///
     /// Typically only used with uncontrolled components.
-    static member inline defaultValue(value: float) = Interop.mkAttr "defaultValue" value
-    /// Sets the value of a React controlled component.
-    static member inline value(value: string) = Interop.mkAttr "value" value
-    /// Sets the value of a React controlled component.
-    static member inline value(value: int) = Interop.mkAttr "value" value
-    /// Sets the value of a React controlled component.
-    static member inline value(value: float) = Interop.mkAttr "value" value
-    /// Sets the value of a React controlled component.
-    static member inline value(value: bool) = Interop.mkAttr "value" value
-    /// Sets the value of a React controlled component.
-    static member inline value(value: System.Guid) = Interop.mkAttr "value" (string value)
-    /// Defines a value which will be selected on page load.
-    static member inline selected(value: bool) = Interop.mkAttr "selected" value
-    /// SVG attribute to define a x-axis coordinate in the user coordinate system.
-    static member inline x(value: int) = Interop.mkAttr "x" value
-    /// SVG attribute to define a x-axis coordinate in the user coordinate system.
-    static member inline x(value: float) = Interop.mkAttr "x" value
-    /// SVG attribute to define a x-axis coordinate in the user coordinate system.
-    static member inline x(value: ICssUnit) = Interop.mkAttr "x" value
-    /// SVG attribute to define a y-axis coordinate in the user coordinate system.
-    static member inline y(value: int) = Interop.mkAttr "y" value
-    /// SVG attribute to define a y-axis coordinate in the user coordinate system.
-    static member inline y(value: float) = Interop.mkAttr "y" value
-    /// SVG attribute to define a y-axis coordinate in the user coordinate system.
-    static member inline y(value: ICssUnit) = Interop.mkAttr "y" value
+    static member inline defaultValue (value: string) = Interop.mkAttr "defaultValue" value
+
+    /// Indicates to a browser that the script is meant to be executed after the document 
+    /// has been parsed, but before firing DOMContentLoaded.
+    /// 
+    /// Scripts with the defer attribute will prevent the DOMContentLoaded event from 
+    /// firing until the script has loaded and finished evaluating.
+    ///
+    /// This attribute must not be used if the src attribute is absent (i.e. for inline scripts), 
+    /// in this case it would have no effect.
+    static member inline defer (value: bool) = Interop.mkAttr "defer" value
+
+    /// Indicates whether the user can interact with the element.
+    static member inline disabled (value: bool) = Interop.mkAttr "disabled" value
+
+    /// This attribute, if present, indicates that the author intends the hyperlink to be used for downloading a resource.
+    static member inline download (value: bool) = Interop.mkAttr "download" value
+
+    /// Indicates whether the the element can be dragged.
+    static member inline draggable (value: bool) = Interop.mkAttr "draggable" value
+
     /// SVG attribute to indicate a shift along the y-axis on the position of an element or its content.
-    static member inline dy(value: int) = Interop.mkAttr "dy" value
+    static member inline dy (value: float) = Interop.mkAttr "dy" value
     /// SVG attribute to indicate a shift along the y-axis on the position of an element or its content.
-    static member inline dy(value: float) = Interop.mkAttr "dy" value
-    /// SVG attribute to define the radius of a circle
-    static member inline r(value: int) = Interop.mkAttr "r" value
-    /// SVG attribute to define the radius of a circle
-    static member inline r(value: float) = Interop.mkAttr "r" value
-    /// SVG attribute to define the radius of a circle
-    static member inline r(value: ICssUnit) = Interop.mkAttr "r" value
-    /// SVG attribute to define the size of the font from baseline to baseline when multiple 
-    /// lines of text are set solid in a multiline layout environment.
-    static member inline fontSize(value: int) = Interop.mkAttr "fontSize" value
-    /// SVG attribute to define the size of the font from baseline to baseline when multiple 
-    /// lines of text are set solid in a multiline layout environment.
-    static member inline fontSize(value: float) = Interop.mkAttr "fontSize" value
-    /// Set visible area of the SVG image.
-    static member inline viewPort(x: int, y: int, height: int, width: int) =
-        Interop.mkAttr "viewport"
-          ((unbox<string> x) + " " +
-           (unbox<string> y) + " " +
-           (unbox<string> height) + " " +
-           (unbox<string> width))
+    static member inline dy (value: int) = Interop.mkAttr "dy" value
+
     /// The fill attribute has two different meanings. For shapes and text it's a presentation
     /// attribute that defines the color (or any SVG paint servers like gradients or patterns) 
     /// used to paint the element; for animation it defines the final state of the animation.
@@ -194,257 +444,207 @@ type prop =
     ///
     /// For animation five elements are using this attribute: <animate>, <animateColor>, 
     /// <animateMotion>, <animateTransform>, and <set>.
-    static member inline fill(color: string) = Interop.mkAttr "fill" color
-    /// The x1 attribute is used to specify the first x-coordinate for drawing an SVG element that 
-    /// requires more than one coordinate. Elements that only need one coordinate use the x attribute instead.
-    ///
-    /// Two elements are using this attribute: <line>, and <linearGradient>
-    static member inline x1(value: int) = Interop.mkAttr "x1" value
-    /// The x1 attribute is used to specify the first x-coordinate for drawing an SVG element that 
-    /// requires more than one coordinate. Elements that only need one coordinate use the x attribute instead.
-    ///
-    /// Two elements are using this attribute: <line>, and <linearGradient>
-    static member inline x1(value: ICssUnit) = Interop.mkAttr "x1" value
-    /// The x1 attribute is used to specify the first x-coordinate for drawing an SVG element that 
-    /// requires more than one coordinate. Elements that only need one coordinate use the x attribute instead.
-    ///
-    /// Two elements are using this attribute: <line>, and <linearGradient>
-    static member inline x1(value: float) = Interop.mkAttr "x1" value
-    /// The x2 attribute is used to specify the second x-coordinate for drawing an SVG element that requires 
-    /// more than one coordinate. Elements that only need one coordinate use the x attribute instead.
-    ///
-    /// Two elements are using this attribute: <line>, and <linearGradient>
-    static member inline x2(value: int) = Interop.mkAttr "x2" value
-    /// The x2 attribute is used to specify the second x-coordinate for drawing an SVG element that requires 
-    /// more than one coordinate. Elements that only need one coordinate use the x attribute instead.
-    ///
-    /// Two elements are using this attribute: <line>, and <linearGradient>
-    static member inline x2(value: ICssUnit) = Interop.mkAttr "x2" value
-    /// The x2 attribute is used to specify the second x-coordinate for drawing an SVG element that requires 
-    /// more than one coordinate. Elements that only need one coordinate use the x attribute instead.
-    ///
-    /// Two elements are using this attribute: <line>, and <linearGradient>
-    static member inline x2(value: float) = Interop.mkAttr "x2" value
-    /// The y1 attribute is used to specify the first y-coordinate for drawing an SVG element that requires 
-    /// more than one coordinate. Elements that only need one coordinate use the y attribute instead.
-    ///
-    /// Two elements are using this attribute: <line>, and <linearGradient>
-    static member inline y1(value: int) = Interop.mkAttr "y1" value
-    /// The y1 attribute is used to specify the first y-coordinate for drawing an SVG element that requires 
-    /// more than one coordinate. Elements that only need one coordinate use the y attribute instead.
-    ///
-    /// Two elements are using this attribute: <line>, and <linearGradient>
-    static member inline y1(value: float) = Interop.mkAttr "y1" value
-    /// The y1 attribute is used to specify the first y-coordinate for drawing an SVG element that requires 
-    /// more than one coordinate. Elements that only need one coordinate use the y attribute instead.
-    ///
-    /// Two elements are using this attribute: <line>, and <linearGradient>
-    static member inline y1(value: ICssUnit) = Interop.mkAttr "y1" value
-    /// The y2 attribute is used to specify the second y-coordinate for drawing an SVG element that requires 
-    /// more than one coordinate. Elements that only need one coordinate use the y attribute instead.
-    ///
-    /// Two elements are using this attribute: <line>, and <linearGradient>
-    static member inline y2(value: int) = Interop.mkAttr "y2" value
-    /// The y2 attribute is used to specify the second y-coordinate for drawing an SVG element that requires 
-    /// more than one coordinate. Elements that only need one coordinate use the y attribute instead.
-    ///
-    /// Two elements are using this attribute: <line>, and <linearGradient>
-    static member inline y2(value: ICssUnit) = Interop.mkAttr "y2" value
-    /// The y2 attribute is used to specify the second y-coordinate for drawing an SVG element that requires 
-    /// more than one coordinate. Elements that only need one coordinate use the y attribute instead.
-    ///
-    /// Two elements are using this attribute: <line>, and <linearGradient>
-    static member inline y2(value: float) = Interop.mkAttr "y2" value
-    /// The title global attribute contains text representing advisory information related to the element it belongs to.
-    static member inline title(value: string) = Interop.mkAttr "title" value
-    /// The `tabindex` global attribute indicates that its element can be focused, and where it participates in sequential keyboard navigation (usually with the Tab key, hence the name).
-    static member inline tabIndex(index: int) = Interop.mkAttr "tabindex" index
-    /// The SVG cx attribute define the x-axis coordinate of a center point.
-    /// 
-    /// Three elements are using this attribute: <circle>, <ellipse>, and <radialGradient>
-    static member inline cx(value: int) = Interop.mkAttr "cx" value
-    /// The SVG cx attribute define the x-axis coordinate of a center point.
-    /// 
-    /// Three elements are using this attribute: <circle>, <ellipse>, and <radialGradient>
-    static member inline cx(value: ICssUnit) = Interop.mkAttr "cx" value
-    /// The SVG cx attribute define the x-axis coordinate of a center point.
-    /// 
-    /// Three elements are using this attribute: <circle>, <ellipse>, and <radialGradient>
-    static member inline cx(value: float) = Interop.mkAttr "cx" value
-    /// The SVG rx attribute defines a radius on the x-axis.
-    ///
-    /// Two elements are using this attribute: <ellipse>, and <rect>
-    static member inline rx(value: int) = Interop.mkAttr "rx" value
-    /// The SVG rx attribute defines a radius on the x-axis.
-    ///
-    /// Two elements are using this attribute: <ellipse>, and <rect>
-    static member inline rx(value: ICssUnit) = Interop.mkAttr "rx" value
-    /// The SVG rx attribute defines a radius on the x-axis.
-    ///
-    /// Two elements are using this attribute: <ellipse>, and <rect>
-    static member inline rx(value: float) = Interop.mkAttr "rx" value
-    /// The SVG ry attribute defines a radius on the y-axis.
-    ///
-    /// Two elements are using this attribute: <ellipse>, and <rect>
-    static member inline ry(value: int) = Interop.mkAttr "ry" value
-    /// The SVG ry attribute defines a radius on the y-axis.
-    ///
-    /// Two elements are using this attribute: <ellipse>, and <rect>
-    static member inline ry(value: ICssUnit) = Interop.mkAttr "ry" value
-    /// The SVG ry attribute defines a radius on the y-axis.
-    ///
-    /// Two elements are using this attribute: <ellipse>, and <rect>
-    static member inline ry(value: float) = Interop.mkAttr "ry" value
-    /// The SVG cy attribute define the y-axis coordinate of a center point.
-    ///
-    /// Three elements are using this attribute: <circle>, <ellipse>, and <radialGradient>
-    static member inline cy(value: float) = Interop.mkAttr "cy" value
-    /// The SVG cy attribute define the y-axis coordinate of a center point.
-    ///
-    /// Three elements are using this attribute: <circle>, <ellipse>, and <radialGradient>
-    static member inline cy(value: int) = Interop.mkAttr "cy" value
-    /// The SVG cy attribute define the y-axis coordinate of a center point.
-    ///
-    /// Three elements are using this attribute: <circle>, <ellipse>, and <radialGradient>
-    static member inline cy(value: ICssUnit) = Interop.mkAttr "cy" value
+    static member inline fill (color: string) = Interop.mkAttr "fill" color
+
     /// SVG attribute to define the opacity of the paint server (color, gradient, pattern, etc) applied to a shape.
-    static member inline fillOpacity(value: float) = Interop.mkAttr "fillOpacity" value
+    static member inline fillOpacity (value: float) = Interop.mkAttr "fillOpacity" value
     /// SVG attribute to define the opacity of the paint server (color, gradient, pattern, etc) applied to a shape.
-    static member inline fillOpacity(value: int) = Interop.mkAttr "fillOpacity" value
-    /// SVG attribute to define the color (or any SVG paint servers like gradients or patterns) used to paint the outline of the shape.
-    static member inline stroke(color: string) = Interop.mkAttr "stroke" color
-    /// SVG attribute to define the width of the stroke to be applied to the shape.
-    static member inline strokeWidth(value: int) = Interop.mkAttr "strokeWidth" value
-    /// SVG attribute to define the width of the stroke to be applied to the shape.
-    static member inline strokeWidth(value: float) = Interop.mkAttr "strokeWidth" value
-    /// SVG attribute to define the width of the stroke to be applied to the shape.
-    static member inline strokeWidth(value: ICssUnit) = Interop.mkAttr "strokeWidth" value
-    /// SVG attribute to define where the gradient color will begin or end.
-    static member inline offset(value: int) = Interop.mkAttr "offset" value
-    /// SVG attribute to define where the gradient color will begin or end.
-    static member inline offset(value: float) = Interop.mkAttr "offset" value
-    /// SVG attribute to define where the gradient color will begin or end.
-    static member inline offset(value: ICssUnit) = Interop.mkAttr "offset" value
-    /// SVG attribute to define a list of points.
-    static member inline points(value: string) = Interop.mkAttr "points" value
-    /// SVG attribute to indicate what color to use at a gradient stop.
-    static member inline stopColor(value: string) = Interop.mkAttr "stopColor" value
-    /// SVG attribute to define the opacity of a given color gradient stop.
-    static member inline stopOpacity(value: float) = Interop.mkAttr "stopOpacity" value
-    /// SVG attribute to define the opacity of a given color gradient stop.
-    static member inline stopOpacity(value: int) = Interop.mkAttr "stopOpacity" value
-    /// List of types the server accepts, typically a file type.
-    static member inline accept(value: string) = Interop.mkAttr "accept" value
-    /// List of supported charsets.
-    static member inline acceptCharset(value: string) = Interop.mkAttr "acceptCharset" value
-    /// Defines a keyboard shortcut to activate or add focus to the element.
-    static member inline accessKey(value: string) = Interop.mkAttr "accessKey" value
-    /// The URI of a program that processes the information submitted via the form.
-    static member inline action(value: string) = Interop.mkAttr "action" value
-    /// Alternative text in case an image can't be displayed.
-    static member inline alt(value: string) = Interop.mkAttr "alt" value
-    /// Indicates that the script should be executed asynchronously.
-    static member inline async(value: bool) = Interop.mkAttr "async" value
-    /// Indicates whether controls in this form can by default have their values automatically completed by the browser.
-    static member inline autoComplete(value: string) = Interop.mkAttr "autoComplete" value
-    /// The element should be automatically focused after the page loaded.
-    static member inline autoFocus(value: bool) = Interop.mkAttr "autoFocus" value
-    /// The audio or video should play as soon as possible.
-    static member inline autoPlay(value: bool) = Interop.mkAttr "autoPlay" value
-    static member inline capture(value: bool) = Interop.mkAttr "capture" value
-    static member inline isChecked(value: bool) = Interop.mkAttr "checked" value
-    /// Defines the number of columns in a textarea.
-    static member inline cols(value: int) = Interop.mkAttr "cols" value
-    /// Defines the number of columns a cell should span.
-    static member inline colSpan(value: int) = Interop.mkAttr "colSpan" value
-    /// Indicates whether the element's content is editable.
-    static member inline contentEditable(value: bool) = Interop.mkAttr "contenteditable" value
-    /// Indicates whether the user can interact with the element.
-    static member inline disabled(value: bool) = Interop.mkAttr "disabled" value
+    static member inline fillOpacity (value: int) = Interop.mkAttr "fillOpacity" value
+
+    /// SVG attribute to define the size of the font from baseline to baseline when multiple 
+    /// lines of text are set solid in a multiline layout environment.
+    static member inline fontSize (value: float) = Interop.mkAttr "fontSize" value
+    /// SVG attribute to define the size of the font from baseline to baseline when multiple 
+    /// lines of text are set solid in a multiline layout environment.
+    static member inline fontSize (value: int) = Interop.mkAttr "fontSize" value
+
+    /// A space-separated list of other elements’ ids, indicating that those elements contributed input 
+    /// values to (or otherwise affected) the calculation.
+    static member inline for' (value: string) = Interop.mkAttr "for" value
+    /// A space-separated list of other elements’ ids, indicating that those elements contributed input 
+    /// values to (or otherwise affected) the calculation.
+    static member inline for' (ids: #seq<string>) = Interop.mkAttr "for" (ids |> String.concat " ")
+
+    /// The <form> element to associate the <meter> element with (its form owner). The value of this 
+    /// attribute must be the id of a <form> in the same document. If this attribute is not set, the 
+    /// <button> is associated with its ancestor <form> element, if any. This attribute is only used 
+    /// if the <meter> element is being used as a form-associated element, such as one displaying a 
+    /// range corresponding to an <input type="number">.
+    static member inline form (value: string) = Interop.mkAttr "form" value
+    
+    /// Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
+    static member inline hidden (value: bool) = Interop.mkAttr "hidden" value
+
     /// Specifies the height of elements listed here. For all other elements, use the CSS height property.
     ///
     /// <canvas>, <embed>, <iframe>, <img>, <input>, <object>, <video>
-    static member inline height(value: int) = Interop.mkAttr "height" value
-    /// Specifies the width of elements listed here. For all other elements, use the CSS height property.
-    ///
-    /// <canvas>, <embed>, <iframe>, <img>, <input>, <object>, <video>
-    static member inline width(value: int) = Interop.mkAttr "width" value
+    static member inline height (value: int) = Interop.mkAttr "height" value
+
+    /// The lower numeric bound of the high end of the measured range. This must be less than the 
+    /// maximum value (max attribute), and it also must be greater than the low value and minimum 
+    /// value (low attribute and min attribute, respectively), if any are specified. If unspecified, 
+    /// or if greater than the maximum value, the high value is equal to the maximum value.
+    static member inline high (value: float) = Interop.mkAttr "high" value
+    /// The lower numeric bound of the high end of the measured range. This must be less than the 
+    /// maximum value (max attribute), and it also must be greater than the low value and minimum 
+    /// value (low attribute and min attribute, respectively), if any are specified. If unspecified, 
+    /// or if greater than the maximum value, the high value is equal to the maximum value.
+    static member inline high (value: int) = Interop.mkAttr "high" value
+
     /// The URL of a linked resource.
     static member inline href (value: string) = Interop.mkAttr "href" value
-    /// Prevents rendering of given element, while keeping child elements, e.g. script elements, active.
-    static member inline hidden (value: bool) = Interop.mkAttr "hidden" value
-    static member inline htmlFor(value: string) = Interop.mkAttr "htmlFor" value
-    /// Indicates the minimum value allowed.
-    static member inline min(value: int) = Interop.mkAttr "min" value
-    /// Indicates the minimum value allowed.
-    static member inline min(value: float) = Interop.mkAttr "min" value
+
+    /// Indicates the language of the linked resource. Allowed values are determined by BCP47. 
+    ///
+    /// Use this attribute only if the href attribute is present.
+    static member inline hrefLang (value: string) = Interop.mkAttr "hreflang" value
+
+    static member inline htmlFor (value: string) = Interop.mkAttr "htmlFor" value
+
+    /// Often used with CSS to style a specific element. The value of this attribute must be unique.
+    static member inline id (value: int) = Interop.mkAttr "id" (string value)
+    /// Often used with CSS to style a specific element. The value of this attribute must be unique.
+    static member inline id (value: string) = Interop.mkAttr "id" value
+
+    /// Alias for `dangerouslySetInnerHTML`, sets the inner Html content of the element.
+    static member inline innerHtml (content: string) = Interop.mkAttr "dangerouslySetInnerHTML" (createObj [ "__html" ==> content ])
+
+    /// Contains inline metadata that a user agent can use to verify that a fetched resource 
+    /// has been delivered free of unexpected manipulation.
+    static member inline integrity (value: string) = Interop.mkAttr "integrity" value
+
+    static member inline isChecked (value: bool) = Interop.mkAttr "checked" value
+
+    static member inline isOpen (value: bool) = Interop.mkAttr "open" value
+    
+    /// A special string attribute you need to include when creating arrays of elements. 
+    /// Keys help React identify which items have changed, are added, or are removed. 
+    /// Keys should be given to the elements inside an array to give the elements a stable identity.
+    /// 
+    /// Keys only need to be unique among sibling elements in the same array. They don’t need to 
+    /// be unique across the whole application or even a single component.
+    static member inline key (value: System.Guid) = Interop.mkAttr "value" (string value)
+    /// A special string attribute you need to include when creating arrays of elements. Keys help 
+    /// React identify which items have changed, are added, or are removed. Keys should be given 
+    /// to the elements inside an array to give the elements a stable identity.
+    /// 
+    /// Keys only need to be unique among sibling elements in the same array. They don’t need to 
+    /// be unique across the whole application or even a single component.
+    static member inline key (value: int) = Interop.mkAttr "key" value
+    /// A special string attribute you need to include when creating arrays of elements. Keys 
+    /// help React identify which 
+    /// items have changed, are added, or are removed. Keys should be given to the elements 
+    /// inside an array to give the elements a stable identity.
+    /// 
+    /// Keys only need to be unique among sibling elements in the same array. They don’t need to 
+    /// be unique across the whole application or even a single component.
+    static member inline key (value: string) = Interop.mkAttr "key" value
+
+    /// Helps define the language of an element: the language that non-editable elements are 
+    /// written in, or the language that the editable elements should be written in by the user.
+    static member inline lang (value: string) = Interop.mkAttr "lang" value
+
+    /// If true, the browser will automatically seek back to the start upon reaching the end of the video.
+    static member inline loop (value: bool) = Interop.mkAttr "loop" value
+
+    /// The upper numeric bound of the low end of the measured range. This must be greater than 
+    /// the minimum value (min attribute), and it also must be less than the high value and 
+    /// maximum value (high attribute and max attribute, respectively), if any are specified. 
+    /// If unspecified, or if less than the minimum value, the low value is equal to the minimum value.
+    static member inline low (value: float) = Interop.mkAttr "low" value
+    /// The upper numeric bound of the low end of the measured range. This must be greater than 
+    /// the minimum value (min attribute), and it also must be less than the high value and 
+    /// maximum value (high attribute and max attribute, respectively), if any are specified. 
+    /// If unspecified, or if less than the minimum value, the low value is equal to the minimum value.
+    static member inline low (value: int) = Interop.mkAttr "low" value
+
     /// Indicates the maximum value allowed.
-    static member inline max(value: int) = Interop.mkAttr "max" value
+    static member inline max (value: float) = Interop.mkAttr "max" value
     /// Indicates the maximum value allowed.
-    static member inline max(value: float) = Interop.mkAttr "max" value
-    /// Indicates the stepping interval.
-    static member inline step(value: int) = Interop.mkAttr "step" value
-    /// Indicates the stepping interval.
-    static member inline step(value: float) = Interop.mkAttr "step" value
-    /// Defines the minimum number of characters allowed in the element.
-    static member inline minLength(value: int) = Interop.mkAttr "minlength" value
+    static member inline max (value: int) = Interop.mkAttr "max" value
+
     /// Defines the maximum number of characters allowed in the element.
-    static member inline maxLength(value: int) = Interop.mkAttr "maxlength" value
-    /// Indicates whether multiple values can be entered in an input of the type email or file.
-    static member inline multiple(value: bool) = Interop.mkAttr "multiple" value
+    static member inline maxLength (value: int) = Interop.mkAttr "maxlength" value
+
+    /// This attribute specifies the media that the linked resource applies to. 
+    /// Its value must be a media type / media query. This attribute is mainly useful 
+    /// when linking to external stylesheets — it allows the user agent to pick the 
+    /// best adapted one for the device it runs on.
+    ///
+    /// In HTML 4, this can only be a simple white-space-separated list of media 
+    /// description literals, i.e., media types and groups, where defined and allowed 
+    /// as values for this attribute, such as print, screen, aural, braille. HTML5 
+    /// extended this to any kind of media queries, which are a superset of the allowed 
+    /// values of HTML 4.
+    ///
+    /// Browsers not supporting CSS3 Media Queries won't necessarily recognize the adequate 
+    /// link; do not forget to set fallback links, the restricted set of media queries 
+    /// defined in HTML 4.
+    static member inline media (value: string) = Interop.mkAttr "media" value
+
+    /// Indicates the minimum value allowed.
+    static member inline min (value: float) = Interop.mkAttr "min" value
+    /// Indicates the minimum value allowed.
+    static member inline min (value: int) = Interop.mkAttr "min" value
+
+    /// Defines the minimum number of characters allowed in the element.
+    static member inline minLength (value: int) = Interop.mkAttr "minlength" value
+
     /// Defines which HTTP method to use when submitting the form. Can be GET (default) or POST.
-    static member inline method(value: string) = Interop.mkAttr "method" value
+    static member inline method (value: string) = Interop.mkAttr "method" value
+
+    /// Indicates whether multiple values can be entered in an input of the type email or file.
+    static member inline multiple (value: bool) = Interop.mkAttr "multiple" value
+    
     /// Indicates whether the audio will be initially silenced on page load.
-    static member inline muted(value: bool) = Interop.mkAttr "muted" value
+    static member inline muted (value: bool) = Interop.mkAttr "muted" value
+    
     /// Name of the element. 
     ///
     /// For example used by the server to identify the fields in form submits.
-    static member inline name(value: string) = Interop.mkAttr "name" value
-    /// Provides a hint to the user of what can be entered in the field.
-    static member inline placeholder(value: string) = Interop.mkAttr "placeholder" value
-    static member inline isOpen(value: bool) = Interop.mkAttr "open" value
-    static member inline sizes (value: string) = Interop.mkAttr "sizes" value
-    /// One or more responsive image candidates.
-    static member inline srcset (value: string) = Interop.mkAttr "srcset" value
-    /// Indicates whether this element is required to fill out or not.
-    static member inline required(value: bool) = Interop.mkAttr "required" value
-    /// A value associated with http-equiv or name depending on the context.
-    static member inline content(value: string) = Interop.mkAttr "content" value
-    /// Children of this React element.
-    static member inline children(value: Fable.React.ReactElement) = Interop.mkAttr "children" value
-    /// Children of this React element.
-    static member inline children (elems: Fable.React.ReactElement seq) = Interop.mkAttr "children" (Interop.reactApi.Children.toArray elems)
-    /// Defines the number of rows in a text area.
-    static member inline rows(value: int) = Interop.mkAttr "rows" value
-    /// Defines the number of rows a table cell should span over.
-    static member inline rowSpan(value: int) = Interop.mkAttr "rowSpan" value
-    /// The URL of the embeddable content.
-    static member inline src(value: string) = Interop.mkAttr "src" value
-    /// Defines the first number if other than 1.
-    static member inline start(value: string) = Interop.mkAttr "start" value
-    /// Indicates whether the element can be edited.
-    static member inline readOnly (value: bool) = Interop.mkAttr "readOnly" value
-    static member inline custom(key: string, value: 't) = Interop.mkAttr key value
-    /// Fires when the user cuts the content of an element.
-    static member inline onCut (handler: ClipboardEvent -> unit) = Interop.mkAttr "onCut" handler
-    /// Fires when the user pastes some content in an element.
-    static member inline onPaste (handler: ClipboardEvent -> unit) = Interop.mkAttr "onPaste" handler
-    static member inline onCompositionEnd (handler: CompositionEvent -> unit) = Interop.mkAttr "onCompositionEnd" handler
-    static member inline onCompositionStart (handler: CompositionEvent -> unit) = Interop.mkAttr "onCompositionStart" handler
-    /// Fires when the user copies the content of an element.
-    static member inline onCopy (handler: ClipboardEvent -> unit) = Interop.mkAttr "onCopy" handler
-    static member inline onCompositionUpdate (handler: CompositionEvent -> unit) = Interop.mkAttr "onCompositionUpdate" handler
-    /// Fires the moment when the element gets focus.
-    static member inline onFocus (handler: FocusEvent -> unit) = Interop.mkAttr "onFocus" handler
+    static member inline name (value: string) = Interop.mkAttr "name" value
+
+    /// This Boolean attribute is set to indicate that the script should not be executed in 
+    /// browsers that support ES2015 modules — in effect, this can be used to serve fallback 
+    /// scripts to older browsers that do not support modular JavaScript code.
+    static member inline nomodule (value: bool) = Interop.mkAttr "nomodule" value
+
+    /// A cryptographic nonce (number used once) to whitelist scripts in a script-src 
+    /// Content-Security-Policy. The server must generate a unique nonce value each time 
+    /// it transmits a policy. It is critical to provide a nonce that cannot be guessed 
+    /// as bypassing a resource's policy is otherwise trivial.
+    static member inline nonce (value: string) = Interop.mkAttr "nonce" value
+
+    /// SVG attribute to define where the gradient color will begin or end.
+    static member inline offset (value: float) = Interop.mkAttr "offset" value
+    /// SVG attribute to define where the gradient color will begin or end.
+    static member inline offset (value: ICssUnit) = Interop.mkAttr "offset" value
+    /// SVG attribute to define where the gradient color will begin or end.
+    static member inline offset (value: int) = Interop.mkAttr "offset" value
+
+    /// Fires when a media event is aborted.
+    static member inline onAbort (handler: Event -> unit) = Interop.mkAttr "onAbort" handler
+    
+    static member inline onAnimationEnd (handler: AnimationEvent -> unit) = Interop.mkAttr "onAnimationEnd" handler
+
+    static member inline onAnimationIteration (handler: AnimationEvent -> unit) = Interop.mkAttr "onAnimationIteration" handler
+
+    static member inline onAnimationStart (handler: AnimationEvent -> unit) = Interop.mkAttr "onAnimationStart" handler
+
     /// Fires the moment that the element loses focus.
     static member inline onBlur (handler: FocusEvent -> unit) = Interop.mkAttr "onBlur" handler
+
+    /// Fires when a file is ready to start playing (when it has buffered enough to begin).
+    static member inline onCanPlay (handler: Event -> unit) = Interop.mkAttr "onCanPlay" handler
+
+    /// Fires when a file can be played all the way to the end without pausing for buffering
+    static member inline onCanPlayThrough (handler: Event -> unit) = Interop.mkAttr "onCanPlayThrough" handler
+
+    /// Same as `onChange` that takes an event as input but instead let's you deal with the `checked` value changed from the `input` element 
+    /// directly when it is defined as a checkbox with `prop.inputType.checkbox`.
+    static member inline onChange (handler: bool -> unit) = Interop.mkAttr "onChange" (fun (ev: Event) -> handler (!!ev.target?``checked``))
     /// Fires the moment when the value of the element is changed
     static member inline onChange (handler: Event -> unit) = Interop.mkAttr "onChange" handler
-    /// Same as `onChange` that takes an event as input but instead lets you deal with the text changed from the `input` element directly
-    /// instead of extracting it from the event arguments.
-    static member inline onChange (handler: string -> unit) = Interop.mkAttr "onChange" (fun (ev: Event) -> handler (!!ev.target?value))
-    /// Same as `onChange` that takes an event as input but instead lets you deal with the `checked` value changed from the `input` element directly when it is defined as a checkbox with `prop.type'.checkbox`.
-    static member inline onChange (handler: bool -> unit) = Interop.mkAttr "onChange" (fun (ev: Event) -> handler (!!ev.target?``checked``))
     /// Same as `onChange` that takes an event as input but instead lets you deal with the selected file directly from the `input` element when it is defined as a checkbox with `prop.type'.file`.
     static member inline onChange (handler: File -> unit) = 
         let fileHandler (ev: Event) : unit = 
@@ -457,309 +657,343 @@ type prop =
             let fileList : FileList = ev?target?files 
             if not (isNullOrUndefined fileList) then handler [ for i in 0 .. fileList.length - 1 -> fileList.item i ]
         Interop.mkAttr "onChange" fileHandler
-    /// Fires when an element gets user input.
-    static member inline onInput (handler: Event -> unit) = Interop.mkAttr "onInput" handler
-    /// Fires when a form is submitted.
-    static member inline onSubmit (handler: Event -> unit) = Interop.mkAttr "onSubmit" handler
-    /// Fires when the Reset button in a form is clicked.
-    static member inline onReset (handler: Event -> unit) = Interop.mkAttr "onReset" handler
-    /// Fires after the page is finished loading.
-    static member inline onLoad (handler: Event -> unit) = Interop.mkAttr "onLoad" handler
-    /// Fires when an error occurs.
-    static member inline onError (handler: Event -> unit) = Interop.mkAttr "onError" handler
-    /// Fires when a user is pressing a key.
-    static member inline onKeyDown (handler: KeyboardEvent -> unit) = Interop.mkAttr "onKeyDown" handler
-    /// Fires when a user presses a key.
-    static member inline onKeyPress (handler: KeyboardEvent -> unit) = Interop.mkAttr "onKeyPress" handler
-    /// Fires when a user releases a key.
-    static member inline onKeyUp (handler: KeyboardEvent -> unit) = Interop.mkAttr "onKeyUp" handler
-    /// Fires when a media event is aborted.
-    static member inline onAbort (handler: Event -> unit) = Interop.mkAttr "onAbort" handler
-    /// Fires when a file is ready to start playing (when it has buffered enough to begin).
-    static member inline onCanPlay (handler: Event -> unit) = Interop.mkAttr "onCanPlay" handler
-    /// Fires when a file can be played all the way to the end without pausing for buffering
-    static member inline onCanPlayThrough (handler: Event -> unit) = Interop.mkAttr "onCanPlayThrough" handler
-    /// Fires when the length of the media changes.
-    static member inline onDurationChange (handler: Event -> unit) = Interop.mkAttr "onDurationChange" handler
-    /// Fires when something bad happens and the file is suddenly unavailable (like unexpectedly disconnects).
-    static member inline onEmptied (handler: Event -> unit) = Interop.mkAttr "onEmptied" handler
-    static member inline onEncrypted (handler: Event -> unit) = Interop.mkAttr "onEncrypted" handler
-    /// Fires when the media has reach the end (a useful event for messages like "thanks for listening").
-    static member inline onEnded (handler: Event -> unit) = Interop.mkAttr "onEnded" handler
-    /// Fires when media data is loaded.
-    static member inline onLoadedData (handler: Event -> unit) = Interop.mkAttr "onLoadedData" handler
-    /// Fires when meta data (like dimensions and duration) are loaded.
-    static member inline onLoadedMetadata (handler: Event -> unit) = Interop.mkAttr "onLoadedMetadata" handler
-    /// Fires when the file begins to load before anything is actually loaded.
-    static member inline onLoadStart (handler: Event -> unit) = Interop.mkAttr "onLoadStart" handler
-    /// Fires when the media is paused either by the user or programmatically.
-    static member inline onPause (handler: Event -> unit) = Interop.mkAttr "onPause" handler
-    /// Fires when the media is ready to start playing.
-    static member inline onPlay (handler: Event -> unit) = Interop.mkAttr "onPlay" handler
-    /// Fires when the media actually has started playing
-    static member inline onPlaying (handler: Event -> unit) = Interop.mkAttr "onPlaying" handler
-    /// Fires when the browser is in the process of getting the media data.
-    static member inline onProgress (handler: Event -> unit) = Interop.mkAttr "onProgress" handler
-    /// Fires when the playback rate changes (like when a user switches to a slow motion or fast forward mode).
-    static member inline onRateChange (handler: Event -> unit) = Interop.mkAttr "onRateChange" handler
-    /// Fires when the seeking attribute is set to false indicating that seeking has ended.
-    static member inline onSeeked (handler: Event -> unit) = Interop.mkAttr "onSeeked" handler
-    /// Fires when the seeking attribute is set to true indicating that seeking is active.
-    static member inline onSeeking (handler: Event -> unit) = Interop.mkAttr "onSeeking" handler
-    /// Fires when the browser is unable to fetch the media data for whatever reason.
-    static member inline onStalled (handler: Event -> unit) = Interop.mkAttr "onStalled" handler
-    /// Fires when fetching the media data is stopped before it is completely loaded for whatever reason.
-    static member inline onSuspend (handler: Event -> unit) = Interop.mkAttr "onSuspend" handler
-    /// Fires when the playing position has changed (like when the user fast forwards to a different point in the media).
-    static member inline onTimeUpdate (handler: Event -> unit) = Interop.mkAttr "onTimeUpdate" handler
-    /// Fires when the volume is changed which (includes setting the volume to "mute").
-    static member inline onVolumeChange (handler: Event -> unit) = Interop.mkAttr "onVolumeChange" handler
-    /// Fires when the media has paused but is expected to resume (like when the media pauses to buffer more data).
-    static member inline onWaiting (handler: Event -> unit) = Interop.mkAttr "onWaiting" handler
+    /// Same as `onChange` that takes an event as input but instead let's you deal with the text changed from the `input` element directly
+    /// instead of extracting it from the event arguments.
+    static member inline onChange (handler: string -> unit) = Interop.mkAttr "onChange" (fun (ev: Event) -> handler (!!ev.target?value))
+
+    /// Same as `onChange` but let's you deal with the `checked` value that has changed from the `input` element directly instead of extracting it from the event arguments.
+    static member inline onCheckedChange (handler: bool -> unit) = Interop.mkAttr "onChange" (fun (ev: Event) -> handler (!!ev.target?``checked``))
+
     /// Fires on a mouse click on the element.
     static member inline onClick (handler: MouseEvent -> unit) = Interop.mkAttr "onClick" handler
+
+    static member inline onCompositionEnd (handler: CompositionEvent -> unit) = Interop.mkAttr "onCompositionEnd" handler
+
+    static member inline onCompositionStart (handler: CompositionEvent -> unit) = Interop.mkAttr "onCompositionStart" handler
+
+    static member inline onCompositionUpdate (handler: CompositionEvent -> unit) = Interop.mkAttr "onCompositionUpdate" handler
+
     /// Fires when a context menu is triggered.
     static member inline onContextMenu (handler: MouseEvent -> unit) = Interop.mkAttr "onContextMenu" handler
+
+    /// Fires when the user copies the content of an element.
+    static member inline onCopy (handler: ClipboardEvent -> unit) = Interop.mkAttr "onCopy" handler
+
+    /// Fires when the user cuts the content of an element.
+    static member inline onCut (handler: ClipboardEvent -> unit) = Interop.mkAttr "onCut" handler
+
     /// Fires when a mouse is double clicked on the element.
     static member inline onDoubleClick (handler: MouseEvent -> unit) = Interop.mkAttr "onDoubleClick" handler
+
     /// Fires when an element is dragged.
     static member inline onDrag (handler: DragEvent -> unit) = Interop.mkAttr "onDrag" handler
+
     /// Fires when the a drag operation has ended.
     static member inline onDragEnd (handler: DragEvent -> unit) = Interop.mkAttr "onDragEnd" handler
+
     /// Fires when an element has been dragged to a valid drop target.
     static member inline onDragEnter (handler: DragEvent -> unit) = Interop.mkAttr "onDragEnter" handler
+
     static member inline onDragExit (handler: DragEvent -> unit) = Interop.mkAttr "onDragExit" handler
+
     /// Fires when an element leaves a valid drop target.
     static member inline onDragLeave (handler: DragEvent -> unit) = Interop.mkAttr "onDragLeave" handler
+
     /// Fires when an element is being dragged over a valid drop target.
     static member inline onDragOver (handler: DragEvent -> unit) = Interop.mkAttr "onDragOver" handler
+
     /// Fires when the a drag operation has begun.
     static member inline onDragStart (handler: DragEvent -> unit) = Interop.mkAttr "onDragStart" handler
+
     /// Fires when dragged element is being dropped.
     static member inline onDrop (handler: DragEvent -> unit) = Interop.mkAttr "onDrop" handler
+
+    /// Fires when the length of the media changes.
+    static member inline onDurationChange (handler: Event -> unit) = Interop.mkAttr "onDurationChange" handler
+
+    /// Fires when something bad happens and the file is suddenly unavailable (like unexpectedly disconnects).
+    static member inline onEmptied (handler: Event -> unit) = Interop.mkAttr "onEmptied" handler
+
+    static member inline onEncrypted (handler: Event -> unit) = Interop.mkAttr "onEncrypted" handler
+
+    /// Fires when the media has reach the end (a useful event for messages like "thanks for listening").
+    static member inline onEnded (handler: Event -> unit) = Interop.mkAttr "onEnded" handler
+
+    /// Fires when an error occurs.
+    static member inline onError (handler: Event -> unit) = Interop.mkAttr "onError" handler
+
+    /// Fires the moment when the element gets focus.
+    static member inline onFocus (handler: FocusEvent -> unit) = Interop.mkAttr "onFocus" handler
+
+    /// Fires when an element gets user input.
+    static member inline onInput (handler: Event -> unit) = Interop.mkAttr "onInput" handler
+
+    /// Fires when a user is pressing a key.
+    static member inline onKeyDown (handler: KeyboardEvent -> unit) = Interop.mkAttr "onKeyDown" handler
+
+    /// Fires when a user presses a key.
+    static member inline onKeyPress (handler: KeyboardEvent -> unit) = Interop.mkAttr "onKeyPress" handler
+
+    /// Fires when a user releases a key.
+    static member inline onKeyUp (handler: KeyboardEvent -> unit) = Interop.mkAttr "onKeyUp" handler
+
+    /// Fires after the page is finished loading.
+    static member inline onLoad (handler: Event -> unit) = Interop.mkAttr "onLoad" handler
+
+    /// Fires when media data is loaded.
+    static member inline onLoadedData (handler: Event -> unit) = Interop.mkAttr "onLoadedData" handler
+
+    /// Fires when meta data (like dimensions and duration) are loaded.
+    static member inline onLoadedMetadata (handler: Event -> unit) = Interop.mkAttr "onLoadedMetadata" handler
+
+    /// Fires when the file begins to load before anything is actually loaded.
+    static member inline onLoadStart (handler: Event -> unit) = Interop.mkAttr "onLoadStart" handler
+
     /// Fires when a mouse button is pressed down on an element.
     static member inline onMouseDown (handler: MouseEvent -> unit) = Interop.mkAttr "onMouseDown" handler
+
     static member inline onMouseEnter (handler: MouseEvent -> unit) = Interop.mkAttr "onMouseEnter" handler
+
     static member inline onMouseLeave (handler: MouseEvent -> unit) = Interop.mkAttr "onMouseLeave" handler
+
     /// Fires when the mouse pointer is moving while it is over an element.
     static member inline onMouseMove (handler: MouseEvent -> unit) = Interop.mkAttr "onMouseMove" handler
+
     /// Fires when the mouse pointer moves out of an element.
     static member inline onMouseOut (handler: MouseEvent -> unit) = Interop.mkAttr "onMouseOut" handler
+
     /// Fires when the mouse pointer moves over an element.
     static member inline onMouseOver (handler: MouseEvent -> unit) = Interop.mkAttr "onMouseOver" handler
-    /// Fires after some text has been selected in an element.
-    static member inline onSelect (handler: Event -> unit) = Interop.mkAttr "onSelect" handler
-    static member inline onTouchCancel (handler: TouchEvent -> unit) = Interop.mkAttr "onTouchCancel" handler
-    static member inline onTouchEnd (handler: TouchEvent -> unit) = Interop.mkAttr "onTouchEnd" handler
-    static member inline onTouchMove (handler: TouchEvent -> unit) = Interop.mkAttr "onTouchMove" handler
-    static member inline onTouchStart (handler: TouchEvent -> unit) = Interop.mkAttr "onTouchStart" handler
+
+    /// Fires when the user pastes some content in an element.
+    static member inline onPaste (handler: ClipboardEvent -> unit) = Interop.mkAttr "onPaste" handler
+
+    /// Fires when the media is paused either by the user or programmatically.
+    static member inline onPause (handler: Event -> unit) = Interop.mkAttr "onPause" handler
+
+    /// Fires when the media is ready to start playing.
+    static member inline onPlay (handler: Event -> unit) = Interop.mkAttr "onPlay" handler
+
+    /// Fires when the media actually has started playing
+    static member inline onPlaying (handler: Event -> unit) = Interop.mkAttr "onPlaying" handler
+
+    /// Fires when the browser is in the process of getting the media data.
+    static member inline onProgress (handler: Event -> unit) = Interop.mkAttr "onProgress" handler
+    
+    /// Fires when the playback rate changes (like when a user switches to a slow motion or fast forward mode).
+    static member inline onRateChange (handler: Event -> unit) = Interop.mkAttr "onRateChange" handler
+
+    /// Fires when the Reset button in a form is clicked.
+    static member inline onReset (handler: Event -> unit) = Interop.mkAttr "onReset" handler
+
     /// Fires when an element's scrollbar is being scrolled.
     static member inline onScroll (handler: UIEvent -> unit) = Interop.mkAttr "onScroll" handler
+
+    /// Fires when the seeking attribute is set to false indicating that seeking has ended.
+    static member inline onSeeked (handler: Event -> unit) = Interop.mkAttr "onSeeked" handler
+
+    /// Fires when the seeking attribute is set to true indicating that seeking is active.
+    static member inline onSeeking (handler: Event -> unit) = Interop.mkAttr "onSeeking" handler
+
+    /// Fires after some text has been selected in an element.
+    static member inline onSelect (handler: Event -> unit) = Interop.mkAttr "onSelect" handler
+
+    /// Fires when the browser is unable to fetch the media data for whatever reason.
+    static member inline onStalled (handler: Event -> unit) = Interop.mkAttr "onStalled" handler
+
+    /// Fires when fetching the media data is stopped before it is completely loaded for whatever reason.
+    static member inline onSuspend (handler: Event -> unit) = Interop.mkAttr "onSuspend" handler
+
+    /// Fires when a form is submitted.
+    static member inline onSubmit (handler: Event -> unit) = Interop.mkAttr "onSubmit" handler
+
+    /// Same as `onChange` but let's you deal with the text changed from the `input` element directly
+    /// instead of extracting it from the event arguments.
+    static member inline onTextChange (handler: string -> unit) = Interop.mkAttr "onChange" (fun (ev: Event) -> handler (!!ev.target?value))
+    
+    /// Fires when the playing position has changed (like when the user fast forwards to a different point in the media).
+    static member inline onTimeUpdate (handler: Event -> unit) = Interop.mkAttr "onTimeUpdate" handler
+    
+    static member inline onTouchCancel (handler: TouchEvent -> unit) = Interop.mkAttr "onTouchCancel" handler
+
+    static member inline onTouchEnd (handler: TouchEvent -> unit) = Interop.mkAttr "onTouchEnd" handler
+
+    static member inline onTouchMove (handler: TouchEvent -> unit) = Interop.mkAttr "onTouchMove" handler
+
+    static member inline onTouchStart (handler: TouchEvent -> unit) = Interop.mkAttr "onTouchStart" handler
+
+    static member inline onTransitionEnd (handler: TransitionEvent -> unit) = Interop.mkAttr "onTransitionEnd" handler
+
+    /// Fires when the volume is changed which (includes setting the volume to "mute").
+    static member inline onVolumeChange (handler: Event -> unit) = Interop.mkAttr "onVolumeChange" handler
+    
+    /// Fires when the media has paused but is expected to resume (like when the media pauses to buffer more data).
+    static member inline onWaiting (handler: Event -> unit) = Interop.mkAttr "onWaiting" handler
+    
     /// Fires when the mouse wheel rolls up or down over an element.
     static member inline onWheel (handler: WheelEvent -> unit) = Interop.mkAttr "onWheel" handler
-    static member inline onAnimationStart (handler: AnimationEvent -> unit) = Interop.mkAttr "onAnimationStart" handler
-    static member inline onAnimationEnd (handler: AnimationEvent -> unit) = Interop.mkAttr "onAnimationEnd" handler
-    static member inline onAnimationIteration (handler: AnimationEvent -> unit) = Interop.mkAttr "onAnimationIteration" handler
-    static member inline onTransitionEnd (handler: TransitionEvent -> unit) = Interop.mkAttr "onTransitionEnd" handler
+    
+    /// This attribute indicates the optimal numeric value. It must be within the range (as defined by the min 
+    /// attribute and max attribute). When used with the low attribute and high attribute, it gives an indication 
+    /// where along the range is considered preferable. For example, if it is between the min attribute and the 
+    /// low attribute, then the lower range is considered preferred.
+    static member inline optimum (value: float) = Interop.mkAttr "optimum" value
+    /// This attribute indicates the optimal numeric value. It must be within the range (as defined by the min 
+    /// attribute and max attribute). When used with the low attribute and high attribute, it gives an indication 
+    /// where along the range is considered preferable. For example, if it is between the min attribute and the 
+    /// low attribute, then the lower range is considered preferred.
+    static member inline optimum (value: int) = Interop.mkAttr "optimum" value
+
+    /// Provides a hint to the user of what can be entered in the field.
+    static member inline placeholder (value: string) = Interop.mkAttr "placeholder" value
+
+    /// Indicating that the video is to be played "inline", that is within the element's playback area. 
+    ///
+    /// Note that the absence of this attribute does not imply that the video will always be played in fullscreen.
+    static member inline playsInline (value: bool) = Interop.mkAttr "playsinline" value
+
+    /// Contains a space-separated list of URLs to which, when the hyperlink is followed, 
+    /// POST requests with the body PING will be sent by the browser (in the background).
+    /// 
+    /// Typically used for tracking.
+    static member inline ping (value: string) = Interop.mkAttr "ping" value
+    /// Contains a space-separated list of URLs to which, when the hyperlink is followed, 
+    /// POST requests with the body PING will be sent by the browser (in the background).
+    /// 
+    /// Typically used for tracking.
+    static member inline ping (urls: #seq<string>) = Interop.mkAttr "ping" (urls |> String.concat " ")
+
+    /// SVG attribute to define a list of points.
+    static member inline points (value: string) = Interop.mkAttr "points" value
+
+    /// A URL for an image to be shown while the video is downloading. If this attribute isn't specified, nothing 
+    /// is displayed until the first frame is available, then the first frame is shown as the poster frame.
+    static member inline poster (value: string) = Interop.mkAttr "poster" value
+
+    /// SVG attribute to define the radius of a circle
+    static member inline r (value: float) = Interop.mkAttr "r" value
+    /// SVG attribute to define the radius of a circle
+    static member inline r (value: ICssUnit) = Interop.mkAttr "r" value
+    /// SVG attribute to define the radius of a circle
+    static member inline r (value: int) = Interop.mkAttr "r" value
+
+    /// Indicates whether the element can be edited.
+    static member inline readOnly (value: bool) = Interop.mkAttr "readOnly" value
+
+    /// Used to reference a DOM element or class component from within a parent component.
+    static member inline ref (handler: Element -> unit) = Interop.mkAttr "ref" handler
+    /// Used to reference a DOM element or class component from within a parent component.
+    static member inline ref (ref: Fable.React.IRefValue<HTMLElement option>) = Interop.mkAttr "ref" ref
+    
+    /// For anchors containing the href attribute, this attribute specifies the relationship 
+    /// of the target object to the link object. The value is a space-separated list of link 
+    /// types values. The values and their semantics will be registered by some authority that 
+    /// might have meaning to the document author. The default relationship, if no other is 
+    /// given, is void. 
+    ///
+    /// Use this attribute only if the href attribute is present.
+    static member inline rel (value: bool) = Interop.mkAttr "rel" value
+
+    /// Indicates whether this element is required to fill out or not.
+    static member inline required (value: bool) = Interop.mkAttr "required" value
+
+    /// Sets the aria role
+    ///
     /// https://www.w3.org/WAI/PF/aria-1.1/roles
     static member inline role ([<System.ParamArray>] roles: string []) = Interop.mkAttr "role" (String.concat " " roles)
-    /// Indicates whether assistive technologies will present all, or only parts
-    /// of, the changed region based on the change notifications defined by the
-    /// `aria-relevant` attribute.
+
+    /// Defines the number of rows in a text area.
+    static member inline rows (value: int) = Interop.mkAttr "rows" value
+
+    /// Defines the number of rows a table cell should span over.
+    static member inline rowSpan (value: int) = Interop.mkAttr "rowSpan" value
+
+    /// The SVG rx attribute defines a radius on the x-axis.
     ///
-    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-atomic
-    static member inline ariaAtomic (value: bool) = Interop.mkAttr "aria-atomic" value
-    /// Indicates whether an element, and its subtree, are currently being
-    /// updated.
+    /// Two elements are using this attribute: <ellipse>, and <rect>
+    static member inline rx (value: float) = Interop.mkAttr "rx" value
+    /// The SVG rx attribute defines a radius on the x-axis.
     ///
-    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-busy
-    static member inline ariaBusy (value: bool) = Interop.mkAttr "aria-busy" value
-    /// Identifies the element (or elements) whose contents or presence are
-    /// controlled by the current element. See related `aria-owns`.
+    /// Two elements are using this attribute: <ellipse>, and <rect>
+    static member inline rx (value: ICssUnit) = Interop.mkAttr "rx" value
+    /// The SVG rx attribute defines a radius on the x-axis.
     ///
-    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-controls
-    static member inline ariaControls ([<System.ParamArray>] ids: string []) = Interop.mkAttr "aria-controls" (String.concat " " ids)
-    /// Specifies a URI referencing content that describes the object. See
-    /// related `aria-describedby`.
+    /// Two elements are using this attribute: <ellipse>, and <rect>
+    static member inline rx (value: int) = Interop.mkAttr "rx" value
+    
+    /// The SVG ry attribute defines a radius on the y-axis.
     ///
-    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-describedat
-    static member inline ariaDescribedAt (uri: string) = Interop.mkAttr "aria-describedat" uri
-    /// Identifies the element (or elements) that describes the object. See
-    /// related `aria-describedat` and `aria-labelledby`.
+    /// Two elements are using this attribute: <ellipse>, and <rect>
+    static member inline ry (value: float) = Interop.mkAttr "ry" value
+    /// The SVG ry attribute defines a radius on the y-axis.
     ///
-    /// The `aria-labelledby` attribute is similar to `aria-describedby` in that
-    /// both reference other elements to calculate a text alternative, but a
-    /// label should be concise, where a description is intended to provide more
-    /// verbose information.
+    /// Two elements are using this attribute: <ellipse>, and <rect>
+    static member inline ry (value: ICssUnit) = Interop.mkAttr "ry" value
+    /// The SVG ry attribute defines a radius on the y-axis.
     ///
-    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-describedby
-    static member inline ariaDescribedBy ([<System.ParamArray>] ids: string []) = Interop.mkAttr "aria-describedby" (String.concat " " ids)
-    /// Indicates that the element is perceivable but disabled, so it is not
-    /// editable or otherwise operable. See related `aria-hidden` and
-    /// `aria-readonly`.
+    /// Two elements are using this attribute: <ellipse>, and <rect>
+    static member inline ry (value: int) = Interop.mkAttr "ry" value
+
+    /// Defines a value which will be selected on page load.
+    static member inline selected (value: bool) = Interop.mkAttr "selected" value
+
+    /// Defines the sizes of the icons for visual media contained in the resource. 
+    /// It must be present only if the rel contains a value of icon or a non-standard 
+    /// type such as Apple's apple-touch-icon.
     ///
-    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-disabled
-    static member inline ariaDisabled (value: bool) = Interop.mkAttr "aria-disabled" value
-    /// Indicates what functions can be performed when the dragged object is
-    /// released on the drop target. This allows assistive technologies to
-    /// convey the possible drag options available to users, including whether a
-    /// pop-up menu of choices is provided by the application. Typically, drop
-    /// effect functions can only be provided once an object has been grabbed
-    /// for a drag operation as the drop effect functions available are
-    /// dependent on the object being dragged.
+    /// It may have the following values:
     ///
-    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-dropeffect
-    static member inline ariaDropEffect ([<System.ParamArray>] values: AriaDropEffect []) = Interop.mkAttr "aria-dropeffect" (values |> unbox<string []> |> String.concat " ")
-    /// Identifies the next element (or elements) in an alternate reading order
-    /// of content which, at the user's discretion, allows assistive technology
-    /// to override the general default of reading in document source order.
+    /// `any`, meaning that the icon can be scaled to any size as it is in a vector 
+    /// format, like image/svg+xml.
     ///
-    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-flowto
-    static member inline ariaFlowTo ([<System.ParamArray>] ids: string []) = Interop.mkAttr "aria-flowto" (String.concat " " ids)
-    /// Indicates an element's "grabbed" state in a drag-and-drop operation.
+    /// A white-space separated list of sizes, each in the format `<width in pixels>x<height in pixels>`
+    /// or `<width in pixels>X<height in pixels>`. Each of these sizes must be contained in the resource.
+    static member inline sizes (value: string) = Interop.mkAttr "sizes" value
+
+    /// Defines whether the element may be checked for spelling errors.
+    static member inline spellcheck (value: bool) = Interop.mkAttr "spellcheck" value
+
+    /// This attribute contains a positive integer indicating the number of consecutive 
+    /// columns the <col> element spans. If not present, its default value is 1.
+    static member inline spam (value: int) = Interop.mkAttr "span" value
+
+    /// The URL of the embeddable content.
+    static member inline src (value: string) = Interop.mkAttr "src" value
+
+    /// Language of the track text data. It must be a valid BCP 47 language tag. 
     ///
-    /// When it is set to true it has been selected for dragging, false
-    /// indicates that the element can be grabbed for a drag-and-drop operation,
-    /// but is not currently grabbed, and undefined (or no value) indicates the
-    /// element cannot be grabbed (default).
-    ///
-    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-grabbed
-    static member inline ariaGrabbed (value: bool) = Interop.mkAttr "aria-grabbed" value
-    /// Indicates that the element has a popup context menu or sub-level menu.
-    ///
-    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-haspopup
-    static member inline ariaHasPopup (value: bool) = Interop.mkAttr "aria-haspopup" value
-    /// Indicates that the element and all of its descendants are not visible or
-    /// perceivable to any user as implemented by the author. See related
-    /// `aria-disabled`.
-    ///
-    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-hidden
-    static member inline ariaHidden (value: bool) = Interop.mkAttr "aria-hidden" value
-    /// Indicates the entered value does not conform to the format expected by
-    /// the application.
-    ///
-    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-invalid
-    static member inline ariaInvalid (value: bool) = Interop.mkAttr "aria-invalid" value
-    /// Defines a string value that labels the current element. See related
-    /// `aria-labelledby`.
-    ///
-    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-label
-    static member inline ariaLabel (value: string) = Interop.mkAttr "aria-label" value
-    /// Identifies the element (or elements) that labels the current element.
-    /// See related `aria-label` and `aria-describedby`.
-    ///
-    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-labelledby
-    static member inline ariaLabelledBy ([<System.ParamArray>] ids: string []) = Interop.mkAttr "aria-labelledby" (String.concat " " ids)
-    /// Identifies an element (or elements) in order to define a visual,
-    /// functional, or contextual parent/child relationship between DOM elements
-    /// where the DOM hierarchy cannot be used to represent the relationship.
-    /// See related `aria-controls`.
-    ///
-    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-owns
-    static member inline ariaOwns ([<System.ParamArray>] ids: string []) = Interop.mkAttr "aria-owns" (String.concat " " ids)
-    /// Indicates what user agent change notifications (additions, removals,
-    /// etc.) assistive technologies will receive within a live region. See
-    /// related `aria-atomic`.
-    ///
-    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-relevant
-    static member inline ariaRelevant ([<System.ParamArray>] values: AriaRelevant []) = Interop.mkAttr "aria-relevant" (values |> unbox<string []> |> String.concat " ")
-    /// Indicates the current "checked" state of checkboxes, radio buttons, and
-    /// other widgets. See related `aria-pressed` and `aria-selected`.
-    ///
-    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-checked
-    static member inline ariaChecked (value: bool) = Interop.mkAttr "aria-checked" value
-    /// Indicates whether the element, or another grouping element it controls,
-    /// is currently expanded or collapsed.
-    ///
-    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-expanded
-    static member inline ariaExpanded (value: bool) = Interop.mkAttr "aria-expanded" value
-    /// Defines the hierarchical level of an element within a structure.
-    ///
-    /// This can be applied inside trees to tree items, to headings inside a
-    /// document, to nested grids, nested tablists and to other structural items
-    /// that may appear inside a container or participate in an ownership
-    /// hierarchy. The value for `aria-level` is an integer greater than or
-    /// equal to 1.
-    ///
-    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-level
-    static member inline ariaLevel (value: int) = Interop.mkAttr "aria-level" value
-    /// Indicates whether a text box accepts multiple lines of input or only a
-    /// single line.
-    ///
-    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-multiline
-    static member inline ariaMultiLine (value: bool) = Interop.mkAttr "aria-multiline" value
-    /// Indicates that the user may select more than one item from the current
-    /// selectable descendants.
-    ///
-    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-multiselectable
-    static member inline ariaMultiSelectable (value: bool) = Interop.mkAttr "aria-multiselectable" value
-    /// Indicates the current "pressed" state of toggle buttons. See related
-    /// `aria-checked` and `aria-selected`.
-    ///
-    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-pressed
-    static member inline ariaPressed (value: bool) = Interop.mkAttr "aria-pressed" value
-    /// Indicates that the element is not editable, but is otherwise operable.
-    /// See related `aria-disabled`.
-    ///
-    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-readonly
-    static member inline ariaReadOnly (value: bool) = Interop.mkAttr "aria-readonly" value
-    /// Indicates that user input is required on the element before a form may
-    /// be submitted.
-    ///
-    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-required
-    static member inline ariaRequired (value: bool) = Interop.mkAttr "aria-required" value
-    /// Indicates the current "selected" state of various widgets. See related
-    /// `aria-checked` and `aria-pressed`.
-    ///
-    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-selected
-    static member inline ariaSelected (value: bool) = Interop.mkAttr "aria-selected" value
-    /// Defines the maximum allowed value for a range widget.
-    ///
-    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-valuemax
-    static member inline ariaValueMax (value: int) = Interop.mkAttr "aria-valuemax" value
-    /// Defines the maximum allowed value for a range widget.
-    ///
-    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-valuemax
-    static member inline ariaValueMax (value: float) = Interop.mkAttr "aria-valuemax" value
-    /// Defines the minimum allowed value for a range widget.
-    ///
-    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-valuemin
-    static member inline ariaValueMin (value: int) = Interop.mkAttr "aria-valuemin" value
-    /// Defines the minimum allowed value for a range widget.
-    ///
-    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-valuemin
-    static member inline ariaValueMin (value: float) = Interop.mkAttr "aria-valuemin" value
-    /// Defines the current value for a range widget. See related
-    /// `aria-valuetext`.
-    ///
-    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-valuenow
-    static member inline ariaValueNow (value: int) = Interop.mkAttr "aria-valuenow" value
-    /// Defines the current value for a range widget. See related
-    /// `aria-valuetext`.
-    ///
-    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-valuenow
-    static member inline ariaValueNow (value: float) = Interop.mkAttr "aria-valuenow" value
-    /// Defines the human readable text alternative of `aria-valuenow` for a
-    /// range widget.
-    ///
-    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-valuetext
-    static member inline ariaValueText (value: string) = Interop.mkAttr "aria-valuetext" value
-    /// Identifies the currently active descendant of a `composite` widget.
-    ///
-    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-activedescendant
-    static member inline ariaActiveDescendant (id: string) = Interop.mkAttr "aria-activedescendant" id
-    /// Defines an element's number or position in the current set of listitems
-    /// or treeitems. Not required if all elements in the set are present in the
-    /// DOM. See related `aria-setsize`.
-    ///
-    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-posinset
-    static member inline ariaPosInSet (value: int) = Interop.mkAttr "aria-posinset" value
-    /// Defines the number of items in the current set of listitems or
-    /// treeitems. Not required if all elements in the set are present in the
-    /// DOM. See related `aria-posinset`.
-    ///
-    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-setsize
-    static member inline ariaSetSize (value: int) = Interop.mkAttr "aria-setsize" value
+    /// If the kind attribute is set to subtitles, then srclang must be defined.
+    static member inline srcLang (value: string) = Interop.mkAttr "srclang" value
+
+    /// One or more responsive image candidates.
+    static member inline srcset (value: string) = Interop.mkAttr "srcset" value
+
+    /// Defines the first number if other than 1.
+    static member inline start (value: string) = Interop.mkAttr "start" value
+
+    /// Indicates the stepping interval.
+    static member inline step (value: float) = Interop.mkAttr "step" value
+    /// Indicates the stepping interval.
+    static member inline step (value: int) = Interop.mkAttr "step" value
+
+    /// SVG attribute to indicate what color to use at a gradient stop.
+    static member inline stopColor (value: string) = Interop.mkAttr "stopColor" value
+
+    /// SVG attribute to define the opacity of a given color gradient stop.
+    static member inline stopOpacity (value: float) = Interop.mkAttr "stopOpacity" value
+    /// SVG attribute to define the opacity of a given color gradient stop.
+    static member inline stopOpacity (value: int) = Interop.mkAttr "stopOpacity" value
+
+    /// SVG attribute to define the color (or any SVG paint servers like gradients or patterns) used to paint the outline of the shape.
+    static member inline stroke (color: string) = Interop.mkAttr "stroke" color
+
+    /// SVG attribute to define the width of the stroke to be applied to the shape.
+    static member inline strokeWidth (value: float) = Interop.mkAttr "strokeWidth" value
+    /// SVG attribute to define the width of the stroke to be applied to the shape.
+    static member inline strokeWidth (value: ICssUnit) = Interop.mkAttr "strokeWidth" value
+    /// SVG attribute to define the width of the stroke to be applied to the shape.
+    static member inline strokeWidth (value: int) = Interop.mkAttr "strokeWidth" value
+    
     static member inline style (properties: #IStyleAttribute list) = Interop.mkAttr "style" (createObj !!properties)
     static member style (properties: (bool * IStyleAttribute list) list) =
         properties
@@ -768,512 +1002,186 @@ type prop =
         |> unbox
         |> createObj
         |> Interop.mkAttr "style"
+
+    /// The `tabindex` global attribute indicates that its element can be focused, 
+    /// and where it participates in sequential keyboard navigation (usually with the Tab key, hence the name).
+    static member inline tabIndex (index: int) = Interop.mkAttr "tabindex" index
+
     /// Controls browser behavior when opening a link.
     static member inline target (frameName: string) = Interop.mkAttr "target" frameName
 
-module prop =
+    /// Defines the text content of the element. Alias for `children [ Html.text value ]`
+    static member inline text (value: float) = Interop.mkAttr "children" value
+    /// Defines the text content of the element. Alias for `children [ Html.text value ]`
+    static member inline text (value: int) = Interop.mkAttr "children" value
+    /// Defines the text content of the element. Alias for `children [ Html.text value ]`
+    static member inline text (value: string) = Interop.mkAttr "children" value
 
-    [<Erase>]
-    /// The `dominantBaseline` attribute specifies the dominant baseline, which is the baseline used to align the box’s text and inline-level contents. It also indicates the default alignment baseline of any boxes participating in baseline alignment in the box’s alignment context.
-    /// It is used to determine or re-determine a scaled-baseline-table. A scaled-baseline-table is a compound value with three components: a baseline-identifier for the dominant-baseline, a baseline-table and a baseline-table font-size. Some values of the property re-determine all three values; other only re-establish the baseline-table font-size. When the initial value, auto, would give an undesired result, this property can be used to explicitly set the desired scaled-baseline-table.
-    /// If there is no baseline table in the nominal font or if the baseline table lacks an entry for the desired baseline, then the browser may use heuristics to determine the position of the desired baseline.
-    type dominantBaseline =
-        /// If this property occurs on a <text> element, then the computed value depends on the value of the writing-mode attribute.
-        /// If the writing-mode is horizontal, then the value of the dominant-baseline component is alphabetic, else if the writing-mode is vertical, then the value of the dominant-baseline component is central.
-        /// If this property occurs on a <tspan>, <tref>, <altGlyph> or <textPath> element, then the dominant-baseline and the baseline-table components remain the same as those of the parent text content element.
-        /// If the computed baseline-shift value actually shifts the baseline, then the baseline-table font-size component is set to the value of the font-size attribute on the element on which the dominant-baseline attribute occurs, otherwise the baseline-table font-size remains the same as that of the element.
-        /// If there is no parent text content element, the scaled-baseline-table value is constructed as above for <text> elements.
-        static member inline auto = Interop.mkAttr "dominantBaseline" "auto"
-        /// The baseline-identifier for the dominant-baseline is set to be ideographic, the derived baseline-table is constructed using the ideographic baseline-table in the font, and the baseline-table font-size is changed to the value of the font-size attribute on this element.
-        static member inline ideographic = Interop.mkAttr "dominantBaseline" "ideographic"
-        /// The baseline-identifier for the dominant-baseline is set to be alphabetic, the derived baseline-table is constructed using the alphabetic baseline-table in the font, and the baseline-table font-size is changed to the value of the font-size attribute on this element.
-        static member inline alphabetic = Interop.mkAttr "dominantBaseline" "alphabetic"
-        /// The baseline-identifier for the dominant-baseline is set to be hanging, the derived baseline-table is constructed using the hanging baseline-table in the font, and the baseline-table font-size is changed to the value of the font-size attribute on this element.
-        static member inline hanging = Interop.mkAttr "dominantBaseline" "hanging"
-        /// The baseline-identifier for the dominant-baseline is set to be mathematical, the derived baseline-table is constructed using the mathematical baseline-table in the font, and the baseline-table font-size is changed to the value of the font-size attribute on this element.
-        static member inline mathematical = Interop.mkAttr "dominantBaseline" "mathematical"
-        /// The baseline-identifier for the dominant-baseline is set to be central. The derived baseline-table is constructed from the defined baselines in a baseline-table in the font. That font baseline-table is chosen using the following priority order of baseline-table names: ideographic, alphabetic, hanging, mathematical. The baseline-table font-size is changed to the value of the font-size attribute on this element.
-        static member inline central = Interop.mkAttr "dominantBaseline" "central"
-        /// The baseline-identifier for the dominant-baseline is set to be middle. The derived baseline-table is constructed from the defined baselines in a baseline-table in the font. That font baseline-table is chosen using the following priority order of baseline-table names: alphabetic, ideographic, hanging, mathematical. The baseline-table font-size is changed to the value of the font-size attribute on this element.
-        static member inline middle = Interop.mkAttr "dominantBaseline" "middle"
-        /// The baseline-identifier for the dominant-baseline is set to be text-after-edge. The derived baseline-table is constructed from the defined baselines in a baseline-table in the font. The choice of which font baseline-table to use from the baseline-tables in the font is browser dependent. The baseline-table font-size is changed to the value of the font-size attribute on this element.
-        static member inline textAfterEdge = Interop.mkAttr "dominantBaseline" "text-after-edge"
-        /// The baseline-identifier for the dominant-baseline is set to be text-before-edge. The derived baseline-table is constructed from the defined baselines in a baseline-table in the font. The choice of which baseline-table to use from the baseline-tables in the font is browser dependent. The baseline-table font-size is changed to the value of the font-size attribute on this element.
-        static member inline textBeforeEdge = Interop.mkAttr "dominantBaseline" "text-before-edge"
-        /// This value uses the top of the em box as the baseline.
-        static member inline textTop = Interop.mkAttr "dominantBaseline" "text-top"
+    /// The title global attribute contains text representing advisory information related to the element it belongs to.
+    static member inline title (value: string) = Interop.mkAttr "title" value
 
-    [<Erase>]
-    /// The `text-anchor` attribute is used to align (start-, middle- or
-    /// end-alignment) a string of pre-formatted text or auto-wrapped text where
-    /// the wrapping area is determined from the `inline-size` property relative
-    /// to a given point. It is not applicable to other types of auto-wrapped
-    /// text. For those cases you should use `text-align`. For multi-line text,
-    /// the alignment takes place for each line.
+    /// Sets the `type` attribute for the element.
+    static member inline type' (value: string) = Interop.mkAttr "type" value
+    
+    /// A hash-name reference to a <map> element; that is a '#' followed by the value of a name of a map element.
+    static member inline usemap (value: string) = Interop.mkAttr "usemap" value
+
+    /// Sets the value of a React controlled component.
+    static member inline value (value: bool) = Interop.mkAttr "value" value
+    /// Sets the value of a React controlled component.
+    static member inline value (value: float) = Interop.mkAttr "value" value
+    /// Sets the value of a React controlled component.
+    static member inline value (value: System.Guid) = Interop.mkAttr "value" (string value)
+    /// Sets the value of a React controlled component.
+    static member inline value (value: int) = Interop.mkAttr "value" value
+    /// Sets the value of a React controlled component.
+    static member inline value (value: string) = Interop.mkAttr "value" value
+
+    /// `prop.ref` callback that sets the value of an input after DOM element is created.
+    /// Can be used instead of `prop.defaultValue` and `prop.value` props to override input value.
+    static member inline valueOrDefault (value: bool) =
+        prop.ref (fun e -> if e |> isNull |> not && !!e?value <> !!value then e?value <- !!value)
+    /// `prop.ref` callback that sets the value of an input after DOM element is created.
+    /// Can be used instead of `prop.defaultValue` and `prop.value` props to override input value.
+    static member inline valueOrDefault (value: float) =
+        prop.ref (fun e -> if e |> isNull |> not && !!e?value <> !!value then e?value <- !!value)
+    /// `prop.ref` callback that sets the value of an input after DOM element is created.
+    /// Can be used instead of `prop.defaultValue` and `prop.value` props to override input value.
+    static member inline valueOrDefault (value: System.Guid) =
+        prop.ref (fun e -> if e |> isNull |> not && !!e?value <> !!value then e?value <- !!value)
+    /// `prop.ref` callback that sets the value of an input after DOM element is created.
+    /// Can be used instead of `prop.defaultValue` and `prop.value` props to override input value.
+    static member inline valueOrDefault (value: int) =
+        prop.ref (fun e -> if e |> isNull |> not && !!e?value <> !!value then e?value <- !!value)
+    /// `prop.ref` callback that sets the value of an input after DOM element is created.
+    /// Can be used instead of `prop.defaultValue` and `prop.value` props to override input box value.
+    static member inline valueOrDefault (value: string) =
+        prop.ref (fun e -> if e |> isNull |> not && !!e?value <> !!value then e?value <- !!value)
+    
+    /// Set visible area of the SVG image.
+    static member inline viewPort (x: int, y: int, height: int, width: int) =
+        Interop.mkAttr "viewport"
+          ((unbox<string> x) + " " +
+           (unbox<string> y) + " " +
+           (unbox<string> height) + " " +
+           (unbox<string> width))
+    
+    /// Specifies the width of elements listed here. For all other elements, use the CSS height property.
     ///
-    /// The `text-anchor` attribute is applied to each individual text chunk
-    /// within a given `<text>` element. Each text chunk has an initial current
-    /// text position, which represents the point in the user coordinate system
-    /// resulting from (depending on context) application of the `x` and `y`
-    /// attributes on the `<text>` element, any `x` or `y` attribute values on a
-    /// `<tspan>`, `<tref>` or `<altGlyph>` element assigned explicitly to the
-    /// first rendered character in a text chunk, or determination of the
-    /// initial current text position for a `<textPath>` element.
-    type textAnchor =
-        /// The rendered characters are aligned such that the start of the text
-        /// string is at the initial current text position. For an element with
-        /// a `direction` property value of `ltr` (typical for most European
-        /// languages), the left side of the text is rendered at the initial
-        /// text position. For an element with a `direction` property value of
-        /// `rtl` (typical for Arabic and Hebrew), the right side of the text is
-        /// rendered at the initial text position. For an element with a
-        /// vertical primary text direction (often typical for Asian text), the
-        /// top side of the text is rendered at the initial text position.
-        static member inline startOfText = Interop.mkAttr "textAnchor" "start"
-        /// The rendered characters are aligned such that the middle of the text
-        /// string is at the current text position. (For text on a path,
-        /// conceptually the text string is first laid out in a straight line.
-        /// The midpoint between the start of the text string and the end of the
-        /// text string is determined. Then, the text string is mapped onto the
-        /// path with this midpoint placed at the current text position.)
-        static member inline middle = Interop.mkAttr "textAnchor" "middle"
-        /// The rendered characters are shifted such that the end of the
-        /// resulting rendered text (final current text position before applying
-        /// the `text-anchor` property) is at the initial current text position.
-        /// For an element with a `direction` property value of `ltr` (typical
-        /// for most European languages), the right side of the text is rendered
-        /// at the initial text position. For an element with a `direction`
-        /// property value of `rtl` (typical for Arabic and Hebrew), the left
-        /// side of the text is rendered at the initial text position. For an
-        /// element with a vertical primary text direction (often typical for
-        /// Asian text), the bottom of the text is rendered at the initial text
-        /// position.
-        static member inline endOfText = Interop.mkAttr "textAnchor" "end"
+    /// <canvas>, <embed>, <iframe>, <img>, <input>, <object>, <video>
+    static member inline width (value: int) = Interop.mkAttr "width" value
 
-    /// https://www.w3.org/WAI/PF/aria-1.1/roles
+    /// SVG attribute to define a x-axis coordinate in the user coordinate system.
+    static member inline x (value: float) = Interop.mkAttr "x" value
+    /// SVG attribute to define a x-axis coordinate in the user coordinate system.
+    static member inline x (value: ICssUnit) = Interop.mkAttr "x" value
+    /// SVG attribute to define a x-axis coordinate in the user coordinate system.
+    static member inline x (value: int) = Interop.mkAttr "x" value
+
+    /// The x1 attribute is used to specify the first x-coordinate for drawing an SVG element that 
+    /// requires more than one coordinate. Elements that only need one coordinate use the x attribute instead.
+    ///
+    /// Two elements are using this attribute: <line>, and <linearGradient>
+    static member inline x1 (value: float) = Interop.mkAttr "x1" value
+    /// The x1 attribute is used to specify the first x-coordinate for drawing an SVG element that 
+    /// requires more than one coordinate. Elements that only need one coordinate use the x attribute instead.
+    ///
+    /// Two elements are using this attribute: <line>, and <linearGradient>
+    static member inline x1 (value: ICssUnit) = Interop.mkAttr "x1" value
+    /// The x1 attribute is used to specify the first x-coordinate for drawing an SVG element that 
+    /// requires more than one coordinate. Elements that only need one coordinate use the x attribute instead.
+    ///
+    /// Two elements are using this attribute: <line>, and <linearGradient>
+    static member inline x1 (value: int) = Interop.mkAttr "x1" value
+
+    /// The x2 attribute is used to specify the second x-coordinate for drawing an SVG element that requires 
+    /// more than one coordinate. Elements that only need one coordinate use the x attribute instead.
+    ///
+    /// Two elements are using this attribute: <line>, and <linearGradient>
+    static member inline x2 (value: float) = Interop.mkAttr "x2" value
+    /// The x2 attribute is used to specify the second x-coordinate for drawing an SVG element that requires 
+    /// more than one coordinate. Elements that only need one coordinate use the x attribute instead.
+    ///
+    /// Two elements are using this attribute: <line>, and <linearGradient>
+    static member inline x2 (value: ICssUnit) = Interop.mkAttr "x2" value
+    /// The x2 attribute is used to specify the second x-coordinate for drawing an SVG element that requires 
+    /// more than one coordinate. Elements that only need one coordinate use the x attribute instead.
+    ///
+    /// Two elements are using this attribute: <line>, and <linearGradient>
+    static member inline x2 (value: int) = Interop.mkAttr "x2" value
+    
+    /// Specifies the XML Namespace of the document. 
+    ///
+    /// Default value is "http://www.w3.org/1999/xhtml". 
+    /// 
+    /// This is required in documents parsed with XML parsers, and optional in text/html documents.
+    static member inline xmlns (value: string) = Interop.mkAttr "xmlns" value
+
+    /// SVG attribute to define a y-axis coordinate in the user coordinate system.
+    static member inline y (value: float) = Interop.mkAttr "y" value
+    /// SVG attribute to define a y-axis coordinate in the user coordinate system.
+    static member inline y (value: ICssUnit) = Interop.mkAttr "y" value
+    /// SVG attribute to define a y-axis coordinate in the user coordinate system.
+    static member inline y (value: int) = Interop.mkAttr "y" value
+
+    /// The y1 attribute is used to specify the first y-coordinate for drawing an SVG element that requires 
+    /// more than one coordinate. Elements that only need one coordinate use the y attribute instead.
+    ///
+    /// Two elements are using this attribute: <line>, and <linearGradient>
+    static member inline y1 (value: float) = Interop.mkAttr "y1" value
+    /// The y1 attribute is used to specify the first y-coordinate for drawing an SVG element that requires 
+    /// more than one coordinate. Elements that only need one coordinate use the y attribute instead.
+    ///
+    /// Two elements are using this attribute: <line>, and <linearGradient>
+    static member inline y1 (value: ICssUnit) = Interop.mkAttr "y1" value
+    /// The y1 attribute is used to specify the first y-coordinate for drawing an SVG element that requires 
+    /// more than one coordinate. Elements that only need one coordinate use the y attribute instead.
+    ///
+    /// Two elements are using this attribute: <line>, and <linearGradient>
+    static member inline y1 (value: int) = Interop.mkAttr "y1" value
+
+    /// The y2 attribute is used to specify the second y-coordinate for drawing an SVG element that requires 
+    /// more than one coordinate. Elements that only need one coordinate use the y attribute instead.
+    ///
+    /// Two elements are using this attribute: <line>, and <linearGradient>
+    static member inline y2 (value: float) = Interop.mkAttr "y2" value
+    /// The y2 attribute is used to specify the second y-coordinate for drawing an SVG element that requires 
+    /// more than one coordinate. Elements that only need one coordinate use the y attribute instead.
+    ///
+    /// Two elements are using this attribute: <line>, and <linearGradient>
+    static member inline y2 (value: ICssUnit) = Interop.mkAttr "y2" value
+    /// The y2 attribute is used to specify the second y-coordinate for drawing an SVG element that requires 
+    /// more than one coordinate. Elements that only need one coordinate use the y attribute instead.
+    ///
+    /// Two elements are using this attribute: <line>, and <linearGradient>
+    static member inline y2 (value: int) = Interop.mkAttr "y2" value
+
+module prop =
+    /// Indicates whether user input completion suggestions are provided.
+    ///
+    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-autocomplete
     [<Erase>]
-    type role =
-        /// A message with important, and usually time-sensitive, information.
-        /// See related `alertdialog` and `status`.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#alert
-        static member inline alert = Interop.mkAttr "role" "alert"
-        /// A type of dialog that contains an alert message, where initial focus
-        /// goes to an element within the dialog. See related `alert` and
-        /// `dialog`.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#alertdialog
-        static member inline alertDialog = Interop.mkAttr "role" "alertdialog"
-        /// An input that allows for user-triggered actions when clicked or
-        /// pressed. See related `link`.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#button
-        static member inline button = Interop.mkAttr "role" "button"
-        /// A checkable input that has three possible values: `true`, `false`,
-        /// or `mixed`.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#checkbox
-        static member inline checkbox = Interop.mkAttr "role" "checkbox"
-        /// A dialog is an application window that is designed to interrupt the
-        /// current processing of an application in order to prompt the user to
-        /// enter information or require a response. See related `alertdialog`.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#dialog
-        static member inline dialog = Interop.mkAttr "role" "dialog"
-        /// A cell in a grid or treegrid.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#gridcell
-        static member inline gridCell = Interop.mkAttr "role" "gridcell"
-        /// An interactive reference to an internal or external resource that,
-        /// when activated, causes the user agent to navigate to that resource.
-        /// See related `button`.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#link
-        static member inline link = Interop.mkAttr "role" "link"
-        /// A type of live region where new information is added in meaningful
-        /// order and old information may disappear. See related `marquee`.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#log
-        static member inline log = Interop.mkAttr "role" "log"
-        /// A type of live region where non-essential information changes
-        /// frequently. See related `log`.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#marquee
-        static member inline marquee = Interop.mkAttr "role" "marquee"
-        /// An option in a set of choices contained by a `menu` or `menubar`.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#menuitem
-        static member inline menuItem = Interop.mkAttr "role" "menuitem"
-        /// A `menuitem` with a checkable state whose possible values are
-        /// `true`, `false`, or `mixed`.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#menuitemcheckbox
-        static member inline menuItemCheckbox = Interop.mkAttr "role" "menuitemcheckbox"
-        /// A checkable menuitem in a set of elements with role `menuitemradio`,
-        /// only one of which can be checked at a time.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#menuitemradio
-        static member inline menuItemRadio = Interop.mkAttr "role" "menuitemradio"
-        /// A selectable item in a `select` list.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#option
-        static member inline option = Interop.mkAttr "role" "option"
-        /// An element that displays the progress status for tasks that take a
-        /// long time.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#progressbar
-        static member inline progressBar = Interop.mkAttr "role" "progressbar"
-        /// A checkable input in a group of elements with role radio, only one
-        /// of which can be checked at a time.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#radio
-        static member inline radio = Interop.mkAttr "role" "radio"
-        /// A graphical object that controls the scrolling of content within a
-        /// viewing area, regardless of whether the content is fully displayed
-        /// within the viewing area.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#scrollbar
-        static member inline scrollBar = Interop.mkAttr "role" "scrollbar"
-        /// A user input where the user selects a value from within a given
-        /// range.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#slider
-        static member inline slider = Interop.mkAttr "role" "slider"
-        /// A form of `range` that expects the user to select from among
-        /// discrete choices.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#spinbutton
-        static member inline spinButton = Interop.mkAttr "role" "spinbutton"
-        /// A container whose content is advisory information for the user but
-        /// is not important enough to justify an alert, often but not
-        /// necessarily presented as a status bar. See related `alert`.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#status
-        static member inline status = Interop.mkAttr "role" "status"
-        /// A grouping label providing a mechanism for selecting the tab content
-        /// that is to be rendered to the user.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#tab
-        static member inline tab = Interop.mkAttr "role" "tab"
-        /// A container for the resources associated with a `tab`, where each
-        /// `tab` is contained in a `tablist`.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#tabpanel
-        static member inline tabPanel = Interop.mkAttr "role" "tabpanel"
-        /// Input that allows free-form text as its value.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#textbox
-        static member inline textBox = Interop.mkAttr "role" "textbox"
-        /// A type of live region containing a numerical counter which indicates
-        /// an amount of elapsed time from a start point, or the time remaining
-        /// until an end point.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#timer
-        static member inline timer = Interop.mkAttr "role" "timer"
-        /// A contextual popup that displays a description for an element.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#tooltip
-        static member inline tooltip = Interop.mkAttr "role" "tooltip"
-        /// An option item of a `tree`. This is an element within a tree that
-        /// may be expanded or collapsed if it contains a sub-level group of
-        /// `treeitem` elements.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#treeitem
-        static member inline treeItem = Interop.mkAttr "role" "treeitem"
-        /// A presentation of a `select`; usually similar to a `textbox` where
-        /// users can type ahead to select an option, or type to enter arbitrary
-        /// text as a new item in the list. See related `listbox`.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#combobox
-        static member inline comboBox = Interop.mkAttr "role" "combobox"
-        /// A grid is an interactive control which contains cells of tabular
-        /// data arranged in rows and columns, like a table.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#grid
-        static member inline grid = Interop.mkAttr "role" "grid"
-        /// A widget that allows the user to select one or more items from a
-        /// list of choices. See related `combobox` and `list`.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#listbox
-        static member inline listBox = Interop.mkAttr "role" "listbox"
-        /// A type of widget that offers a list of choices to the user.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#menu
-        static member inline menu = Interop.mkAttr "role" "menu"
-        /// A presentation of `menu` that usually remains visible and is usually
-        /// presented horizontally.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#menubar
-        static member inline menuBar = Interop.mkAttr "role" "menubar"
-        /// A group of radio buttons.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#radiogroup
-        static member inline radioGroup = Interop.mkAttr "role" "radiogroup"
-        /// A list of `tab` elements, which are references to `tabpanel`
-        /// elements.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#tablist
-        static member inline tabList = Interop.mkAttr "role" "tablist"
-        /// A type of `list` that may contain sub-level nested groups that can
-        /// be collapsed and expanded.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#tree
-        static member inline tree = Interop.mkAttr "role" "tree"
-        /// A `grid` whose rows can be expanded and collapsed in the same manner
-        /// as for a `tree`.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#treegrid
-        static member inline treeGrid = Interop.mkAttr "role" "treegrid"
-        /// A section of a page that consists of a composition that forms an
-        /// independent part of a document, page, or site.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#article
-        static member inline article = Interop.mkAttr "role" "article"
-        /// A cell containing header information for a column.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#columnheader
-        static member inline columnHeader = Interop.mkAttr "role" "columnheader"
-        /// A definition of a term or concept.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#definition
-        static member inline definition = Interop.mkAttr "role" "definition"
-        /// A list of references to members of a group, such as a static table
-        /// of contents.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#directory
-        static member inline directory = Interop.mkAttr "role" "directory"
-        /// A region containing related information that is declared as document
-        /// content, as opposed to a web application.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#document
-        static member inline document = Interop.mkAttr "role" "document"
-        /// A set of user interface objects which are not intended to be
-        /// included in a page summary or table of contents by assistive
-        /// technologies.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#group
-        static member inline group = Interop.mkAttr "role" "group"
-        /// A heading for a section of the page.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#heading
-        static member inline heading = Interop.mkAttr "role" "heading"
-        /// A container for a collection of elements that form an image.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#img
-        static member inline img = Interop.mkAttr "role" "img"
-        /// A group of non-interactive list items. See related `listbox`.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#list
-        static member inline list = Interop.mkAttr "role" "list"
-        /// A single item in a list or directory.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#listitem
-        static member inline listItem = Interop.mkAttr "role" "listitem"
-        /// Content that represents a mathematical expression.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#math
-        static member inline math = Interop.mkAttr "role" "math"
-        /// A section whose content is parenthetic or ancillary to the main
-        /// content of the resource.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#note
-        static member inline note = Interop.mkAttr "role" "note"
-        /// An element whose implicit native role semantics will not be mapped
-        /// to the accessibility API.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#presentation
-        static member inline presentation = Interop.mkAttr "role" "presentation"
-        /// A large perceivable section of a web page or document, that is
-        /// important enough to be included in a page summary or table of
-        /// contents, for example, an area of the page containing live sporting
-        /// event statistics.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#region
-        static member inline region = Interop.mkAttr "role" "region"
-        /// A row of cells in a grid.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#row
-        static member inline row = Interop.mkAttr "role" "row"
-        /// A group containing one or more row elements in a grid.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#rowgroup
-        static member inline rowGroup = Interop.mkAttr "role" "rowgroup"
-        /// A cell containing header information for a row in a grid.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#rowheader
-        static member inline rowHeader = Interop.mkAttr "role" "rowheader"
-        /// A divider that separates and distinguishes sections of content or
-        /// groups of menuitems.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#separator
-        static member inline separator = Interop.mkAttr "role" "separator"
-        /// A collection of commonly used function buttons or controls
-        /// represented in compact visual form.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#toolbar
-        static member inline toolbar = Interop.mkAttr "role" "toolbar"
-        /// A region declared as a web application, as opposed to a web
-        /// `document`.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#application
-        static member inline application = Interop.mkAttr "role" "application"
-        /// A region that contains mostly site-oriented content, rather than
-        /// page-specific content.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#banner
-        static member inline banner = Interop.mkAttr "role" "banner"
-        /// A supporting section of the document, designed to be complementary
-        /// to the main content at a similar level in the DOM hierarchy, but
-        /// remains meaningful when separated from the main content.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#complementary
-        static member inline complementary = Interop.mkAttr "role" "complementary"
-        /// A large perceivable region that contains information about the
-        /// parent document.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#contentinfo
-        static member inline contentInfo = Interop.mkAttr "role" "contentinfo"
-        /// A `landmark` region that contains a collection of items and objects
-        /// that, as a whole, combine to create a form. See related search.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#form
-        static member inline form = Interop.mkAttr "role" "form"
-        /// The main content of a document.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#main
-        static member inline main = Interop.mkAttr "role" "main"
-        /// A collection of navigational elements (usually links) for navigating
-        /// the document or related documents.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#navigation
-        static member inline navigation = Interop.mkAttr "role" "navigation"
-        /// A `landmark` region that contains a collection of items and objects
-        /// that, as a whole, combine to create a search facility. See related
-        /// `form`.
-        ///
-        /// https://www.w3.org/WAI/PF/aria-1.1/roles#search
-        static member inline search = Interop.mkAttr "role" "search"
+    type ariaAutocomplete =
+        /// A list of choices appears and the currently selected suggestion also
+        /// appears inline.
+        static member inline both = Interop.mkAttr "aria-autocomplete" "both"
+        /// The system provides text after the caret as a suggestion for how to
+        /// complete the field.
+        static member inline inlinedAfterCaret = Interop.mkAttr "aria-autocomplete" "inline"
+        /// A list of choices appears from which the user can choose.
+        static member inline list = Interop.mkAttr "aria-autocomplete" "list"
+        /// No input completion suggestions are provided.
+        static member inline none = Interop.mkAttr "aria-autocomplete" "none"
 
+    /// Indicates the current "checked" state of checkboxes, radio buttons, and
+    /// other widgets. See related `aria-pressed` and `aria-selected`.
+    ///
+    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-checked
     [<Erase>]
-    type target =
-        /// Opens the linked document in a new window or tab.
-        static member inline blank = Interop.mkAttr "target" "_blank"
-        /// Opens the linked document in the same frame as it was clicked (this is default).
-        static member inline self = Interop.mkAttr "target" "_self"
-        /// Opens the linked document in the parent frame.
-        static member inline parent = Interop.mkAttr "target" "_parent"
-        /// Opens the linked document in the full body of the window.
-        static member inline top = Interop.mkAttr "target" "_top"
-
-    [<Erase>]
-    type transform =
-        /// Defines that there should be no transformation.
-        static member inline none = Interop.mkAttr "transform" "none"
-        /// Defines a 2D transformation, using a matrix of six values.
-        static member inline matrix(x1: int, y1: int, z1: int, x2: int, y2: int, z2: int) =
-            Interop.mkAttr "transform" (
-                "matrix(" +
-                (unbox<string> x1) + "," +
-                (unbox<string> y1) + "," +
-                (unbox<string> z1) + "," +
-                (unbox<string> x2) + "," +
-                (unbox<string> y2) + "," +
-                (unbox<string> z2) + ")"
-            )
-
-        /// Defines a 2D translation.
-        static member inline translate(x: int, y: int) =
-            Interop.mkAttr "transform" (
-                "translate(" + (unbox<string> x) + "," + (unbox<string> y) + ")"
-            )
-
-        static member inline translate(x: float, y: float) =
-            Interop.mkAttr "transform" (
-                "translate(" + (unbox<string> x) + "," + (unbox<string> y) + ")"
-            )
-        /// Defines that there should be no transformation.
-        static member inline translate3D(x: int, y: int, z: int) =
-            Interop.mkAttr "transform" (
-                "translate3d(" + (unbox<string> x) + "," + (unbox<string> y) + "," + (unbox<string> z) + ")"
-            )
-
-        /// Defines a translation, using only the value for the X-axis.
-        static member inline translateX(x: int) =
-            Interop.mkAttr "transform" ("translateX(" + (unbox<string> x) + ")")
-        /// Defines a translation, using only the value for the Y-axis
-        static member inline translateY(y: int) =
-            Interop.mkAttr "transform" ("translateY(" + (unbox<string> y) + ")")
-        /// Defines a 3D translation, using only the value for the Z-axis
-        static member inline translateZ(z: int) =
-            Interop.mkAttr "transform" ("translateZ(" + (unbox<string> z) + ")")
-
-        /// Defines a 2D scale transformation.
-        static member inline scale(x: int, y: int) =
-            Interop.mkAttr "transform" (
-                "scale(" + (unbox<string> x) + "," + (unbox<string> y) + ")"
-            )
-
-        /// Defines a 3D scale transformation
-        static member inline scale3D(x: int, y: int, z: int) =
-            Interop.mkAttr "transform" (
-                "scale3d(" + (unbox<string> x) + "," + (unbox<string> y) + "," + (unbox<string> z) + ")"
-            )
-
-        /// Defines a scale transformation by giving a value for the X-axis.
-        static member inline scaleX(x: int) =
-            Interop.mkAttr "transform" ("scaleX(" + (unbox<string> x) + ")")
-
-        /// Defines a scale transformation by giving a value for the Y-axis.
-        static member inline scaleY(y: int) =
-            Interop.mkAttr "transform" ("scaleY(" + (unbox<string> y) + ")")
-        /// Defines a 3D translation, using only the value for the Z-axis
-        static member inline scaleZ(z: int) =
-            Interop.mkAttr "transform" ("scaleZ(" + (unbox<string> z) + ")")
-        /// Defines a 2D rotation, the angle is specified in the parameter.
-        static member inline rotate(deg: int) =
-            Interop.mkAttr "transform" ("rotate(" + (unbox<string> deg) + "deg)")
-        /// Defines a 2D rotation, the angle is specified in the parameter.
-        static member inline rotate(deg: float) =
-            Interop.mkAttr "transform" ("rotate(" + (unbox<string> deg) + "deg)")
-        /// Defines a 3D rotation along the X-axis.
-        static member inline rotateX(deg: float) =
-            Interop.mkAttr "transform" ("rotateX(" + (unbox<string> deg) + "deg)")
-        /// Defines a 3D rotation along the X-axis.
-        static member inline rotateX(deg: int) =
-            Interop.mkAttr "transform" ("rotateX(" + (unbox<string> deg) + "deg)")
-        /// Defines a 3D rotation along the Y-axis
-        static member inline rotateY(deg: float) =
-            Interop.mkAttr "transform" ("rotateY(" + (unbox<string> deg) + "deg)")
-        /// Defines a 3D rotation along the Y-axis
-        static member inline rotateY(deg: int) =
-            Interop.mkAttr "transform" ("rotateY(" + (unbox<string> deg) + "deg)")
-        /// Defines a 3D rotation along the Z-axis
-        static member inline rotateZ(deg: float) =
-            Interop.mkAttr "transform" ("rotateZ(" + (unbox<string> deg) + "deg)")
-        /// Defines a 3D rotation along the Z-axis
-        static member inline rotateZ(deg: int) =
-            Interop.mkAttr "transform" ("rotateZ(" + (unbox<string> deg) + "deg)")
-        /// Defines a 2D skew transformation along the X- and the Y-axis.
-        static member inline skew(xAngle: int, yAngle: int) =
-            Interop.mkAttr "transform" ("skew(" + (unbox<string> xAngle) + "deg," + (unbox<string> yAngle) + "deg)")
-        /// Defines a 2D skew transformation along the X- and the Y-axis.
-        static member inline skew(xAngle: float, yAngle: float) =
-            Interop.mkAttr "transform" ("skew(" + (unbox<string> xAngle) + "deg," + (unbox<string> yAngle) + "deg)")
-        /// Defines a 2D skew transformation along the X-axis
-        static member inline skewX(xAngle: int) =
-            Interop.mkAttr "transform" ("skewX(" + (unbox<string> xAngle) + "deg)")
-        /// Defines a 2D skew transformation along the X-axis
-        static member inline skewX(xAngle: float) =
-            Interop.mkAttr "transform" ("skewX(" + (unbox<string> xAngle) + "deg)")
-        /// Defines a 2D skew transformation along the Y-axis
-        static member inline skewY(xAngle: int) =
-            Interop.mkAttr "transform" ("skewY(" + (unbox<string> xAngle) + "deg)")
-        /// Defines a 2D skew transformation along the Y-axis
-        static member inline skewY(xAngle: float) =
-            Interop.mkAttr "transform" ("skewY(" + (unbox<string> xAngle) + "deg)")
-        /// Defines a perspective view for a 3D transformed element
-        static member inline perspective(n: int) =
-            Interop.mkAttr "transform" ("perspective(" + (unbox<string> n) + ")")
+    type ariaChecked =
+        /// Indicates a mixed mode value for a tri-state checkbox or
+        /// `menuitemcheckbox`.
+        static member inline mixed = Interop.mkAttr "aria-checked" "mixed"
 
     /// Indicates what functions can be performed when the dragged object is
     /// released on the drop target. This allows assistive technologies to
@@ -1318,24 +1226,6 @@ module prop =
         /// A spelling error was detected.
         static member inline spelling = Interop.mkAttr "aria-invalid" "spelling"
 
-    /// Indicates what user agent change notifications (additions, removals,
-    /// etc.) assistive technologies will receive within a live region. See
-    /// related `aria-atomic`.
-    ///
-    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-relevant
-    [<Erase>]
-    type ariaRelevant =
-        /// Element nodes are added to the DOM within the live region.
-        static member inline additions = Interop.mkAttr "aria-relevant" "additions"
-        /// Equivalent to the combination of all values, "additions removals
-        /// text".
-        static member inline all = Interop.mkAttr "aria-relevant" "all"
-        /// Text or element nodes within the live region are removed from the
-        /// DOM.
-        static member inline removals = Interop.mkAttr "aria-relevant" "removals"
-        /// Text is added to any DOM descendant nodes of the live region.
-        static member inline text = Interop.mkAttr "aria-relevant" "text"
-
     /// Indicates that an element will be updated, and describes the types of
     /// updates the user agents, assistive technologies, and user can expect
     /// from the live region.
@@ -1353,32 +1243,6 @@ module prop =
         /// graceful opportunity, such as at the end of speaking the current
         /// sentence or when the user pauses typing.
         static member inline polite = Interop.mkAttr "aria-live" "polite"
-
-    /// Indicates whether user input completion suggestions are provided.
-    ///
-    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-autocomplete
-    [<Erase>]
-    type ariaAutocomplete =
-        /// A list of choices appears and the currently selected suggestion also
-        /// appears inline.
-        static member inline both = Interop.mkAttr "aria-autocomplete" "both"
-        /// The system provides text after the caret as a suggestion for how to
-        /// complete the field.
-        static member inline inlinedAfterCaret = Interop.mkAttr "aria-autocomplete" "inline"
-        /// A list of choices appears from which the user can choose.
-        static member inline list = Interop.mkAttr "aria-autocomplete" "list"
-        /// No input completion suggestions are provided.
-        static member inline none = Interop.mkAttr "aria-autocomplete" "none"
-
-    /// Indicates the current "checked" state of checkboxes, radio buttons, and
-    /// other widgets. See related `aria-pressed` and `aria-selected`.
-    ///
-    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-checked
-    [<Erase>]
-    type ariaChecked =
-        /// Indicates a mixed mode value for a tri-state checkbox or
-        /// `menuitemcheckbox`.
-        static member inline mixed = Interop.mkAttr "aria-checked" "mixed"
 
     /// Indicates whether the element and orientation is horizontal or vertical.
     ///
@@ -1399,6 +1263,24 @@ module prop =
         /// Indicates a mixed mode value for a tri-state toggle button.
         static member inline mixed = Interop.mkAttr "aria-pressed" "mixed"
 
+    /// Indicates what user agent change notifications (additions, removals,
+    /// etc.) assistive technologies will receive within a live region. See
+    /// related `aria-atomic`.
+    ///
+    /// https://www.w3.org/WAI/PF/aria-1.1/states_and_properties#aria-relevant
+    [<Erase>]
+    type ariaRelevant =
+        /// Element nodes are added to the DOM within the live region.
+        static member inline additions = Interop.mkAttr "aria-relevant" "additions"
+        /// Equivalent to the combination of all values, "additions removals
+        /// text".
+        static member inline all = Interop.mkAttr "aria-relevant" "all"
+        /// Text or element nodes within the live region are removed from the
+        /// DOM.
+        static member inline removals = Interop.mkAttr "aria-relevant" "removals"
+        /// Text is added to any DOM descendant nodes of the live region.
+        static member inline text = Interop.mkAttr "aria-relevant" "text"    
+
     /// Indicates if items in a table or grid are sorted in ascending or
     /// descending order.
     ///
@@ -1415,12 +1297,688 @@ module prop =
         /// applied.
         static member inline other = Interop.mkAttr "aria-sort" "other"
 
+    /// This attribute is only used when rel="preload" or rel="prefetch" has been set on the <link> element. 
+    /// It specifies the type of content being loaded by the <link>, which is necessary for request matching, 
+    /// application of correct content security policy, and setting of correct Accept request header. 
+    /// Furthermore, rel="preload" uses this as a signal for request prioritization.
+    [<Erase>]
+    type as' =
+        /// Applies to <audio> elements.
+        static member inline audio = Interop.mkAttr "as" "audio"
+        /// Applies to <iframe> and <frame> elements.
+        static member inline document = Interop.mkAttr "as" "document"
+        /// Applies to <embed> elements.
+        static member inline embed = Interop.mkAttr "as" "embed"
+        /// Applies to fetch and XHR.
+        ///
+        /// This value also requires <link> to contain the crossorigin attribute.
+        static member inline fetch = Interop.mkAttr "as" "fetch"
+        /// Applies to CSS @font-face.
+        static member inline font = Interop.mkAttr "as" "font"
+        /// Applies to <img> and <picture> elements with srcset or imageset attributes, 
+        /// SVG <image> elements, and CSS *-image rules.
+        static member inline image = Interop.mkAttr "as" "image"
+        /// Applies to <object> elements.
+        static member inline object = Interop.mkAttr "as" "object"
+        /// Applies to <script> elements, Worker importScripts.
+        static member inline script = Interop.mkAttr "as" "script"
+        /// Applies to <link rel=stylesheet> elements, and CSS @import.
+        static member inline style = Interop.mkAttr "as" "style"
+        /// Applies to <track> elements.
+        static member inline track = Interop.mkAttr "as" "track"
+        /// Applies to <video> elements.
+        static member inline video = Interop.mkAttr "as" "video"
+        /// Applies to Worker and SharedWorker.
+        static member inline worker = Interop.mkAttr "as" "worker"
+
+    /// A set of values specifying the coordinates of the hot-spot region. 
+    ///
+    /// The number and meaning of the values depend upon the value specified for the shape attribute
+    [<Erase>]
+    type coords =
+        static member inline rect (left: int, top: int, right: int, bottom: int) = 
+            Interop.mkAttr "coords" 
+                ((unbox<string> left) + "," +
+                 (unbox<string> top) + "," +
+                 (unbox<string> right) + "," +
+                 (unbox<string> bottom))
+        static member inline circle (x: int, y: int, r: int) =
+            Interop.mkAttr "coords" 
+                ((unbox<string> x) + "," +
+                 (unbox<string> y) + "," +
+                 (unbox<string> r))
+        static member inline poly (x1: int, y1: int, x2: int, y2: int, x3: int, y3: int) =
+            Interop.mkAttr "coords" 
+                ((unbox<string> x1) + "," +
+                 (unbox<string> y1) + "," +
+                 (unbox<string> x2) + "," +
+                 (unbox<string> y2) + "," +
+                 (unbox<string> x3) + "," +
+                 (unbox<string> y3))
+
+    /// Indicates whether CORS must be used when fetching the resource.
+    [<Erase>]
+    type crossOrigin =
+        /// A cross-origin request (i.e. with an Origin HTTP header) is performed, but no credential 
+        /// is sent (i.e. no cookie, X.509 certificate, or HTTP Basic authentication). If the server 
+        /// does not give credentials to the origin site (by not setting the Access-Control-Allow-Origin 
+        /// HTTP header) the resource will be tainted and its usage restricted.
+        static member inline anonymous = Interop.mkAttr "crossorigin" "anonymous"
+        /// A cross-origin request (i.e. with an Origin HTTP header) is performed along with a credential 
+        /// sent (i.e. a cookie, certificate, and/or HTTP Basic authentication is performed). If the server 
+        /// does not give credentials to the origin site (through Access-Control-Allow-Credentials HTTP 
+        /// header), the resource will be tainted and its usage restricted.
+        static member inline useCredentials = Interop.mkAttr "crossorigin" "use-credentials"
+
+    /// Indicates the directionality of the element's text.
+    [<Erase>]
+    type dir =
+        /// Lets the user agent decide.
+        static member inline auto = Interop.mkAttr "dir" "auto"
+        /// Left to right - for languages that are written from left to right.
+        static member inline ltr = Interop.mkAttr "dir" "ltr"
+        /// Right to left - for languages that are written from right to left.
+        static member inline rtl = Interop.mkAttr "dir" "rtl"
+    
+    /// The `dominantBaseline` attribute specifies the dominant baseline, which is the baseline used to align the box’s text
+    /// and inline-level contents. It also indicates the default alignment baseline of any boxes participating in baseline 
+    /// alignment in the box’s alignment context. It is used to determine or re-determine a scaled-baseline-table. A 
+    /// scaled-baseline-table is a compound value with three components: a baseline-identifier for the dominant-baseline, a 
+    /// baseline-table and a baseline-table font-size. Some values of the property re-determine all three values; other only 
+    /// re-establish the baseline-table font-size. When the initial value, auto, would give an undesired result, this property 
+    /// can be used to explicitly set the desired scaled-baseline-table.
+    /// If there is no baseline table in the nominal font or if the baseline table lacks an entry for the desired baseline, 
+    /// then the browser may use heuristics to determine the position of the desired baseline.
+    [<Erase>]
+    type dominantBaseline =
+        /// The baseline-identifier for the dominant-baseline is set to be alphabetic, the derived baseline-table is constructed 
+        /// using the alphabetic baseline-table in the font, and the baseline-table font-size is changed to the value of the 
+        /// font-size attribute on this element.
+        static member inline alphabetic = Interop.mkAttr "dominantBaseline" "alphabetic"
+        /// If this property occurs on a <text> element, then the computed value depends on the value of the writing-mode attribute.
+        ///
+        /// If the writing-mode is horizontal, then the value of the dominant-baseline component is alphabetic, else if the writing-mode 
+        /// is vertical, then the value of the dominant-baseline component is central. 
+        ///
+        /// If this property occurs on a <tspan>, <tref>, 
+        /// <altGlyph> or <textPath> element, then the dominant-baseline and the baseline-table components remain the same as those of 
+        /// the parent text content element. 
+        ///
+        /// If the computed baseline-shift value actually shifts the baseline, then the baseline-table 
+        /// font-size component is set to the value of the font-size attribute on the element on which the dominant-baseline attribute 
+        /// occurs, otherwise the baseline-table font-size remains the same as that of the element. 
+        ///
+        /// If there is no parent text content 
+        /// element, the scaled-baseline-table value is constructed as above for <text> elements.
+        static member inline auto = Interop.mkAttr "dominantBaseline" "auto"
+        /// The baseline-identifier for the dominant-baseline is set to be central. The derived baseline-table is constructed from the 
+        /// defined baselines in a baseline-table in the font. That font baseline-table is chosen using the following priority order of 
+        /// baseline-table names: ideographic, alphabetic, hanging, mathematical. The baseline-table font-size is changed to the value 
+        /// of the font-size attribute on this element.
+        static member inline central = Interop.mkAttr "dominantBaseline" "central"
+        /// The baseline-identifier for the dominant-baseline is set to be hanging, the derived baseline-table is constructed using the 
+        /// hanging baseline-table in the font, and the baseline-table font-size is changed to the value of the font-size attribute on 
+        /// this element.
+        static member inline hanging = Interop.mkAttr "dominantBaseline" "hanging"
+        /// The baseline-identifier for the dominant-baseline is set to be ideographic, the derived baseline-table is constructed using 
+        /// the ideographic baseline-table in the font, and the baseline-table font-size is changed to the value of the font-size 
+        /// attribute on this element.
+        static member inline ideographic = Interop.mkAttr "dominantBaseline" "ideographic"
+        /// The baseline-identifier for the dominant-baseline is set to be mathematical, the derived baseline-table is constructed using 
+        /// the mathematical baseline-table in the font, and the baseline-table font-size is changed to the value of the font-size 
+        /// attribute on this element.
+        static member inline mathematical = Interop.mkAttr "dominantBaseline" "mathematical"
+        /// The baseline-identifier for the dominant-baseline is set to be middle. The derived baseline-table is constructed from the 
+        /// defined baselines in a baseline-table in the font. That font baseline-table is chosen using the following priority order 
+        /// of baseline-table names: alphabetic, ideographic, hanging, mathematical. The baseline-table font-size is changed to the value 
+        /// of the font-size attribute on this element.
+        static member inline middle = Interop.mkAttr "dominantBaseline" "middle"
+        /// The baseline-identifier for the dominant-baseline is set to be text-after-edge. The derived baseline-table is constructed 
+        /// from the defined baselines in a baseline-table in the font. The choice of which font baseline-table to use from the 
+        /// baseline-tables in the font is browser dependent. The baseline-table font-size is changed to the value of the font-size 
+        /// attribute on this element.
+        static member inline textAfterEdge = Interop.mkAttr "dominantBaseline" "text-after-edge"
+        /// The baseline-identifier for the dominant-baseline is set to be text-before-edge. The derived baseline-table is constructed 
+        /// from the defined baselines in a baseline-table in the font. The choice of which baseline-table to use from the baseline-tables 
+        /// in the font is browser dependent. The baseline-table font-size is changed to the value of the font-size attribute on this element.
+        static member inline textBeforeEdge = Interop.mkAttr "dominantBaseline" "text-before-edge"
+        /// This value uses the top of the em box as the baseline.
+        static member inline textTop = Interop.mkAttr "dominantBaseline" "text-top"
+
+    /// How the text track is meant to be used.
+    [<Erase>]
+    type kind =
+        /// Subtitles provide translation of content that cannot be understood by the viewer. For example dialogue 
+        /// or text that is not English in an English language film.
+        ///
+        /// Subtitles may contain additional content, usually extra background information. For example the text 
+        /// at the beginning of the Star Wars films, or the date, time, and location of a scene.
+        static member inline subtitles = Interop.mkAttr "kind" "subtitles"
+        /// Closed captions provide a transcription and possibly a translation of audio.
+        ///
+        /// It may include important non-verbal information such as music cues or sound effects. 
+        /// It may indicate the cue's source (e.g. music, text, character).
+        ///
+        /// Suitable for users who are deaf or when the sound is muted.
+        static member inline captions = Interop.mkAttr "kind" "captions"
+        /// Textual description of the video content.
+        ///
+        /// Suitable for users who are blind or where the video cannot be seen.
+        static member inline descriptions = Interop.mkAttr "kind" "descriptions"
+        /// Chapter titles are intended to be used when the user is navigating the media resource.
+        static member inline chapters = Interop.mkAttr "kind" "chapters"
+        /// Tracks used by scripts. Not visible to the user.
+        static member inline metadata = Interop.mkAttr "kind" "metadata"
+
+    /// Provide a hint to the browser about what the author thinks will lead to the best user experience with regards 
+    /// to what content is loaded before the video is played.
+    [<Erase>]
+    type preload =
+        /// Indicates that the whole video file can be downloaded, even if the user is not expected to use it.
+        static member inline auto = Interop.mkAttr "preload" "auto"
+        /// Indicates that only video metadata (e.g. length) is fetched.
+        static member inline metadata = Interop.mkAttr "preload" "metadata"
+        /// Indicates that the video should not be preloaded.
+        static member inline none = Interop.mkAttr "preload" "none"
+
+    /// Indicates which referrer to send when fetching the script, or resources fetched by the script
+    [<Erase>]
+    type referrerPolicy =
+        /// The Referer header will not be sent.
+        static member inline noReferrer = Interop.mkAttr "referrerpolicy" "no-referrer"
+        /// The Referer header will not be sent to origins without TLS (HTTPS).
+        static member inline noReferrerWhenDowngrade = Interop.mkAttr "referrerpolicy" "no-referrer-when-downgrade"
+        /// The sent referrer will be limited to the origin of the referring page: its scheme, host, and port.
+        static member inline origin = Interop.mkAttr "referrerpolicy" "origin"
+        /// The referrer sent to other origins will be limited to the scheme, the host, and the port. 
+        /// Navigations on the same origin will still include the path.
+        static member inline originWhenCrossOrigin = Interop.mkAttr "referrerpolicy" "origin-when-cross-origin"
+        /// A referrer will be sent for same origin, but cross-origin requests will contain no referrer information.
+        static member inline sameOrigin = Interop.mkAttr "referrerpolicy" "same-origin"
+        /// Only send the origin of the document as the referrer when the protocol security level stays the same 
+        /// (e.g. HTTPS→HTTPS), but don't send it to a less secure destination (e.g. HTTPS→HTTP).
+        static member inline strictOrigin = Interop.mkAttr "referrerpolicy" "strict-origin"
+        /// Send a full URL when performing a same-origin request, but only send the origin when the protocol security 
+        /// level stays the same (e.g.HTTPS→HTTPS), and send no header to a less secure destination (e.g. HTTPS→HTTP).
+        static member inline strictOriginWhenCrossOrigin = Interop.mkAttr "referrerpolicy" "strict-origin-when-cross-origin"
+        /// The referrer will include the origin and the path (but not the fragment, password, or username). This value is unsafe, 
+        /// because it leaks origins and paths from TLS-protected resources to insecure origins.
+        static member inline unsafeUrl = Interop.mkAttr "referrerpolicy" "unsafe-url"
+
+    /// https://www.w3.org/WAI/PF/aria-1.1/roles
+    [<Erase>]
+    type role =
+        /// A message with important, and usually time-sensitive, information.
+        /// See related `alertdialog` and `status`.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#alert
+        static member inline alert = Interop.mkAttr "role" "alert"
+        /// A type of dialog that contains an alert message, where initial focus
+        /// goes to an element within the dialog. See related `alert` and
+        /// `dialog`.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#alertdialog
+        static member inline alertDialog = Interop.mkAttr "role" "alertdialog"
+        /// A region declared as a web application, as opposed to a web
+        /// `document`.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#application
+        static member inline application = Interop.mkAttr "role" "application"
+        /// A section of a page that consists of a composition that forms an
+        /// independent part of a document, page, or site.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#article
+        static member inline article = Interop.mkAttr "role" "article"
+        /// A region that contains mostly site-oriented content, rather than
+        /// page-specific content.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#banner
+        static member inline banner = Interop.mkAttr "role" "banner"
+        /// An input that allows for user-triggered actions when clicked or
+        /// pressed. See related `link`.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#button
+        static member inline button = Interop.mkAttr "role" "button"
+        /// A checkable input that has three possible values: `true`, `false`,
+        /// or `mixed`.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#checkbox
+        static member inline checkbox = Interop.mkAttr "role" "checkbox"
+        /// A cell containing header information for a column.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#columnheader
+        static member inline columnHeader = Interop.mkAttr "role" "columnheader"
+        /// A presentation of a `select`; usually similar to a `textbox` where
+        /// users can type ahead to select an option, or type to enter arbitrary
+        /// text as a new item in the list. See related `listbox`.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#combobox
+        static member inline comboBox = Interop.mkAttr "role" "combobox"
+        /// A supporting section of the document, designed to be complementary
+        /// to the main content at a similar level in the DOM hierarchy, but
+        /// remains meaningful when separated from the main content.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#complementary
+        static member inline complementary = Interop.mkAttr "role" "complementary"
+        /// A large perceivable region that contains information about the
+        /// parent document.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#contentinfo
+        static member inline contentInfo = Interop.mkAttr "role" "contentinfo"
+        /// A definition of a term or concept.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#definition
+        static member inline definition = Interop.mkAttr "role" "definition"
+        /// A dialog is an application window that is designed to interrupt the
+        /// current processing of an application in order to prompt the user to
+        /// enter information or require a response. See related `alertdialog`.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#dialog
+        static member inline dialog = Interop.mkAttr "role" "dialog"
+        /// A list of references to members of a group, such as a static table
+        /// of contents.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#directory
+        static member inline directory = Interop.mkAttr "role" "directory"
+        /// A region containing related information that is declared as document
+        /// content, as opposed to a web application.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#document
+        static member inline document = Interop.mkAttr "role" "document"
+        /// A `landmark` region that contains a collection of items and objects
+        /// that, as a whole, combine to create a form. See related search.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#form
+        static member inline form = Interop.mkAttr "role" "form"
+        /// A grid is an interactive control which contains cells of tabular
+        /// data arranged in rows and columns, like a table.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#grid
+        static member inline grid = Interop.mkAttr "role" "grid"
+        /// A cell in a grid or treegrid.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#gridcell
+        static member inline gridCell = Interop.mkAttr "role" "gridcell"
+        /// A set of user interface objects which are not intended to be
+        /// included in a page summary or table of contents by assistive
+        /// technologies.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#group
+        static member inline group = Interop.mkAttr "role" "group"
+        /// A heading for a section of the page.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#heading
+        static member inline heading = Interop.mkAttr "role" "heading"
+        /// A container for a collection of elements that form an image.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#img
+        static member inline img = Interop.mkAttr "role" "img"
+        /// An interactive reference to an internal or external resource that,
+        /// when activated, causes the user agent to navigate to that resource.
+        /// See related `button`.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#link
+        static member inline link = Interop.mkAttr "role" "link"
+        /// A group of non-interactive list items. See related `listbox`.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#list
+        static member inline list = Interop.mkAttr "role" "list"
+        /// A widget that allows the user to select one or more items from a
+        /// list of choices. See related `combobox` and `list`.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#listbox
+        static member inline listBox = Interop.mkAttr "role" "listbox"
+        /// A single item in a list or directory.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#listitem
+        static member inline listItem = Interop.mkAttr "role" "listitem"
+        /// A type of live region where new information is added in meaningful
+        /// order and old information may disappear. See related `marquee`.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#log
+        static member inline log = Interop.mkAttr "role" "log"
+        /// The main content of a document.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#main
+        static member inline main = Interop.mkAttr "role" "main"
+        /// A type of live region where non-essential information changes
+        /// frequently. See related `log`.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#marquee
+        static member inline marquee = Interop.mkAttr "role" "marquee"
+        /// Content that represents a mathematical expression.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#math
+        static member inline math = Interop.mkAttr "role" "math"
+        /// A type of widget that offers a list of choices to the user.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#menu
+        static member inline menu = Interop.mkAttr "role" "menu"
+        /// A presentation of `menu` that usually remains visible and is usually
+        /// presented horizontally.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#menubar
+        static member inline menuBar = Interop.mkAttr "role" "menubar"
+        /// An option in a set of choices contained by a `menu` or `menubar`.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#menuitem
+        static member inline menuItem = Interop.mkAttr "role" "menuitem"
+        /// A `menuitem` with a checkable state whose possible values are
+        /// `true`, `false`, or `mixed`.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#menuitemcheckbox
+        static member inline menuItemCheckbox = Interop.mkAttr "role" "menuitemcheckbox"
+        /// A checkable menuitem in a set of elements with role `menuitemradio`,
+        /// only one of which can be checked at a time.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#menuitemradio
+        static member inline menuItemRadio = Interop.mkAttr "role" "menuitemradio"
+        /// A collection of navigational elements (usually links) for navigating
+        /// the document or related documents.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#navigation
+        static member inline navigation = Interop.mkAttr "role" "navigation"
+        /// A section whose content is parenthetic or ancillary to the main
+        /// content of the resource.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#note
+        static member inline note = Interop.mkAttr "role" "note"
+        /// A selectable item in a `select` list.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#option
+        static member inline option = Interop.mkAttr "role" "option"
+        /// An element whose implicit native role semantics will not be mapped
+        /// to the accessibility API.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#presentation
+        static member inline presentation = Interop.mkAttr "role" "presentation"
+        /// An element that displays the progress status for tasks that take a
+        /// long time.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#progressbar
+        static member inline progressBar = Interop.mkAttr "role" "progressbar"
+        /// A checkable input in a group of elements with role radio, only one
+        /// of which can be checked at a time.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#radio
+        static member inline radio = Interop.mkAttr "role" "radio"
+        /// A group of radio buttons.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#radiogroup
+        static member inline radioGroup = Interop.mkAttr "role" "radiogroup"
+        /// A large perceivable section of a web page or document, that is
+        /// important enough to be included in a page summary or table of
+        /// contents, for example, an area of the page containing live sporting
+        /// event statistics.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#region
+        static member inline region = Interop.mkAttr "role" "region"
+        /// A row of cells in a grid.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#row
+        static member inline row = Interop.mkAttr "role" "row"
+        /// A group containing one or more row elements in a grid.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#rowgroup
+        static member inline rowGroup = Interop.mkAttr "role" "rowgroup"
+        /// A cell containing header information for a row in a grid.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#rowheader
+        static member inline rowHeader = Interop.mkAttr "role" "rowheader"
+        /// A graphical object that controls the scrolling of content within a
+        /// viewing area, regardless of whether the content is fully displayed
+        /// within the viewing area.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#scrollbar
+        static member inline scrollBar = Interop.mkAttr "role" "scrollbar"
+        /// A divider that separates and distinguishes sections of content or
+        /// groups of menuitems.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#separator
+        static member inline separator = Interop.mkAttr "role" "separator"
+        /// A `landmark` region that contains a collection of items and objects
+        /// that, as a whole, combine to create a search facility. See related
+        /// `form`.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#search
+        static member inline search = Interop.mkAttr "role" "search"
+        /// A user input where the user selects a value from within a given
+        /// range.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#slider
+        static member inline slider = Interop.mkAttr "role" "slider"
+        /// A form of `range` that expects the user to select from among
+        /// discrete choices.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#spinbutton
+        static member inline spinButton = Interop.mkAttr "role" "spinbutton"
+        /// A container whose content is advisory information for the user but
+        /// is not important enough to justify an alert, often but not
+        /// necessarily presented as a status bar. See related `alert`.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#status
+        static member inline status = Interop.mkAttr "role" "status"
+        /// A grouping label providing a mechanism for selecting the tab content
+        /// that is to be rendered to the user.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#tab
+        static member inline tab = Interop.mkAttr "role" "tab"
+        /// A list of `tab` elements, which are references to `tabpanel`
+        /// elements.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#tablist
+        static member inline tabList = Interop.mkAttr "role" "tablist"
+        /// A container for the resources associated with a `tab`, where each
+        /// `tab` is contained in a `tablist`.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#tabpanel
+        static member inline tabPanel = Interop.mkAttr "role" "tabpanel"
+        /// Input that allows free-form text as its value.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#textbox
+        static member inline textBox = Interop.mkAttr "role" "textbox"
+        /// A type of live region containing a numerical counter which indicates
+        /// an amount of elapsed time from a start point, or the time remaining
+        /// until an end point.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#timer
+        static member inline timer = Interop.mkAttr "role" "timer"
+        /// A collection of commonly used function buttons or controls
+        /// represented in compact visual form.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#toolbar
+        static member inline toolbar = Interop.mkAttr "role" "toolbar"
+        /// A contextual popup that displays a description for an element.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#tooltip
+        static member inline tooltip = Interop.mkAttr "role" "tooltip"
+        /// A type of `list` that may contain sub-level nested groups that can
+        /// be collapsed and expanded.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#tree
+        static member inline tree = Interop.mkAttr "role" "tree"
+        /// A `grid` whose rows can be expanded and collapsed in the same manner
+        /// as for a `tree`.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#treegrid
+        static member inline treeGrid = Interop.mkAttr "role" "treegrid"
+        /// An option item of a `tree`. This is an element within a tree that
+        /// may be expanded or collapsed if it contains a sub-level group of
+        /// `treeitem` elements.
+        ///
+        /// https://www.w3.org/WAI/PF/aria-1.1/roles#treeitem
+        static member inline treeItem = Interop.mkAttr "role" "treeitem"        
+
+    /// The shape of the associated hot spot.
+    [<Erase>]
+    type shape =
+        static member inline rect = Interop.mkAttr "shape" "rect"
+        static member inline circle = Interop.mkAttr "shape" "circle"
+        static member inline poly = Interop.mkAttr "shape" "poly"
+
+    [<Erase>]
+    type target =
+        /// Opens the linked document in a new window or tab.
+        static member inline blank = Interop.mkAttr "target" "_blank"
+        /// Opens the linked document in the parent frame.
+        static member inline parent = Interop.mkAttr "target" "_parent"
+        /// Opens the linked document in the same frame as it was clicked (this is default).
+        static member inline self = Interop.mkAttr "target" "_self"
+        /// Opens the linked document in the full body of the window.
+        static member inline top = Interop.mkAttr "target" "_top"
+    
+    /// The `text-anchor` attribute is used to align (start-, middle- or
+    /// end-alignment) a string of pre-formatted text or auto-wrapped text where
+    /// the wrapping area is determined from the `inline-size` property relative
+    /// to a given point. It is not applicable to other types of auto-wrapped
+    /// text. For those cases you should use `text-align`. For multi-line text,
+    /// the alignment takes place for each line.
+    ///
+    /// The `text-anchor` attribute is applied to each individual text chunk
+    /// within a given `<text>` element. Each text chunk has an initial current
+    /// text position, which represents the point in the user coordinate system
+    /// resulting from (depending on context) application of the `x` and `y`
+    /// attributes on the `<text>` element, any `x` or `y` attribute values on a
+    /// `<tspan>`, `<tref>` or `<altGlyph>` element assigned explicitly to the
+    /// first rendered character in a text chunk, or determination of the
+    /// initial current text position for a `<textPath>` element.
+    [<Erase>]
+    type textAnchor =
+        /// The rendered characters are shifted such that the end of the
+        /// resulting rendered text (final current text position before applying
+        /// the `text-anchor` property) is at the initial current text position.
+        /// For an element with a `direction` property value of `ltr` (typical
+        /// for most European languages), the right side of the text is rendered
+        /// at the initial text position. For an element with a `direction`
+        /// property value of `rtl` (typical for Arabic and Hebrew), the left
+        /// side of the text is rendered at the initial text position. For an
+        /// element with a vertical primary text direction (often typical for
+        /// Asian text), the bottom of the text is rendered at the initial text
+        /// position.
+        static member inline endOfText = Interop.mkAttr "textAnchor" "end"
+        /// The rendered characters are aligned such that the middle of the text
+        /// string is at the current text position. (For text on a path,
+        /// conceptually the text string is first laid out in a straight line.
+        /// The midpoint between the start of the text string and the end of the
+        /// text string is determined. Then, the text string is mapped onto the
+        /// path with this midpoint placed at the current text position.)
+        static member inline middle = Interop.mkAttr "textAnchor" "middle"
+        /// The rendered characters are aligned such that the start of the text
+        /// string is at the initial current text position. For an element with
+        /// a `direction` property value of `ltr` (typical for most European
+        /// languages), the left side of the text is rendered at the initial
+        /// text position. For an element with a `direction` property value of
+        /// `rtl` (typical for Arabic and Hebrew), the right side of the text is
+        /// rendered at the initial text position. For an element with a
+        /// vertical primary text direction (often typical for Asian text), the
+        /// top side of the text is rendered at the initial text position.
+        static member inline startOfText = Interop.mkAttr "textAnchor" "start"
+
+    [<Erase>]
+    type transform =
+        /// Defines a 2D transformation, using a matrix of six values.
+        static member inline matrix(x1: int, y1: int, z1: int, x2: int, y2: int, z2: int) =
+            Interop.mkAttr "transform" (
+                "matrix(" +
+                (unbox<string> x1) + "," +
+                (unbox<string> y1) + "," +
+                (unbox<string> z1) + "," +
+                (unbox<string> x2) + "," +
+                (unbox<string> y2) + "," +
+                (unbox<string> z2) + ")"
+            )
+        /// Defines that there should be no transformation.
+        static member inline none = Interop.mkAttr "transform" "none"
+        /// Defines a perspective view for a 3D transformed element
+        static member inline perspective(n: int) =
+            Interop.mkAttr "transform" ("perspective(" + (unbox<string> n) + ")")
+        /// Defines a 2D rotation, the angle is specified in the parameter.
+        static member inline rotate(deg: int) =
+            Interop.mkAttr "transform" ("rotate(" + (unbox<string> deg) + "deg)")
+        /// Defines a 2D rotation, the angle is specified in the parameter.
+        static member inline rotate(deg: float) =
+            Interop.mkAttr "transform" ("rotate(" + (unbox<string> deg) + "deg)")
+        /// Defines a 3D rotation along the X-axis.
+        static member inline rotateX(deg: float) =
+            Interop.mkAttr "transform" ("rotateX(" + (unbox<string> deg) + "deg)")
+        /// Defines a 3D rotation along the X-axis.
+        static member inline rotateX(deg: int) =
+            Interop.mkAttr "transform" ("rotateX(" + (unbox<string> deg) + "deg)")
+        /// Defines a 3D rotation along the Y-axis
+        static member inline rotateY(deg: float) =
+            Interop.mkAttr "transform" ("rotateY(" + (unbox<string> deg) + "deg)")
+        /// Defines a 3D rotation along the Y-axis
+        static member inline rotateY(deg: int) =
+            Interop.mkAttr "transform" ("rotateY(" + (unbox<string> deg) + "deg)")
+        /// Defines a 3D rotation along the Z-axis
+        static member inline rotateZ(deg: float) =
+            Interop.mkAttr "transform" ("rotateZ(" + (unbox<string> deg) + "deg)")
+        /// Defines a 3D rotation along the Z-axis
+        static member inline rotateZ(deg: int) =
+            Interop.mkAttr "transform" ("rotateZ(" + (unbox<string> deg) + "deg)")
+        /// Defines a 2D scale transformation.
+        static member inline scale(x: int, y: int) =
+            Interop.mkAttr "transform" (
+                "scale(" + (unbox<string> x) + "," + (unbox<string> y) + ")"
+            )
+        /// Defines a 3D scale transformation
+        static member inline scale3D(x: int, y: int, z: int) =
+            Interop.mkAttr "transform" (
+                "scale3d(" + (unbox<string> x) + "," + (unbox<string> y) + "," + (unbox<string> z) + ")"
+            )
+        /// Defines a scale transformation by giving a value for the X-axis.
+        static member inline scaleX(x: int) =
+            Interop.mkAttr "transform" ("scaleX(" + (unbox<string> x) + ")")
+        /// Defines a scale transformation by giving a value for the Y-axis.
+        static member inline scaleY(y: int) =
+            Interop.mkAttr "transform" ("scaleY(" + (unbox<string> y) + ")")
+        /// Defines a 3D translation, using only the value for the Z-axis
+        static member inline scaleZ(z: int) =
+            Interop.mkAttr "transform" ("scaleZ(" + (unbox<string> z) + ")")
+        /// Defines a 2D skew transformation along the X- and the Y-axis.
+        static member inline skew(xAngle: int, yAngle: int) =
+            Interop.mkAttr "transform" ("skew(" + (unbox<string> xAngle) + "deg," + (unbox<string> yAngle) + "deg)")
+        /// Defines a 2D skew transformation along the X- and the Y-axis.
+        static member inline skew(xAngle: float, yAngle: float) =
+            Interop.mkAttr "transform" ("skew(" + (unbox<string> xAngle) + "deg," + (unbox<string> yAngle) + "deg)")
+        /// Defines a 2D skew transformation along the X-axis
+        static member inline skewX(xAngle: int) =
+            Interop.mkAttr "transform" ("skewX(" + (unbox<string> xAngle) + "deg)")
+        /// Defines a 2D skew transformation along the X-axis
+        static member inline skewX(xAngle: float) =
+            Interop.mkAttr "transform" ("skewX(" + (unbox<string> xAngle) + "deg)")
+        /// Defines a 2D skew transformation along the Y-axis
+        static member inline skewY(xAngle: int) =
+            Interop.mkAttr "transform" ("skewY(" + (unbox<string> xAngle) + "deg)")
+        /// Defines a 2D skew transformation along the Y-axis
+        static member inline skewY(xAngle: float) =
+            Interop.mkAttr "transform" ("skewY(" + (unbox<string> xAngle) + "deg)")
+        /// Defines a 2D translation.
+        static member inline translate(x: int, y: int) =
+            Interop.mkAttr "transform" (
+                "translate(" + (unbox<string> x) + "," + (unbox<string> y) + ")"
+            )
+        static member inline translate(x: float, y: float) =
+            Interop.mkAttr "transform" (
+                "translate(" + (unbox<string> x) + "," + (unbox<string> y) + ")"
+            )
+        /// Defines that there should be no transformation.
+        static member inline translate3D(x: int, y: int, z: int) =
+            Interop.mkAttr "transform" (
+                "translate3d(" + (unbox<string> x) + "," + (unbox<string> y) + "," + (unbox<string> z) + ")"
+            )
+        /// Defines a translation, using only the value for the X-axis.
+        static member inline translateX(x: int) =
+            Interop.mkAttr "transform" ("translateX(" + (unbox<string> x) + ")")
+        /// Defines a translation, using only the value for the Y-axis
+        static member inline translateY(y: int) =
+            Interop.mkAttr "transform" ("translateY(" + (unbox<string> y) + ")")
+        /// Defines a 3D translation, using only the value for the Z-axis
+        static member inline translateZ(z: int) =
+            Interop.mkAttr "transform" ("translateZ(" + (unbox<string> z) + ")")
+
     [<Erase>]
     type type' =
-        /// Defines a password field
-        static member inline password = Interop.mkAttr "type" "password"
-        /// Default. Defines a single-line text field
-        static member inline text = Interop.mkAttr "type" "text"
         /// Defines a clickable button (mostly used with a JavaScript code to activate a script)
         static member inline button = Interop.mkAttr "type" "button"
         /// Defines a checkbox
@@ -1443,6 +2001,8 @@ module prop =
         static member inline month = Interop.mkAttr "type" "month"
         /// Defines a field for entering a number
         static member inline number = Interop.mkAttr "type" "number"
+        /// Defines a password field
+        static member inline password = Interop.mkAttr "type" "password"
         /// Defines a radio button
         static member inline radio = Interop.mkAttr "type" "radio"
         /// Defines a range control (like a slider control)
@@ -1455,6 +2015,8 @@ module prop =
         static member inline submit = Interop.mkAttr "type" "submit"
         /// Defines a field for entering a telephone number
         static member inline tel = Interop.mkAttr "type" "tel"
+        /// Default. Defines a single-line text field
+        static member inline text = Interop.mkAttr "type" "text"
         /// Defines a control for entering a time (no timezone)
         static member inline time = Interop.mkAttr "type" "time"
         /// Defines a field for entering a URL

--- a/Feliz/Properties.fs
+++ b/Feliz/Properties.fs
@@ -934,6 +934,12 @@ type prop =
     /// Two elements are using this attribute: <ellipse>, and <rect>
     static member inline ry (value: int) = Interop.mkAttr "ry" value
 
+    /// Applies extra restrictions to the content in the frame. 
+    ///
+    /// The value of the attribute can either be empty to apply all restrictions, 
+    /// or space-separated tokens to lift particular restrictions
+    static member inline sandbox (values: #seq<string>) = Interop.mkAttr "sandbox" (values |> String.concat " ")
+
     /// Defines a value which will be selected on page load.
     static member inline selected (value: bool) = Interop.mkAttr "selected" value
 


### PR DESCRIPTION
* Added all HTML 5.2 spec elements and their respective attributes.
* Organized and made uniform code structure for Properties and Html.
* Added extra overloads where only `int` was specified and applicable.
* Added some additional comments outside the functions and types defined where they were missing.

Should resolve #149 and resolve #124
Partial work towards #81