### PR TITLE
Refactor docs

### DIFF
--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -27,15 +27,9 @@
     <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' AND Exists('$(PaketRootPath)paket.bootstrapper.exe')">$(PaketRootPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
     <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' ">$(PaketToolsPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
     <PaketBootStrapperExeDir Condition=" Exists('$(PaketBootStrapperExePath)') " >$([System.IO.Path]::GetDirectoryName("$(PaketBootStrapperExePath)"))\</PaketBootStrapperExeDir>
-
+    
     <PaketBootStrapperCommand Condition=" '$(OS)' == 'Windows_NT' ">"$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
     <PaketBootStrapperCommand Condition=" '$(OS)' != 'Windows_NT' ">$(MonoPath) --runtime=v4.0.30319 "$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
-
-    <!-- Disable automagic references for F# DotNet SDK -->
-    <!-- This will not do anything for other project types -->
-    <!-- see https://github.com/fsharp/fslang-design/blob/master/tooling/FST-1002-fsharp-in-dotnet-sdk.md -->
-    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
-    <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
 
     <!-- Disable Paket restore under NCrunch build -->
     <PaketRestoreDisabled Condition="'$(NCrunch)' == '1'">True</PaketRestoreDisabled>
@@ -136,7 +130,7 @@
         <!-- Parse our simple 'paket.restore.cached' json ...-->
         <PaketRestoreCachedSplitObject Include="$([System.Text.RegularExpressions.Regex]::Split(`$(PaketRestoreCachedContents)`, `{|}|,`))"></PaketRestoreCachedSplitObject>
         <!-- Keep Key, Value ItemGroup-->
-        <PaketRestoreCachedKeyValue Include="@(PaketRestoreCachedSplitObject)"
+        <PaketRestoreCachedKeyValue Include="@(PaketRestoreCachedSplitObject)" 
             Condition=" $([System.Text.RegularExpressions.Regex]::Split(`%(Identity)`, `&quot;: &quot;`).Length) &gt; 1 ">
           <Key>$([System.Text.RegularExpressions.Regex]::Split(`%(Identity)`, `": "`)[0].Replace(`"`, ``).Replace(` `, ``))</Key>
           <Value>$([System.Text.RegularExpressions.Regex]::Split(`%(Identity)`, `": "`)[1].Replace(`"`, ``).Replace(` `, ``))</Value>
@@ -169,7 +163,7 @@
     <Exec Command='$(PaketBootStrapperCommand)' Condition=" '$(PaketBootstrapperStyle)' == 'classic' AND Exists('$(PaketBootStrapperExePath)') AND !(Exists('$(PaketExePath)'))" ContinueOnError="false" />
     <Error Text="Stop build because of PAKET_ERROR_ON_MSBUILD_EXEC and we need a full restore (hashes don't match)" Condition=" '$(PAKET_ERROR_ON_MSBUILD_EXEC)' == 'true' AND '$(PaketRestoreRequired)' == 'true' AND '$(PaketDisableGlobalRestore)' != 'true'" />
     <Exec Command='$(PaketCommand) restore' Condition=" '$(PaketRestoreRequired)' == 'true' AND '$(PaketDisableGlobalRestore)' != 'true' " ContinueOnError="false" />
-
+    
     <!-- Step 2 Detect project specific changes -->
     <ItemGroup>
       <MyTargetFrameworks Condition="'$(TargetFramework)' != '' " Include="$(TargetFramework)"></MyTargetFrameworks>

--- a/docs/Urls.fs
+++ b/docs/Urls.fs
@@ -1,69 +1,105 @@
 module Urls
 
 let [<Literal>] Feliz = "Feliz"
-let [<Literal>] General = "General"
+
 let [<Literal>] Aliasing = "Aliasing"
+let [<Literal>] ConditionalStyling = "ConditionalStyling"
+let [<Literal>] Contributing = "Contributing"
 let [<Literal>] Installation = "Installation"
-let [<Literal>] Recharts = "Recharts"
-let [<Literal>] AreaCharts = "AreaCharts"
-let [<Literal>] SimpleAreaChart = "SimpleAreaChart"
-let [<Literal>] StackedAreaChart = "StackedAreaChart"
-let [<Literal>] TinyAreaChart = "TinyAreaChart"
 let [<Literal>] Overview = "Overview"
