### PR TITLE
Update to Fable.React 6.0.0

### DIFF
--- a/Feliz/React.fs
+++ b/Feliz/React.fs
@@ -23,7 +23,7 @@ type internal Internal() =
             ?name: string,
             ?withKey: 'props -> string
         )
-        : Fable.React.FunctionComponent<'props> =
+        : 'props -> Fable.React.ReactElement =
             name |> Option.iter (fun name -> renderElement?displayName <- name)
             fun props ->
                 let props = props |> propsWithKey withKey
@@ -36,7 +36,7 @@ type internal Internal() =
             ?areEqual: 'props -> 'props -> bool,
             ?withKey: 'props -> string
         )
-        : Fable.React.FunctionComponent<'props> =
+        : 'props -> Fable.React.ReactElement =
             let memoElementType = Interop.reactApi.memo(renderElement, (defaultArg areEqual (unbox null)))
             name |> Option.iter (fun name -> memoElementType?displayName <- name)
             fun props ->
@@ -115,7 +115,7 @@ type React =
     static member useRef(initialValue) = Interop.reactApi.useRef(initialValue)
 
     /// A specialized version of React.useRef() that creates a reference to an input element.
-    /// 
+    ///
     /// Useful for controlling the internal properties and methods that element, for example to enable focus().
     static member useInputRef() : IRefValue<HTMLInputElement option> = React.useRef(None)
 
@@ -123,7 +123,7 @@ type React =
     static member useButtonRef() : IRefValue<HTMLButtonElement option> = React.useRef(None)
 
     /// A specialized version of React.useRef() that creates a reference to a generic HTML element.
-    /// 
+    ///
     /// Useful for controlling the internal properties and methods that element, for integration with third-party libraries that require a Html element.
     static member useElementRef() : IRefValue<HTMLElement option> = React.useRef(None)
 

--- a/Feliz/ReactDOM.fs
+++ b/Feliz/ReactDOM.fs
@@ -5,8 +5,6 @@ open Fable.Core
 type ReactDOM =
     [<Import("render", "react-dom")>]
     static member render(element: Fable.React.ReactElement, container: Browser.Types.HTMLElement) = jsNative
-    static member render(element: Fable.React.FunctionComponent, container: Browser.Types.HTMLElement) =
-        ReactDOM.render(element, container)
 
 /// The ReactDOMServer object enables you to render components to static markup.
 type ReactDOMServer =

--- a/Feliz/ReactDOM.fs
+++ b/Feliz/ReactDOM.fs
@@ -5,8 +5,8 @@ open Fable.Core
 type ReactDOM =
     [<Import("render", "react-dom")>]
     static member render(element: Fable.React.ReactElement, container: Browser.Types.HTMLElement) = jsNative
-    static member render(element: Fable.React.FunctionComponent<unit>, container: Browser.Types.HTMLElement) =
-        ReactDOM.render(element(), container)
+    static member render(element: Fable.React.FunctionComponent, container: Browser.Types.HTMLElement) =
+        ReactDOM.render(element, container)
 
 /// The ReactDOMServer object enables you to render components to static markup.
 type ReactDOMServer =

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -2,13 +2,13 @@ group Main
     source https://api.nuget.org/v3/index.json
     storage:none
 
-nuget Fable.SimpleHttp
-nuget Feliz.Router
+    nuget Fable.SimpleHttp
+    nuget Feliz.Router
     nuget FSharp.Core
     nuget Fable.Core
     nuget Fable.Elmish.React
     nuget Fable.React
-nuget Zanaptak.TypedCssClasses
+    nuget Zanaptak.TypedCssClasses
 
 group Build
   framework >= net45

--- a/paket.lock
+++ b/paket.lock
@@ -22,7 +22,7 @@ NUGET
       Fable.Browser.Event (>= 1.0) - restriction: >= netstandard2.0
       Fable.Core (>= 3.0) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.6.2) - restriction: >= netstandard2.0
-    Fable.Core (3.1.3)
+    Fable.Core (3.1.5)
       FSharp.Core (>= 4.7) - restriction: >= netstandard2.0
     Fable.Elmish (3.0.6) - restriction: >= netstandard2.0
       Fable.Core (>= 3.0) - restriction: >= netstandard2.0
@@ -32,10 +32,10 @@ NUGET
       Fable.Elmish (>= 3.0) - restriction: >= netstandard2.0
       Fable.React (>= 5.1) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.6.2) - restriction: >= netstandard2.0
-    Fable.React (5.3.2)
+    Fable.React (6.0)
       Fable.Browser.Dom (>= 1.0) - restriction: >= netstandard2.0
-      Fable.Core (>= 3.0) - restriction: >= netstandard2.0
-      FSharp.Core (>= 4.6.2) - restriction: >= netstandard2.0
+      Fable.Core (>= 3.1.5) - restriction: >= netstandard2.0
+      FSharp.Core (>= 4.7) - restriction: >= netstandard2.0
     Fable.SimpleHttp (2.6)
       Fable.Browser.Dom (>= 1.0) - restriction: >= netstandard2.0
       Fable.Browser.XMLHttpRequest (>= 1.1) - restriction: >= netstandard2.0


### PR DESCRIPTION
Fable.React 6.0.0 [removed the type alias for FunctionComponent](https://github.com/fable-compiler/fable-react/pull/188/files#diff-80320e3248fd41bc3ce59f9bc8dc53b4L6).

I am unsure if this is deliberate or something we forget to undo when implementing the new version.

But because it was just an alias, I fixed Feliz code directly.