### PR TITLE
Add React.forwardRef

### DIFF
--- a/Feliz/React.fs
+++ b/Feliz/React.fs
@@ -494,7 +494,7 @@ type React =
     /// dependency declarations and never causes a re-render.
     /// </summary>
     /// <param name='callback'>The function call.</param>
-    static member useCallbackRef (callback: ('a -> 'b)) =
+    static member useCallbackRef(callback: ('a -> 'b)) =
         let lastRenderCallbackRef = React.useRef(callback)
         
         let callbackRef = 
@@ -508,3 +508,8 @@ type React =
         )
 
         callbackRef
+
+    static member forwardRef(render: ('Props * IRefValue<#HTMLElement option> -> ReactElement)) : ('Props * IRefValue<#HTMLElement option> -> ReactElement) = 
+        let forwardRefType = Interop.reactApi.forwardRef(render)
+        fun props ->
+            Interop.reactApi.createElement(forwardRefType, props)

--- a/Feliz/React.fs
+++ b/Feliz/React.fs
@@ -529,22 +529,3 @@ type React =
         fun props ->
             Interop.reactApi.createElement(forwardRefType, props)
 
-    /// <summary>
-    /// Forwards a given ref, allowing you to pass it further down to a child.
-    /// </summary>
-    /// <param name='render'>A render function that returns a list of elements.</param>
-    static member forwardRef(render: ('Props * IRefValue<#HTMLElement option> -> #seq<ReactElement>)) : ('Props * IRefValue<#HTMLElement option> -> ReactElement) = 
-        let forwardRefType = Interop.reactApi.forwardRef(render >> React.fragment)
-        fun props ->
-            Interop.reactApi.createElement(forwardRefType, props)
-
-    /// <summary>
-    /// Forwards a given ref, allowing you to pass it further down to a child.
-    /// </summary>
-    /// <param name='name'>The component name to display in the React dev tools.</param>
-    /// <param name='render'>A render function that returns a list of elements.</param>
-    static member forwardRef(name: string, render: ('Props * IRefValue<#HTMLElement option> -> #seq<ReactElement>)) : ('Props * IRefValue<#HTMLElement option> -> ReactElement) = 
-        let forwardRefType = Interop.reactApi.forwardRef(render >> React.fragment)
-        render?displayName <- name
-        fun props ->
-            Interop.reactApi.createElement(forwardRefType, props)

--- a/Feliz/React.fs
+++ b/Feliz/React.fs
@@ -509,7 +509,42 @@ type React =
 
         callbackRef
 
+    /// <summary>
+    /// Forwards a given ref, allowing you to pass it further down to a child.
+    /// </summary>
+    /// <param name='render'>A render function that returns an element.</param>
     static member forwardRef(render: ('Props * IRefValue<#HTMLElement option> -> ReactElement)) : ('Props * IRefValue<#HTMLElement option> -> ReactElement) = 
         let forwardRefType = Interop.reactApi.forwardRef(render)
+        fun props ->
+            Interop.reactApi.createElement(forwardRefType, props)
+
+    /// <summary>
+    /// Forwards a given ref, allowing you to pass it further down to a child.
+    /// </summary>
+    /// <param name='name'>The component name to display in the React dev tools.</param>
+    /// <param name='render'>A render function that returns an element.</param>
+    static member forwardRef(name: string, render: ('Props * IRefValue<#HTMLElement option> -> ReactElement)) : ('Props * IRefValue<#HTMLElement option> -> ReactElement) = 
+        let forwardRefType = Interop.reactApi.forwardRef(render)
+        render?displayName <- name
+        fun props ->
+            Interop.reactApi.createElement(forwardRefType, props)
+
+    /// <summary>
+    /// Forwards a given ref, allowing you to pass it further down to a child.
+    /// </summary>
+    /// <param name='render'>A render function that returns a list of elements.</param>
+    static member forwardRef(render: ('Props * IRefValue<#HTMLElement option> -> #seq<ReactElement>)) : ('Props * IRefValue<#HTMLElement option> -> ReactElement) = 
+        let forwardRefType = Interop.reactApi.forwardRef(render >> React.fragment)
+        fun props ->
+            Interop.reactApi.createElement(forwardRefType, props)
+
+    /// <summary>
+    /// Forwards a given ref, allowing you to pass it further down to a child.
+    /// </summary>
+    /// <param name='name'>The component name to display in the React dev tools.</param>
+    /// <param name='render'>A render function that returns a list of elements.</param>
+    static member forwardRef(name: string, render: ('Props * IRefValue<#HTMLElement option> -> #seq<ReactElement>)) : ('Props * IRefValue<#HTMLElement option> -> ReactElement) = 
+        let forwardRefType = Interop.reactApi.forwardRef(render >> React.fragment)
+        render?displayName <- name
         fun props ->
             Interop.reactApi.createElement(forwardRefType, props)

--- a/Feliz/ReactTypes.fs
+++ b/Feliz/ReactTypes.fs
@@ -22,3 +22,4 @@ type IReactApi =
     abstract memo: render: ('props -> ReactElement) * areEqual: ('props -> 'props -> bool) -> ('props -> ReactElement)
     abstract createContext: defaultValue: 'a -> IContext<'a>
     abstract useContext: ctx: IContext<'a> -> 'a
+    abstract forwardRef : render: ('props * IRefValue<'ref option> -> ReactElement) -> ('props -> IRefValue<'ref option> -> ReactElement)

--- a/docs/App.fs
+++ b/docs/App.fs
@@ -8,12 +8,9 @@ open Feliz.Recharts
 open Feliz.Markdown
 open Feliz.PigeonMaps
 open Feliz.Router
-open Fable.Core
 open Fable.Core.JsInterop
 open Fable.SimpleHttp
 open Zanaptak.TypedCssClasses
-open System
-open Browser.Types
 
 type Bulma = CssClasses<"https://cdnjs.cloudflare.com/ajax/libs/bulma/0.7.5/css/bulma.min.css", Naming.PascalCase>
 type FA = CssClasses<"https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css", Naming.PascalCase>
@@ -36,8 +33,6 @@ let init () =
       CurrentTab = path }, Cmd.none
 
 type Msg =
-    | Increment
-    | Decrement
     | TabToggled of string list
     | UrlChanged of string list
 
@@ -55,7 +50,6 @@ let update msg state =
         match tabs with
         | [ ] -> { state with CurrentTab = [ ] }, Cmd.none
         | _ -> { state with CurrentTab = tabs }, Cmd.none
-    | _ -> state, Cmd.none
 
 [
     style.display.flex
@@ -121,160 +115,6 @@ let update msg state =
 ]
 |> List.iter (fun x -> Browser.Dom.console.log(createObj [!!x]))
 
-let keyedFragments state dispatch =
-    React.keyedFragment(1, [
-        Html.div [
-            React.keyedFragment("hello", [
-                Html.h1 "Hello"
-                Html.div [ ]
-                Html.div [ Html.h1 "More stuff" ]
-                Html.div [ Html.h2 [ Html.strong "Bold" ] ]
-                Html.ul [
-                    Html.li [ Html.strong "Wow" ]
-                    Html.li "So"
-                    Html.li (Html.em "Lightweight")
-                    Html.ol [
-                        Html.li [ Html.strong "More" ]
-                        Html.li [ ]
-                        Html.li [ Html.none ]
-                    ]
-                ]
-            ])
-        ]
-    ])
-
-let inputs state dispatch =
-    Html.form [
-        Html.input [ prop.type'.checkbox ]
-        Html.input [ prop.type' "password" ]
-    ]
-
-let staticHtml = React.functionComponent(fun () ->
-    let html = Html.div [
-        prop.style [ style.padding 20 ]
-        prop.children [
-            Html.h1 "Html content"
-            Html.br [ ]
-        ]
-    ]
-
-
-    Html.pre [
-        Html.text (ReactDOMServer.renderToString html)
-    ])
-
-
-let staticMarkup = React.functionComponent(fun () ->
-    let html = Html.div [
-        prop.style [ style.padding 20 ]
-        prop.children [
-            Html.h1 "Html content"
-            Html.br [ ]
-        ]
-    ]
-
-
-    Html.pre [
-        Html.text (ReactDOMServer.renderToStaticMarkup html)
-    ])
-
-let multipleStateVariables = React.functionComponent(fun () ->
-    let (count, setCount) = React.useState(0)
-    let (textColor, setTextColor) = React.useState(color.red)
-
-    Html.div [
-        Html.h1 [
-            prop.style [ style.color textColor ]
-            prop.text count
-        ]
-
-        Html.button [
-            prop.text "Increment"
-            prop.onClick (fun _ -> setCount(count + 1))
-        ]
-
-        Html.button [
-            prop.text "Red"
-            prop.onClick (fun _ -> setTextColor(color.red))
-        ]
-
-        Html.button [
-            prop.text "Blue"
-            prop.onClick (fun _ -> setTextColor(color.blue))
-        ]
-    ])
-
-let asyncEffect = React.functionComponent(fun () ->
-    let (isLoading, setLoading) = React.useState(false)
-    let (content, setContent) = React.useState("")
-
-    let loadData() = async {
-        setLoading true
-        do! Async.Sleep 1500
-        setLoading false
-        setContent "Content"
-    }
-
-    React.useEffect(loadData >> Async.StartImmediate, [||])
-
-    Html.div [
-        if isLoading
-        then Html.h1 "Loading"
-        else Html.h1 content
-    ])
-
-let asyncEffectOnce = React.functionComponent(fun () ->
-    let (isLoading, setLoading) = React.useState(false)
-    let (content, setContent) = React.useState("")
-
-    let loadData() = async {
-        setLoading true
-        do! Async.Sleep 1500
-        setLoading false
-        setContent "Content"
-    }
-
-    React.useEffectOnce(loadData >> Async.StartImmediate)
-
-    Html.div [
-        if isLoading
-        then Html.h1 "Loading"
-        else Html.h1 content
-    ])
-
-[<Emit("setTimeout($0, $1)")>]
-let setTimeout (f: unit -> unit) (timeout: int) : int = jsNative
-
-[<Emit("clearTimeout($0)")>]
-let clearTimeout (id: int) : unit = jsNative
-
-let timer = React.functionComponent(fun () ->
-    let (paused, setPaused) = React.useState(false)
-    let (value, setValue) = React.useState(0)
-
-    let subscribeToTimer() =
-        // start the ticking
-        let subscriptionId = setTimeout (fun _ -> if not paused then setValue (value + 1)) 1000
-        // return IDisposable with cleanup code
-        { new IDisposable with member this.Dispose() = clearTimeout(subscriptionId) }
-
-    React.useEffect(subscribeToTimer)
-
-    Html.div [
-        Html.h1 value
-
-        Html.button [
-            prop.className [
-                Bulma.Button
-                Bulma.IsLarge
-                if paused then Bulma.IsPrimary else Bulma.IsWarning
-            ]
-
-            prop.onClick (fun _ -> setPaused(not paused))
-            prop.text (if paused then "Resume" else "Pause")
-        ]
-    ])
-
 let delayedComponent = React.functionComponent (fun (props: {| load: unit -> ReactElement |}) ->
     let (started, setStarted) = React.useState(false)
     Html.div [
@@ -293,301 +133,19 @@ let delayedComponent = React.functionComponent (fun (props: {| load: unit -> Rea
         if started then props.load()
     ])
 
-
-let rnd = System.Random()
-let effectfulUserId = React.functionComponent(fun () ->
-    let (isLoading, setLoading) = React.useState(false)
-    let (content, setContent) = React.useState("")
-    let (userId, setUserId) = React.useState(0)
-    let (textColor, setTextColor) = React.useState(color.red)
-
-    let loadData() = async {
-        setLoading true
-        do! Async.Sleep 1500
-        setLoading false
-        setContent (sprintf "User %d" userId)
-    }
-
-    React.useEffect(loadData >> Async.StartImmediate, [| box userId |])
-
-    Html.div [
-        Html.h1 [
-            prop.style [ style.color textColor ]
-            prop.text (if isLoading then "Loading" else content)
-        ]
-
-        Html.button [
-            prop.text "Red"
-            prop.onClick (fun _ -> setTextColor(color.red))
-        ]
-
-        Html.button [
-            prop.text "Blue"
-            prop.onClick (fun _ -> setTextColor(color.blue))
-        ]
-
-        Html.button [
-            prop.text "Update User ID"
-            prop.onClick (fun _ -> setUserId(rnd.Next(1, 100)))
-        ]
-    ])
-
-let effectfulTabCounter = React.functionComponent(fun () ->
-    let (count, setCount) = React.useState(0)
-
-    // execute this effect on every render cycle
-    React.useEffect(fun () -> Browser.Dom.document.title <- sprintf "Count = %d" count)
-
-    Html.div [
-        Html.h1 count
-        Html.button [
-            prop.text "Increment"
-            prop.onClick (fun _ -> setCount(count + 1))
-        ]
-    ])
-
-let counterApp state dispatch =
-    Html.div [
-        prop.id "main"
-        prop.style [ style.padding 20 ]
-        prop.children [
-
-            Html.button [
-                prop.style [ style.marginRight 5 ]
-                prop.onClick (fun _ -> dispatch Increment)
-                prop.text "Increment"
-            ]
-
-            Html.button [
-                prop.style [ style.marginLeft 5 ]
-                prop.onClick (fun _ -> dispatch Decrement)
-                prop.text "Decrement"
-            ]
-
-            Html.h1 "Count"
-        ]
-    ]
-
-let keyWarnings state dispatch =
-    Html.div [
-        prop.id "id"
-        prop.className ["class"]
-        prop.children [
-            Html.div "text"
-            Html.div [
-                prop.id "id"
-                prop.children [
-                    Html.text "text"
-                    Html.div [
-                        prop.id "id"
-                        prop.className "class"
-                        prop.children [
-                            Html.text "text"
-                            Html.div [
-                                prop.id "id"
-                                prop.className "class"
-                                prop.children [
-                                    Html.text "text"
-                                    Html.div []
-                                ]
-                            ]
-                        ]
-                    ]
-                ]
-            ]
-        ]
-    ]
-
-let fragmentTests =
-    Html.div [
-        prop.children [
-            React.fragment [
-                Html.h1 "One"
-                Html.h2 "Two"
-            ]
-        ]
-    ]
-
-// Re-use state internally using React hooks
-let animationsOnHover' = React.functionComponent(fun (props: {| content: ReactElement |}) -> [
-    let (hovered, setHovered) = React.useState(false)
-    Html.div [
-        prop.style [
-            style.padding 10
-            style.transitionDuration (TimeSpan.FromMilliseconds 1000.0)
-            style.transitionProperty [
-                transitionProperty.backgroundColor
-                transitionProperty.color
-            ]
-
-            if hovered then
-               style.backgroundColor.lightBlue
-               style.color.black
-            else
-               style.backgroundColor.limeGreen
-               style.color.white
-        ]
-        prop.onMouseEnter (fun _ -> setHovered(true))
-        prop.onMouseLeave (fun _ -> setHovered(false))
-        prop.children [ props.content ]
-    ]
-])
-
-let animationsOnHover content = animationsOnHover' {| content = React.fragment content |}
-let animationSample =
-    Html.div [
-        animationsOnHover [ Html.span "Hover me!" ]
-        animationsOnHover [ Html.p "So smooth" ]
-    ]
-
-module ReactComponents =
-    type Greeting = { Name: string option }
-    let greeting = React.functionComponent(fun (props: Greeting) ->
-        Html.div [
-            Html.span "Hello, "
-            Html.span (Option.defaultValue "World" props.Name)
-        ])
-
-    let simple = Html.div [
-        prop.className "content"
-        prop.children [
-            greeting { Name = Some "John" }
-            greeting { Name = None }
-        ]
-    ]
-
-    let counter = React.functionComponent(fun () ->
-        let (count, setCount) = React.useState(0)
-        Html.div [
-            Html.h1 count
-            Html.button [
-                prop.text "Increment"
-                prop.onClick (fun _ -> setCount(count + 1))
-            ]
-        ])
-
-let counter = React.functionComponent(fun () ->
-    let (count, setCount) = React.useState 0
-
-    let modifyDocumentTitle() =
-        Browser.Dom.window.document.title <- string count
-
-    React.useEffect(modifyDocumentTitle)
-
-    Html.div [
-        Html.h1 count
-        Html.button [
-            prop.text "Increment"
-            prop.onClick (fun _ -> setCount(count + 1))
-        ]
-    ])
-
-[<Emit("setInterval($0, $1)")>]
-let setInterval (f: unit -> unit) (n: int) : int = jsNative
-
-[<Emit("clearInterval($0)")>]
-let clearInterval (n: int) : unit = jsNative
-
-let ticker = React.functionComponent("Ticker", fun (input: {| start: int |}) ->
-    let (tick, setTick) = React.useState input.start
-
-    let tickerEffect() : IDisposable =
-        let interval = setInterval (fun () -> setTick(tick + 1)) 1000
-        React.createDisposable(fun () -> clearInterval(interval))
-
-    React.useEffect(tickerEffect, [| box input.start |])
-
-    Html.div [
-        Html.h1 tick
-    ])
-
-let hooksAreAwesome =
-    React.fragment [
-        counter()
-        Html.hr [ ]
-        ticker {| start = 0 |}
-        Html.hr [ ]
-        ticker {| start = 10 |}
-    ]
-
-module ElmishCounter =
-    type State = { Count : int }
-    type Msg = Increment | Decrement
-
-    let initialState = { Count = 0 }
-
-    let update (state: State) = function
-        | Increment -> { state with Count = state.Count + 1 }
-        | Decrement -> { state with Count = state.Count - 1 }
-
-    let app = React.functionComponent("Counter", fun () ->
-        let (state, dispatch) = React.useReducer(update, initialState)
-        Html.div [
-            Html.button [
-                prop.onClick (fun _ -> dispatch Increment)
-                prop.text "Increment"
-            ]
-
-            Html.button [
-                prop.onClick (fun _ -> dispatch Decrement)
-                prop.text "Decrement"
-            ]
-
-            Html.h1 state.Count
-        ])
-
-let fullFocusInputExample = React.functionComponent(fun () ->
-    // obtain a reference
-    let inputRef = React.useRef(None)
-
-    let focusTextInput() =
-        match inputRef.current with
-        | None -> ()
-        | Some element ->
-            let inputElement = unbox<HTMLInputElement> element
-            inputElement.focus()
-
-    Html.div [
-        Html.input [
-            prop.ref inputRef
-            prop.type'.text
-        ]
-
-        Html.button [
-            prop.onClick (fun _ -> focusTextInput())
-            prop.text "Focus Input"
-        ]
-    ])
-
-let focusInputExample = React.functionComponent(fun () ->
-    let inputRef = React.useInputRef()
-    let focusTextInput() = inputRef.current |> Option.iter (fun el -> el.focus())
-
-    Html.div [
-        Html.input [
-            prop.ref inputRef
-            prop.type'.text
-        ]
-
-        Html.button [
-            prop.onClick (fun _ -> focusTextInput())
-            prop.text "Focus Input"
-        ]
-    ])
-
 let samples = [
-    "feliz-elmish-counter", ElmishCounter.app()
-    "simple-components", ReactComponents.simple
-    "multiple-state-variables", multipleStateVariables()
-    "hover-animations", animationSample
-    "stateful-counter", ReactComponents.counter()
-    "effectful-tab-counter", delayedComponent {| load = effectfulTabCounter |}
-    "effectful-async", delayedComponent {| load = asyncEffect |}
-    "effectful-async-once", delayedComponent {| load = asyncEffectOnce |}
-    "effectful-user-id", delayedComponent {| load = effectfulUserId |}
-    "effectful-timer", delayedComponent {| load = timer |}
-    "static-html", staticHtml()
-    "static-markup", staticMarkup()
+    "feliz-elmish-counter", Examples.ElmishCounter.app()
+    "simple-components", Examples.ReactComponents.simple
+    "multiple-state-variables", Examples.multipleStateVariables()
+    "hover-animations", Examples.animationSample
+    "stateful-counter", Examples.ReactComponents.counter()
+    "effectful-tab-counter", delayedComponent {| load = Examples.effectfulTabCounter |}
+    "effectful-async", delayedComponent {| load = Examples.asyncEffect |}
+    "effectful-async-once", delayedComponent {| load = Examples.asyncEffectOnce |}
+    "effectful-user-id", delayedComponent {| load = Examples.effectfulUserId |}
+    "effectful-timer", delayedComponent {| load = Examples.timer |}
+    "static-html", Examples.staticHtml()
+    "static-markup", Examples.staticMarkup()
     "recharts-main", Samples.Recharts.AreaCharts.Main.chart()
     "recharts-area-simpleareachart", Samples.Recharts.AreaCharts.SimpleAreaChart.chart()
     "recharts-area-stackedareachart", Samples.Recharts.AreaCharts.StackedAreaChart.chart()
@@ -618,7 +176,8 @@ let samples = [
     "popover-basic-sample", Samples.Popover.Basic.sample
     "elmish-components-counter", Samples.ElmishComponents.application
     "elmish-components-dispose", Samples.ElmishComponents.WithDispose.application
-    "focus-input-example", focusInputExample()
+    "focus-input-example", Examples.focusInputExample()
+    "forward-ref-example", Examples.forwardRefParent()
 ]
 
 let githubPath (rawPath: string) =
@@ -953,146 +512,6 @@ let sidebar = React.functionComponent(fun (input: {| state: State; dispatch: Msg
         ]
     ])
 
-let fileUpload = React.functionComponent(fun () -> [
-    Html.div [
-        Html.h1 "Single File Selection"
-        Html.input [
-            prop.type'.file
-            prop.onChange (fun (file: File) -> Browser.Dom.console.log(file))
-        ]
-
-        Html.h1 "Multi-File Selection"
-        Html.input [
-            prop.type'.file
-            prop.multiple true
-            prop.onChange (fun (files: File list) -> Browser.Dom.console.log(Array.ofList files))
-        ]
-    ]
-])
-
-let keyboardKey = React.functionComponent(fun () -> [
-    let (keyPressed, setKeyPressed) = React.useState("")
-
-    let update() = setKeyPressed (sprintf "Key 'Enter' presssed at %s" (DateTime.Now.ToString("hh:mm:ss")))
-
-    Html.div [
-        Html.h3 "Handling ENTER"
-        Html.input [
-            prop.onKeyUp(key.enter, fun ev -> update())
-        ]
-
-        Html.h3 "Handling SHIFT + ENTER"
-        Html.input [
-            prop.onKeyUp(key.shift(key.enter), fun ev -> update())
-        ]
-
-        Html.h3 "Handling CTRL + ENTER"
-        Html.input [
-            prop.onKeyUp(key.ctrl(key.enter), fun ev -> update())
-        ]
-
-        Html.h3 "Handling CTRL + SHIFT + ENTER"
-
-        Html.input [
-            prop.onKeyUp(key.ctrlAndShift(key.enter), fun ev -> update())
-        ]
-
-        Html.h1 keyPressed
-    ]
-])
-
-[<Emit("alert($0)")>]
-let alert s : unit = jsNative
-
-let renderCount = React.functionComponent(fun (input: {| label: string |}) ->
-    let countRef = React.useRef 0
-        
-    let mutable currentCount = countRef.current
-
-    React.useEffect(fun () -> countRef.current <- currentCount)
-
-    currentCount <- currentCount + 1
-
-    Html.div [
-        prop.text (sprintf "%s render count: %i" input.label currentCount)
-    ])
-
-let callbackRefButton = React.memo(fun (input: {| onClick: unit -> unit |}) ->
-    Html.div [
-        renderCount {| label = "Button" |}
-        Html.button [
-            prop.onClick <| fun _ -> input.onClick()
-            prop.text "Show renders"
-        ]
-    ])
-
-let callbackRef = React.functionComponent(fun () -> 
-    let count,setCount = React.useState 1
-
-    React.useEffect((fun () ->
-        let interval = setInterval(fun () -> setCount(count + 1)) 1000
-        React.createDisposable(fun () -> clearInterval(interval))
-    ), [| count :> obj |])
-
-    let showCount = React.useCallbackRef(fun () -> alert count)
-
-    Html.div [
-        renderCount {| label = "Main" |}
-        callbackRefButton {| onClick = showCount |}
-    ])
-
-let callbackNoRef = React.functionComponent(fun () -> 
-    let count,setCount = React.useState 1
-
-    React.useEffect((fun () ->
-        let interval = setInterval(fun () -> setCount(count + 1)) 1000
-        React.createDisposable(fun () -> clearInterval(interval))
-    ), [| count :> obj |])
-
-    let showCount = React.useCallback(fun () -> alert count)
-
-    Html.div [
-        renderCount {| label = "Main" |}
-        callbackRefButton {| onClick = showCount |}
-    ])
-
-let runCallbackTests = React.functionComponent(fun () ->
-    Html.div [
-        prop.style [ 
-            style.display.inheritFromParent
-        ]
-        prop.children [
-            Html.div [
-                prop.style [
-                    style.paddingRight (length.em 10)
-                ]
-                prop.children [
-                    Html.h1 [
-                        prop.style [
-                            style.paddingBottom (length.em 2)
-                        ]
-                        prop.text "Using callbackRef"
-                    ]
-                    callbackRef()
-                ]
-            ]
-            Html.div [
-                prop.style [
-                    style.paddingRight (length.em 10)
-                ]
-                prop.children [
-                    Html.h1 [
-                        prop.style [
-                            style.paddingBottom (length.em 2)
-                        ]
-                        prop.text "Using callback"
-                    ]
-                    callbackNoRef()
-                ]
-            ]
-        ]
-    ])
-
 let readme = sprintf "https://raw.githubusercontent.com/%s/%s/master/README.md"
 
 let reactExamples (currentPath: string list) =
@@ -1209,11 +628,12 @@ let content = React.functionComponent(fun (input: {| state: State; dispatch: Msg
         |> loadOrSegment [ Urls.PigeonMaps ]
     | PathPrefix [ Urls.Tests ] (Some res) ->
         match res with
-        | [ Urls.CallbackRef ] -> runCallbackTests()
+        | [ Urls.CallbackRef ] -> Tests.runCallbackTests()
         | [ Urls.ElmishComponents ] -> Samples.ElmishComponents.ReplacementTests.counterSwitcher()
-        | [ Urls.FileUpload ] -> fileUpload()
-        | [ Urls.KeyboardKey ] -> keyboardKey()
-        | [ Urls.Refs ] -> focusInputExample()
+        | [ Urls.FileUpload ] -> Tests.fileUpload()
+        | [ Urls.ForwardRef ] -> Examples.forwardRefParent()
+        | [ Urls.KeyboardKey ] -> Tests.keyboardKey()
+        | [ Urls.Refs ] -> Examples.focusInputExample()
         | _ -> React.fragment [ for segment in input.state.CurrentPath -> Html.p segment ]
     | segments -> React.fragment [ for segment in segments -> Html.p segment ])
 

--- a/docs/App.fsproj
+++ b/docs/App.fsproj
@@ -36,6 +36,8 @@
         <Compile Include="PigeonMaps.fs" />
         <Compile Include="Popover.fs" />
         <Compile Include="ElmishComponents.fs" />
+        <Compile Include="Examples.fs" />
+        <Compile Include="Tests.fs" />
         <Compile Include="App.fs" />
     </ItemGroup>
     <PropertyGroup>

--- a/docs/Examples.fs
+++ b/docs/Examples.fs
@@ -1,0 +1,444 @@
+﻿module Examples
+
+open Elmish
+open Feliz
+open Fable.Core
+open Zanaptak.TypedCssClasses
+open System
+
+type Bulma = CssClasses<"https://cdnjs.cloudflare.com/ajax/libs/bulma/0.7.5/css/bulma.min.css", Naming.PascalCase>
+
+type Msg =
+    | Increment
+    | Decrement
+
+let keyedFragments state dispatch =
+    React.keyedFragment(1, [
+        Html.div [
+            React.keyedFragment("hello", [
+                Html.h1 "Hello"
+                Html.div [ ]
+                Html.div [ Html.h1 "More stuff" ]
+                Html.div [ Html.h2 [ Html.strong "Bold" ] ]
+                Html.ul [
+                    Html.li [ Html.strong "Wow" ]
+                    Html.li "So"
+                    Html.li (Html.em "Lightweight")
+                    Html.ol [
+                        Html.li [ Html.strong "More" ]
+                        Html.li [ ]
+                        Html.li [ Html.none ]
+                    ]
+                ]
+            ])
+        ]
+    ])
+
+let inputs state dispatch =
+    Html.form [
+        Html.input [ prop.type'.checkbox ]
+        Html.input [ prop.type' "password" ]
+    ]
+
+let staticHtml = React.functionComponent(fun () ->
+    let html = Html.div [
+        prop.style [ style.padding 20 ]
+        prop.children [
+            Html.h1 "Html content"
+            Html.br [ ]
+        ]
+    ]
+
+
+    Html.pre [
+        Html.text (ReactDOMServer.renderToString html)
+    ])
+
+
+let staticMarkup = React.functionComponent(fun () ->
+    let html = Html.div [
+        prop.style [ style.padding 20 ]
+        prop.children [
+            Html.h1 "Html content"
+            Html.br [ ]
+        ]
+    ]
+
+
+    Html.pre [
+        Html.text (ReactDOMServer.renderToStaticMarkup html)
+    ])
+
+let multipleStateVariables = React.functionComponent(fun () ->
+    let (count, setCount) = React.useState(0)
+    let (textColor, setTextColor) = React.useState(color.red)
+
+    Html.div [
+        Html.h1 [
+            prop.style [ style.color textColor ]
+            prop.text count
+        ]
+
+        Html.button [
+            prop.text "Increment"
+            prop.onClick (fun _ -> setCount(count + 1))
+        ]
+
+        Html.button [
+            prop.text "Red"
+            prop.onClick (fun _ -> setTextColor(color.red))
+        ]
+
+        Html.button [
+            prop.text "Blue"
+            prop.onClick (fun _ -> setTextColor(color.blue))
+        ]
+    ])
+
+let asyncEffect = React.functionComponent(fun () ->
+    let (isLoading, setLoading) = React.useState(false)
+    let (content, setContent) = React.useState("")
+
+    let loadData() = async {
+        setLoading true
+        do! Async.Sleep 1500
+        setLoading false
+        setContent "Content"
+    }
+
+    React.useEffect(loadData >> Async.StartImmediate, [||])
+
+    Html.div [
+        if isLoading
+        then Html.h1 "Loading"
+        else Html.h1 content
+    ])
+
+let asyncEffectOnce = React.functionComponent(fun () ->
+    let (isLoading, setLoading) = React.useState(false)
+    let (content, setContent) = React.useState("")
+
+    let loadData() = async {
+        setLoading true
+        do! Async.Sleep 1500
+        setLoading false
+        setContent "Content"
+    }
+
+    React.useEffectOnce(loadData >> Async.StartImmediate)
+
+    Html.div [
+        if isLoading
+        then Html.h1 "Loading"
+        else Html.h1 content
+    ])
+
+[<Emit("setTimeout($0, $1)")>]
+let setTimeout (f: unit -> unit) (timeout: int) : int = jsNative
+
+[<Emit("clearTimeout($0)")>]
+let clearTimeout (id: int) : unit = jsNative
+
+let timer = React.functionComponent(fun () ->
+    let (paused, setPaused) = React.useState(false)
+    let (value, setValue) = React.useState(0)
+
+    let subscribeToTimer() =
+        // start the ticking
+        let subscriptionId = setTimeout (fun _ -> if not paused then setValue (value + 1)) 1000
+        // return IDisposable with cleanup code
+        { new IDisposable with member this.Dispose() = clearTimeout(subscriptionId) }
+
+    React.useEffect(subscribeToTimer)
+
+    Html.div [
+        Html.h1 value
+
+        Html.button [
+            prop.className [
+                Bulma.Button
+                Bulma.IsLarge
+                if paused then Bulma.IsPrimary else Bulma.IsWarning
+            ]
+
+            prop.onClick (fun _ -> setPaused(not paused))
+            prop.text (if paused then "Resume" else "Pause")
+        ]
+    ])
+
+let rnd = System.Random()
+
+let effectfulUserId = React.functionComponent(fun () ->
+    let (isLoading, setLoading) = React.useState(false)
+    let (content, setContent) = React.useState("")
+    let (userId, setUserId) = React.useState(0)
+    let (textColor, setTextColor) = React.useState(color.red)
+
+    let loadData() = async {
+        setLoading true
+        do! Async.Sleep 1500
+        setLoading false
+        setContent (sprintf "User %d" userId)
+    }
+
+    React.useEffect(loadData >> Async.StartImmediate, [| box userId |])
+
+    Html.div [
+        Html.h1 [
+            prop.style [ style.color textColor ]
+            prop.text (if isLoading then "Loading" else content)
+        ]
+
+        Html.button [
+            prop.text "Red"
+            prop.onClick (fun _ -> setTextColor(color.red))
+        ]
+
+        Html.button [
+            prop.text "Blue"
+            prop.onClick (fun _ -> setTextColor(color.blue))
+        ]
+
+        Html.button [
+            prop.text "Update User ID"
+            prop.onClick (fun _ -> setUserId(rnd.Next(1, 100)))
+        ]
+    ])
+
+let effectfulTabCounter = React.functionComponent(fun () ->
+    let (count, setCount) = React.useState(0)
+
+    // execute this effect on every render cycle
+    React.useEffect(fun () -> Browser.Dom.document.title <- sprintf "Count = %d" count)
+
+    Html.div [
+        Html.h1 count
+        Html.button [
+            prop.text "Increment"
+            prop.onClick (fun _ -> setCount(count + 1))
+        ]
+    ])
+
+let counterApp state dispatch =
+    Html.div [
+        prop.id "main"
+        prop.style [ style.padding 20 ]
+        prop.children [
+
+            Html.button [
+                prop.style [ style.marginRight 5 ]
+                prop.onClick (fun _ -> dispatch Increment)
+                prop.text "Increment"
+            ]
+
+            Html.button [
+                prop.style [ style.marginLeft 5 ]
+                prop.onClick (fun _ -> dispatch Decrement)
+                prop.text "Decrement"
+            ]
+
+            Html.h1 "Count"
+        ]
+    ]
+
+let keyWarnings state dispatch =
+    Html.div [
+        prop.id "id"
+        prop.className ["class"]
+        prop.children [
+            Html.div "text"
+            Html.div [
+                prop.id "id"
+                prop.children [
+                    Html.text "text"
+                    Html.div [
+                        prop.id "id"
+                        prop.className "class"
+                        prop.children [
+                            Html.text "text"
+                            Html.div [
+                                prop.id "id"
+                                prop.className "class"
+                                prop.children [
+                                    Html.text "text"
+                                    Html.div []
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ]
+    ]
+
+let fragmentTests =
+    Html.div [
+        prop.children [
+            React.fragment [
+                Html.h1 "One"
+                Html.h2 "Two"
+            ]
+        ]
+    ]
+
+let animationsOnHover' = React.functionComponent(fun (props: {| content: ReactElement |}) -> [
+    let (hovered, setHovered) = React.useState(false)
+    Html.div [
+        prop.style [
+            style.padding 10
+            style.transitionDuration (TimeSpan.FromMilliseconds 1000.0)
+            style.transitionProperty [
+                transitionProperty.backgroundColor
+                transitionProperty.color
+            ]
+
+            if hovered then
+               style.backgroundColor.lightBlue
+               style.color.black
+            else
+               style.backgroundColor.limeGreen
+               style.color.white
+        ]
+        prop.onMouseEnter (fun _ -> setHovered(true))
+        prop.onMouseLeave (fun _ -> setHovered(false))
+        prop.children [ props.content ]
+    ]
+])
+
+let animationsOnHover content = animationsOnHover' {| content = React.fragment content |}
+let animationSample =
+    Html.div [
+        animationsOnHover [ Html.span "Hover me!" ]
+        animationsOnHover [ Html.p "So smooth" ]
+    ]
+
+module ReactComponents =
+    type Greeting = { Name: string option }
+    let greeting = React.functionComponent(fun (props: Greeting) ->
+        Html.div [
+            Html.span "Hello, "
+            Html.span (Option.defaultValue "World" props.Name)
+        ])
+
+    let simple = Html.div [
+        prop.className "content"
+        prop.children [
+            greeting { Name = Some "John" }
+            greeting { Name = None }
+        ]
+    ]
+
+    let counter = React.functionComponent(fun () ->
+        let (count, setCount) = React.useState(0)
+        Html.div [
+            Html.h1 count
+            Html.button [
+                prop.text "Increment"
+                prop.onClick (fun _ -> setCount(count + 1))
+            ]
+        ])
+
+let counter = React.functionComponent(fun () ->
+    let (count, setCount) = React.useState 0
+
+    let modifyDocumentTitle() =
+        Browser.Dom.window.document.title <- string count
+
+    React.useEffect(modifyDocumentTitle)
+
+    Html.div [
+        Html.h1 count
+        Html.button [
+            prop.text "Increment"
+            prop.onClick (fun _ -> setCount(count + 1))
+        ]
+    ])
+
+[<Emit("setInterval($0, $1)")>]
+let setInterval (f: unit -> unit) (n: int) : int = jsNative
+
+[<Emit("clearInterval($0)")>]
+let clearInterval (n: int) : unit = jsNative
+
+let ticker = React.functionComponent("Ticker", fun (input: {| start: int |}) ->
+    let (tick, setTick) = React.useState input.start
+
+    let tickerEffect() : IDisposable =
+        let interval = setInterval (fun () -> setTick(tick + 1)) 1000
+        React.createDisposable(fun () -> clearInterval(interval))
+
+    React.useEffect(tickerEffect, [| box input.start |])
+
+    Html.div [
+        Html.h1 tick
+    ])
+
+let hooksAreAwesome =
+    React.fragment [
+        counter()
+        Html.hr [ ]
+        ticker {| start = 0 |}
+        Html.hr [ ]
+        ticker {| start = 10 |}
+    ]
+
+module ElmishCounter =
+    type State = { Count : int }
+    type Msg = Increment | Decrement
+
+    let initialState = { Count = 0 }
+
+    let update (state: State) = function
+        | Increment -> { state with Count = state.Count + 1 }
+        | Decrement -> { state with Count = state.Count - 1 }
+
+    let app = React.functionComponent("Counter", fun () ->
+        let (state, dispatch) = React.useReducer(update, initialState)
+        Html.div [
+            Html.button [
+                prop.onClick (fun _ -> dispatch Increment)
+                prop.text "Increment"
+            ]
+
+            Html.button [
+                prop.onClick (fun _ -> dispatch Decrement)
+                prop.text "Decrement"
+            ]
+
+            Html.h1 state.Count
+        ])
+
+let focusInputExample = React.functionComponent(fun () ->
+    let inputRef = React.useInputRef()
+    let focusTextInput() = inputRef.current |> Option.iter (fun el -> el.focus())
+
+    Html.div [
+        Html.input [
+            prop.ref inputRef
+            prop.type'.text
+        ]
+
+        Html.button [
+            prop.onClick (fun _ -> focusTextInput())
+            prop.text "Focus Input"
+        ]
+    ])
+
+let forwardRefChild = React.forwardRef(fun ((), ref) ->
+    Html.input [
+        prop.type'.text
+        prop.ref ref
+    ])
+
+let forwardRefParent = React.functionComponent(fun () ->
+    let inputRef = React.useInputRef()
+
+    Html.div [
+        forwardRefChild((), inputRef)
+        Html.button [
+            prop.text "Focus Input"
+            prop.onClick <| fun ev ->
+                inputRef.current 
+                |> Option.iter (fun elem -> elem.focus())
+        ]
+    ])

--- a/docs/Tests.fs
+++ b/docs/Tests.fs
@@ -1,0 +1,171 @@
+﻿module Tests
+
+open Elmish
+open Feliz
+open Fable.Core
+open System
+open Browser.Types
+
+[<Emit("alert($0)")>]
+let alert s : unit = jsNative
+
+let renderCount = React.functionComponent(fun (input: {| label: string |}) ->
+    let countRef = React.useRef 0
+        
+    let mutable currentCount = countRef.current
+
+    React.useEffect(fun () -> countRef.current <- currentCount)
+
+    currentCount <- currentCount + 1
+
+    Html.div [
+        prop.text (sprintf "%s render count: %i" input.label currentCount)
+    ])
+
+let callbackRefButton = React.memo(fun (input: {| onClick: unit -> unit |}) ->
+    Html.div [
+        renderCount {| label = "Button" |}
+        Html.button [
+            prop.onClick <| fun _ -> input.onClick()
+            prop.text "Show renders"
+        ]
+    ])
+
+let callbackRef = React.functionComponent(fun () -> 
+    let count,setCount = React.useState 1
+
+    React.useEffect((fun () ->
+        let interval = JS.setInterval(fun () -> setCount(count + 1)) 1000
+        React.createDisposable(fun () -> JS.clearInterval(interval))
+    ), [| count :> obj |])
+
+    let showCount = React.useCallbackRef(fun () -> alert count)
+
+    Html.div [
+        renderCount {| label = "Main" |}
+        callbackRefButton {| onClick = showCount |}
+    ])
+
+let callbackNoRef = React.functionComponent(fun () -> 
+    let count,setCount = React.useState 1
+
+    React.useEffect((fun () ->
+        let interval = JS.setInterval(fun () -> setCount(count + 1)) 1000
+        React.createDisposable(fun () -> JS.clearInterval(interval))
+    ), [| count :> obj |])
+
+    let showCount = React.useCallback(fun () -> alert count)
+
+    Html.div [
+        renderCount {| label = "Main" |}
+        callbackRefButton {| onClick = showCount |}
+    ])
+
+let runCallbackTests = React.functionComponent(fun () ->
+    Html.div [
+        prop.style [ 
+            style.display.inheritFromParent
+        ]
+        prop.children [
+            Html.div [
+                prop.style [
+                    style.paddingRight (length.em 10)
+                ]
+                prop.children [
+                    Html.h1 [
+                        prop.style [
+                            style.paddingBottom (length.em 2)
+                        ]
+                        prop.text "Using callbackRef"
+                    ]
+                    callbackRef()
+                ]
+            ]
+            Html.div [
+                prop.style [
+                    style.paddingRight (length.em 10)
+                ]
+                prop.children [
+                    Html.h1 [
+                        prop.style [
+                            style.paddingBottom (length.em 2)
+                        ]
+                        prop.text "Using callback"
+                    ]
+                    callbackNoRef()
+                ]
+            ]
+        ]
+    ])
+
+let fileUpload = React.functionComponent(fun () -> [
+    Html.div [
+        Html.h1 "Single File Selection"
+        Html.input [
+            prop.type'.file
+            prop.onChange (fun (file: File) -> Browser.Dom.console.log(file))
+        ]
+
+        Html.h1 "Multi-File Selection"
+        Html.input [
+            prop.type'.file
+            prop.multiple true
+            prop.onChange (fun (files: File list) -> Browser.Dom.console.log(Array.ofList files))
+        ]
+    ]
+])
+
+
+let keyboardKey = React.functionComponent(fun () -> [
+    let (keyPressed, setKeyPressed) = React.useState("")
+
+    let update() = setKeyPressed (sprintf "Key 'Enter' presssed at %s" (DateTime.Now.ToString("hh:mm:ss")))
+
+    Html.div [
+        Html.h3 "Handling ENTER"
+        Html.input [
+            prop.onKeyUp(key.enter, fun ev -> update())
+        ]
+
+        Html.h3 "Handling SHIFT + ENTER"
+        Html.input [
+            prop.onKeyUp(key.shift(key.enter), fun ev -> update())
+        ]
+
+        Html.h3 "Handling CTRL + ENTER"
+        Html.input [
+            prop.onKeyUp(key.ctrl(key.enter), fun ev -> update())
+        ]
+
+        Html.h3 "Handling CTRL + SHIFT + ENTER"
+
+        Html.input [
+            prop.onKeyUp(key.ctrlAndShift(key.enter), fun ev -> update())
+        ]
+
+        Html.h1 keyPressed
+    ]
+])
+
+let fullFocusInputExample = React.functionComponent(fun () ->
+    // obtain a reference
+    let inputRef = React.useRef(None)
+
+    let focusTextInput() =
+        match inputRef.current with
+        | None -> ()
+        | Some element ->
+            let inputElement = unbox<HTMLInputElement> element
+            inputElement.focus()
+
+    Html.div [
+        Html.input [
+            prop.ref inputRef
+            prop.type'.text
+        ]
+
+        Html.button [
+            prop.onClick (fun _ -> focusTextInput())
+            prop.text "Focus Input"
+        ]
+    ])

--- a/docs/Urls.fs
+++ b/docs/Urls.fs
@@ -102,5 +102,6 @@ let [<Literal>] Tests = "Tests"
 
 let [<Literal>] Bulma = "Bulma"
 let [<Literal>] FileUpload = "FileUpload"
+let [<Literal>] ForwardRef = "ForwardRef"
 let [<Literal>] KeyboardKey = "KeyboardKey"
 let [<Literal>] CallbackRef = "CallbackRef"

--- a/public/Feliz/React/UsingReferences.md
+++ b/public/Feliz/React/UsingReferences.md
@@ -54,3 +54,32 @@ let focusInputExample = React.functionComponent(fun () ->
         ]
     ])
 ```
+
+#### Forwarding Refs
+
+You can also use `React.forwardRef` for passing refs to children components.
+
+In most cases the above examples will suit your needs, but in some use-cases such as creating libraries for reusable components, it can be useful.
+
+For more information see the React docs on [forwarding refs](https://reactjs.org/docs/forwarding-refs.html).
+
+```fs:forward-ref-example
+let forwardRefChild = React.forwardRef(fun ((), ref) ->
+    Html.input [
+        prop.type'.text
+        prop.ref ref
+    ])
+
+let forwardRefParent = React.functionComponent(fun () ->
+    let inputRef = React.useInputRef()
+
+    Html.div [
+        forwardRefChild((), inputRef)
+        Html.button [
+            prop.text "Focus Input"
+            prop.onClick <| fun ev ->
+                inputRef.current 
+                |> Option.iter (fun elem -> elem.focus())
+        ]
+    ])
+```

--- a/tests/Tests.fs
+++ b/tests/Tests.fs
@@ -151,7 +151,7 @@ let focusInputExample = React.functionComponent(fun () ->
         ]
     ])
 
-let forwardRefChild = React.forwardRef(fun ((), ref) ->
+let forwardRefChild = React.forwardRef("forwardChild", fun ((), ref) ->
     Html.div [
         prop.children [
             Html.input [

--- a/tests/Tests.fs
+++ b/tests/Tests.fs
@@ -151,6 +151,33 @@ let focusInputExample = React.functionComponent(fun () ->
         ]
     ])
 
+let forwardRefChild = React.forwardRef(fun ((), ref) ->
+    Html.div [
+        prop.children [
+            Html.input [
+                prop.testId "focus-input"
+                prop.type'.text
+                prop.ref ref
+            ]
+        ]
+    ])
+
+let forwardRefParent = React.functionComponent(fun () ->
+    let inputRef = React.useInputRef()
+
+    Html.div [
+        prop.children [
+            forwardRefChild((), inputRef)
+            Html.button [
+                prop.testId "focus-button"
+                prop.text "Click!"
+                prop.onClick <| fun ev ->
+                    inputRef.current 
+                    |> Option.iter (fun elem -> elem.focus())
+            ]
+        ]
+    ])
+
 let felizTests = testList "Feliz Tests" [
 
     testCase "Html elements can be rendered" <| fun _ ->
@@ -281,6 +308,16 @@ let felizTests = testList "Feliz Tests" [
         Expect.isTrue (buttonField.innerText = "1") "Child component has not re-rendered"
         Expect.isTrue (parentField.innerText <> "1") "Parent component has re-rendered"
         Expect.isTrue (mainField.innerText <> "1" && mainField.innerText <> "") "Count was updated by child component"
+    }
+
+    testReactAsync "forwardRef works correctly" <| async {
+        let render = RTL.render(forwardRefParent())
+        let button = render.getByTestId "focus-button"
+        let input = render.getByTestId "focus-input"
+
+        Expect.isFalse (input = unbox document.activeElement) "Input is not focused yet before clicking button"
+        do! RTL.waitFor(fun () -> RTL.userEvent.click(button)) |> Async.AwaitPromise
+        Expect.isTrue (input = unbox document.activeElement) "Input is now active"
     }
 ]
 


### PR DESCRIPTION
Adds the `React.forwardRef` feature.

I also separated out some of the examples and test functions from the main `App.fs` so it's a bit easier to navigate.

Partial work towards #127
Should also un-block #50 for `useImperativeHandle`