-let [<Literal>] ElmishCounter = "ElmishCounter"
+let [<Literal>] ProjectTemplate = "ProjectTemplate"
 let [<Literal>] Syntax = "Syntax"
 let [<Literal>] TypeSafeCss = "TypeSafeCss"
 let [<Literal>] TypeSafeStyling = "TypeSafeStyling"
-let [<Literal>] ConditionalStyling = "ConditionalStyling"
-let [<Literal>] React = "React"
-let [<Literal>] Standalone = "Standalone"
-let [<Literal>] Components = "Components"
-let [<Literal>] StatelessComponents = "StatelessComponents"
-let [<Literal>] StatefulComponents = "StatefulComponents"
-let [<Literal>] EffectfulComponents = "EffectfulComponents"
-let [<Literal>] ReactApiSupport = "ReactApiSupport"
-let [<Literal>] SubscriptionsWithEffects = "SubscriptionsWithEffects"
-let [<Literal>] ContextPropagation = "ContextPropagation"
-let [<Literal>] NotJustFunctions = "NotJustFunctions"
-let [<Literal>] UseState = "UseState"
-let [<Literal>] UseEffect = "UseEffect"
-let [<Literal>] RenderStaticHtml = "RenderStaticHtml"
-let [<Literal>] UseReducer = "UseReducer"
-let [<Literal>] UseContext = "UseContext"
-let [<Literal>] Ecosystem = "Ecosystem"
-let [<Literal>] Mui = "Mui"
-let [<Literal>] Router = "Router"
-let [<Literal>] LineCharts = "LineCharts"
-let [<Literal>] SimpleLineChart = "SimpleLineChart"
+let [<Literal>] UseWithElmish = "UseWithElmish"
+
+// ____________________________________________________
+// Shared Urls
+
+let [<Literal>] Refs = "Refs"
+
+// ____________________________________________________
+
+let [<Literal>] Recharts = "Recharts"
+
+// Shared
 let [<Literal>] ResponsiveFullWidth = "ResponsiveFullWidth"
-let [<Literal>] BarCharts = "BarCharts"
-let [<Literal>] SimpleBarChart = "SimpleBarChart"
-let [<Literal>] StackedBarChart = "StackedBarChart"
-let [<Literal>] MixBarChart = "MixBarChart"
-let [<Literal>] TinyBarChart = "TinyBarChart"
+
+// __________________________
+
+let [<Literal>] AreaCharts = "AreaCharts"
+
+let [<Literal>] AreaChartFillByValue = "AreaChartFillByValue"
+let [<Literal>] AreaChartOptionalValues = "AreaChartOptionalValues"
+let [<Literal>] SimpleAreaChart = "SimpleAreaChart"
+let [<Literal>] StackedAreaChart = "StackedAreaChart"
+let [<Literal>] SynchronizedAreaChart = "SynchronizedAreaChart"
+let [<Literal>] TinyAreaChart = "TinyAreaChart"
+
+// __________________________
+
+let [<Literal>] LineCharts = "LineCharts"
+
+let [<Literal>] BiaxialLineChart = "BiaxialLineChart"
 let [<Literal>] CustomizedLabelLineChart = "CustomizedLabelLineChart"
 let [<Literal>] LineChartOptionalValues = "LineChartOptionalValues"
+let [<Literal>] SimpleLineChart = "SimpleLineChart"
+
+// __________________________
+
+let [<Literal>] BarCharts = "BarCharts"
+
+let [<Literal>] MixBarChart = "MixBarChart"
 let [<Literal>] PositiveAndNegative = "PositiveAndNegative"
-let [<Literal>] BiaxialLineChart = "BiaxialLineChart"
+let [<Literal>] SimpleBarChart = "SimpleBarChart"
+let [<Literal>] StackedBarChart = "StackedBarChart"
+let [<Literal>] TinyBarChart = "TinyBarChart"
+
+// __________________________
+
 let [<Literal>] PieCharts = "PieCharts"
+
 let [<Literal>] CustomizedLabelPieChart = "CustomizedLabelPieChart"
