### PR TITLE
Minor optimizations to elmishComponents and type annotations

### DIFF
--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -27,15 +27,9 @@
     <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' AND Exists('$(PaketRootPath)paket.bootstrapper.exe')">$(PaketRootPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
     <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' ">$(PaketToolsPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
     <PaketBootStrapperExeDir Condition=" Exists('$(PaketBootStrapperExePath)') " >$([System.IO.Path]::GetDirectoryName("$(PaketBootStrapperExePath)"))\</PaketBootStrapperExeDir>
-
+    
     <PaketBootStrapperCommand Condition=" '$(OS)' == 'Windows_NT' ">"$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
     <PaketBootStrapperCommand Condition=" '$(OS)' != 'Windows_NT' ">$(MonoPath) --runtime=v4.0.30319 "$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
-
-    <!-- Disable automagic references for F# DotNet SDK -->
-    <!-- This will not do anything for other project types -->
-    <!-- see https://github.com/fsharp/fslang-design/blob/master/tooling/FST-1002-fsharp-in-dotnet-sdk.md -->
-    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
-    <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
 
     <!-- Disable Paket restore under NCrunch build -->
     <PaketRestoreDisabled Condition="'$(NCrunch)' == '1'">True</PaketRestoreDisabled>
@@ -136,7 +130,7 @@
         <!-- Parse our simple 'paket.restore.cached' json ...-->
         <PaketRestoreCachedSplitObject Include="$([System.Text.RegularExpressions.Regex]::Split(`$(PaketRestoreCachedContents)`, `{|}|,`))"></PaketRestoreCachedSplitObject>
         <!-- Keep Key, Value ItemGroup-->
-        <PaketRestoreCachedKeyValue Include="@(PaketRestoreCachedSplitObject)"
+        <PaketRestoreCachedKeyValue Include="@(PaketRestoreCachedSplitObject)" 
             Condition=" $([System.Text.RegularExpressions.Regex]::Split(`%(Identity)`, `&quot;: &quot;`).Length) &gt; 1 ">
           <Key>$([System.Text.RegularExpressions.Regex]::Split(`%(Identity)`, `": "`)[0].Replace(`"`, ``).Replace(` `, ``))</Key>
           <Value>$([System.Text.RegularExpressions.Regex]::Split(`%(Identity)`, `": "`)[1].Replace(`"`, ``).Replace(` `, ``))</Value>
@@ -169,7 +163,7 @@
     <Exec Command='$(PaketBootStrapperCommand)' Condition=" '$(PaketBootstrapperStyle)' == 'classic' AND Exists('$(PaketBootStrapperExePath)') AND !(Exists('$(PaketExePath)'))" ContinueOnError="false" />
     <Error Text="Stop build because of PAKET_ERROR_ON_MSBUILD_EXEC and we need a full restore (hashes don't match)" Condition=" '$(PAKET_ERROR_ON_MSBUILD_EXEC)' == 'true' AND '$(PaketRestoreRequired)' == 'true' AND '$(PaketDisableGlobalRestore)' != 'true'" />
     <Exec Command='$(PaketCommand) restore' Condition=" '$(PaketRestoreRequired)' == 'true' AND '$(PaketDisableGlobalRestore)' != 'true' " ContinueOnError="false" />
-
+    
     <!-- Step 2 Detect project specific changes -->
     <ItemGroup>
       <MyTargetFrameworks Condition="'$(TargetFramework)' != '' " Include="$(TargetFramework)"></MyTargetFrameworks>

--- a/Feliz.ElmishComponents/Components.fs
+++ b/Feliz.ElmishComponents/Components.fs
@@ -68,10 +68,7 @@ module ElmishComponentExtensions =
         let ring = React.useRef(RingBuffer(10))
         let reentered = React.useRef(false)
         let childState, setChildState = React.useState(fst input.Initial)
-        let setChildState = 
-            React.useCallback(fun () -> 
-                JS.setTimeout(fun () -> setChildState state.current) 0 
-                |> ignore)
+        let setChildState () = JS.setTimeout(fun () -> setChildState state.current) 0 |> ignore
 
         let token = React.useRef(new System.Threading.CancellationTokenSource())
     
@@ -94,7 +91,7 @@ module ElmishComponentExtensions =
             }
             |> Promise.start
 
-        let dispatch = React.useCallback(dispatch, [| token |])
+        let dispatch = React.useCallbackRef(dispatch)
 
         React.useEffectOnce(fun () ->
             React.createDisposable <| fun () ->
@@ -113,7 +110,7 @@ module ElmishComponentExtensions =
 
     type React with
         /// Creates a standalone React component using an Elmish dispatch loop
-        static member inline elmishComponent(name, init, update, render, ?key) =
+        static member inline elmishComponent(name: string, init: 'Model * Cmd<'Msg>, update: 'Msg -> 'Model -> 'Model * Cmd<'Msg>, render: 'Model -> ('Msg -> unit) -> ReactElement, ?key: string) =
             let fullKey =
                 match key with
                 | None -> name
@@ -122,7 +119,7 @@ module ElmishComponentExtensions =
             elmishComponent { Initial = init; Update = update; Render = render; key = fullKey }
 
         /// Creates a standalone React component using an Elmish dispatch loop
-        static member inline elmishComponent(name, init, update, render, ?key) =
+        static member inline elmishComponent(name: string, init: 'Model, update: 'Msg -> 'Model -> 'Model * Cmd<'Msg>, render: 'Model -> ('Msg -> unit) -> ReactElement, ?key: string)  =
             let fullKey =
                 match key with
                 | None -> name
@@ -131,7 +128,7 @@ module ElmishComponentExtensions =
             elmishComponent { Initial = init, Cmd.none; Update = update; Render = render; key = fullKey }
     
         /// Creates a standalone React component using an Elmish dispatch loop
-        static member inline elmishComponent(name, init, update, render, ?key) =
+        static member inline elmishComponent(name: string, init: 'Model, update: 'Msg -> 'Model -> 'Model, render: 'Model -> ('Msg -> unit) -> ReactElement, ?key: string) =
             let fullKey =
                 match key with
                 | None -> name
@@ -144,7 +141,7 @@ module ElmishComponentExtensions =
                   key = fullKey }
     
         /// Creates a standalone React component using an Elmish dispatch loop
-        static member inline elmishComponent(name, init, update, render, ?key) =
+        static member inline elmishComponent(name: string, init: 'Model * Cmd<'Msg>, update: 'Msg -> 'Model -> 'Model, render: 'Model -> ('Msg -> unit) -> ReactElement, ?key: string) =
             let fullKey =
                 match key with
                 | None -> name


### PR DESCRIPTION
Removed an unnecessary `useCallback` and changed the dispatch to use `useCallbackRef`.

I also added type annotations for the `React.elmishComponent` overloads so it's easier to pick out what's needed and parameter order. 