-let [<Literal>] TwoLevelPieChart = "TwoLevelPieChart"
-let [<Literal>] Contributing = "Contributing"
-let [<Literal>] CommonPitfalls = "CommonPitfalls"
-let [<Literal>] Plotly = "Plotly"
-let [<Literal>] PigeonMaps = "PigeonMaps"
-let [<Literal>] AreaChartOptionalValues = "AreaChartOptionalValues"
-let [<Literal>] SynchronizedAreaChart = "SynchronizedAreaChart"
-let [<Literal>] AreaChartFillByValue = "AreaChartFillByValue"
 let [<Literal>] StraightAngle = "StraightAngle"
+let [<Literal>] TwoLevelPieChart = "TwoLevelPieChart"
+
+// ____________________________________________________
+
+let [<Literal>] React = "React"
+
+let [<Literal>] CommonPitfalls = "CommonPitfalls"
+let [<Literal>] Components = "Components"
+let [<Literal>] ContextPropagation = "ContextPropagation"
+let [<Literal>] EffectfulComponents = "EffectfulComponents"
 let [<Literal>] HoverAnimations = "HoverAnimations"
-let [<Literal>] ProjectTemplate = "ProjectTemplate"
-let [<Literal>] Popover = "Popover"
+let [<Literal>] NotJustFunctions = "NotJustFunctions"
+let [<Literal>] ReactApiSupport = "ReactApiSupport"
+let [<Literal>] RenderStaticHtml = "RenderStaticHtml"
+let [<Literal>] Standalone = "Standalone"
+let [<Literal>] StatefulComponents = "StatefulComponents"
+let [<Literal>] StatelessComponents = "StatelessComponents"
+let [<Literal>] SubscriptionsWithEffects = "SubscriptionsWithEffects"
+let [<Literal>] UseContext = "UseContext"
+let [<Literal>] UseEffect = "UseEffect"
+let [<Literal>] UseReducer = "UseReducer"
+let [<Literal>] UseState = "UseState"
+
+// ____________________________________________________
+
+let [<Literal>] Ecosystem = "Ecosystem"
+
 let [<Literal>] ElmishComponents = "ElmishComponents"
-let [<Literal>] UseWithElmish = "UseWithElmish"
-let [<Literal>] Tests = "Tests"
-let [<Literal>] FileUpload = "FileUpload"
-let [<Literal>] Bulma = "Bulma"
-let [<Literal>] KeyboardKey = "KeyboardKey"
-let [<Literal>] Refs = "Refs"
+let [<Literal>] Mui = "Mui"
+let [<Literal>] PigeonMaps = "PigeonMaps"
+let [<Literal>] Plotly = "Plotly"
+let [<Literal>] Popover = "Popover"
+let [<Literal>] Router = "Router"
 let [<Literal>] ViewEngine = "ViewEngine"
+
+// ____________________________________________________
+
+let [<Literal>] Tests = "Tests"
+
+let [<Literal>] Bulma = "Bulma"
+let [<Literal>] FileUpload = "FileUpload"
+let [<Literal>] KeyboardKey = "KeyboardKey"

--- a/public/index.html
+++ b/public/index.html
@@ -18,11 +18,36 @@
         <style>
             pre {
                 padding: 0;
-                margin-top:20px;
-                margin-bottom:20px;
+                margin-top: 20px;
+                margin-bottom: 20px;
             }
 
-            code { margin: 10 }
+            code {
+                margin: 10px;
+            }
+
+            .scrollbar {
+                max-height: 90vh;
+                overflow: auto;
+            }
+
+            *::-webkit-scrollbar {
+                width: 6px;
+            }
+
+            *::-webkit-scrollbar-track {
+                display: none;
+            }
+
+            *::-webkit-scrollbar-thumb {
+                border-radius: 10px;
+                background: #00000000;
+                transition: background 3s;
+            }
+
+            *:hover::-webkit-scrollbar-thumb {
+                background: rgba(0, 209, 178, 0.54);
+            }
         </style>
         <div id="root">
 


### PR DESCRIPTION
This is mostly for making maintenance easier, but also makes all menu items collapsed by default and keeps at most only one tab open at once. Currently the docs are getting quite large and increasingly harder to navigate. 

I also converted everything applicable to react components and did some other things to help make the app a bit snappier.

Lastly I did a little bit of styling adjustments, mostly for the sidebar and scrollbar, feel free to ditch them if you don't like them.
