### PR TITLE
Fix forwardRef

### DIFF
--- a/Feliz/React.fs
+++ b/Feliz/React.fs
@@ -6,11 +6,11 @@ open Fable.Core.JsInterop
 open Browser.Types
 
 module internal ReactInterop =
-    let useEffectWithDeps (effect:  obj) (deps: obj) : unit = import "useEffectWithDeps" "./ReactInterop.js"
-    let useEffect (effect: obj) : unit =  import "useEffect" "./ReactInterop.js"
-    let useLayoutEffectWithDeps (effect:  obj) (deps: obj) : unit = import "useLayoutEffectWithDeps" "./ReactInterop.js"
-    let useLayoutEffect (effect: obj) : unit =  import "useLayoutEffect" "./ReactInterop.js"
     let useDebugValueWithFormatter<'t>(value: 't, formatter: 't -> string) : unit = import "useDebugValue" "./ReactInterop.js"
+    let useEffect (effect: obj) : unit =  import "useEffect" "./ReactInterop.js"
+    let useEffectWithDeps (effect:  obj) (deps: obj) : unit = import "useEffectWithDeps" "./ReactInterop.js"
+    let useLayoutEffect (effect: obj) : unit =  import "useLayoutEffect" "./ReactInterop.js"
+    let useLayoutEffectWithDeps (effect:  obj) (deps: obj) : unit = import "useLayoutEffectWithDeps" "./ReactInterop.js"
 
 type internal Internal() =
     static let propsWithKey (withKey: ('props -> string) option) props =
@@ -514,9 +514,9 @@ type React =
     /// </summary>
     /// <param name='render'>A render function that returns an element.</param>
     static member forwardRef(render: ('Props * IRefValue<#HTMLElement option> -> ReactElement)) : ('Props * IRefValue<#HTMLElement option> -> ReactElement) = 
-        let forwardRefType = Interop.reactApi.forwardRef(render)
-        fun props ->
-            Interop.reactApi.createElement(forwardRefType, props)
+        let forwardRefType = Interop.reactApi.forwardRef(Func<'Props,IRefValue<#HTMLElement option>,ReactElement> (fun props ref -> render(props,ref)))
+        fun (props, ref) ->
+            Interop.reactApi.createElement(forwardRefType, {| props = props; ref = ref |} |> JsInterop.toPlainJsObj)
 
     /// <summary>
     /// Forwards a given ref, allowing you to pass it further down to a child.
@@ -524,8 +524,7 @@ type React =
     /// <param name='name'>The component name to display in the React dev tools.</param>
     /// <param name='render'>A render function that returns an element.</param>
     static member forwardRef(name: string, render: ('Props * IRefValue<#HTMLElement option> -> ReactElement)) : ('Props * IRefValue<#HTMLElement option> -> ReactElement) = 
-        let forwardRefType = Interop.reactApi.forwardRef(render)
+        let forwardRefType = Interop.reactApi.forwardRef(Func<'Props,IRefValue<#HTMLElement option>,ReactElement> (fun props ref -> render(props,ref)))
         render?displayName <- name
-        fun props ->
-            Interop.reactApi.createElement(forwardRefType, props)
-
+        fun (props, ref) ->
+            Interop.reactApi.createElement(forwardRefType, {| props = props; ref = ref |} |> JsInterop.toPlainJsObj)

--- a/Feliz/ReactTypes.fs
+++ b/Feliz/ReactTypes.fs
@@ -1,25 +1,27 @@
 module Feliz.ReactApi
 
+open Browser.Types
 open Fable.React
 open Fable.Core
+open System
 
 type ReactChildren =
     abstract toArray: ReactElement -> ReactElement seq
     abstract toArray: ReactElement seq -> ReactElement seq
 
 type IReactApi =
-    abstract useState<'t> : initial:'t -> ('t * ('t -> unit))
-    abstract useRef<'t> : initial: 't -> Fable.React.IRefValue<'t>
-    abstract useReducer : ('state -> 'msg -> 'state) -> 'state -> ('state * ('msg -> unit))
+    abstract Children : ReactChildren
+    abstract createContext: defaultValue: 'a -> IContext<'a>
+    abstract createElement: comp: obj * props: obj -> ReactElement
+    abstract createElement: comp: obj * props: obj * [<ParamList>] children: ReactElement seq -> ReactElement
+    abstract forwardRef : render: Func<'Props,IRefValue<#HTMLElement option>,ReactElement> -> ('props -> IRefValue<'ref option> -> ReactElement)
+    abstract memo: render: ('props -> ReactElement) * areEqual: ('props -> 'props -> bool) -> ('props -> ReactElement)
+    abstract useCallback : callbackFunction: ('a -> 'b) -> dependencies: obj array -> ('a -> 'b)
+    abstract useContext: ctx: IContext<'a> -> 'a
     abstract useEffect : obj * 't array -> unit
     abstract useEffect : obj -> unit
     abstract useEffect : (unit -> unit) -> unit
-    abstract createElement: comp: obj * props: obj -> ReactElement
-    abstract createElement: comp: obj * props: obj * [<ParamList>] children: ReactElement seq -> ReactElement
-    abstract Children : ReactChildren
-    abstract useCallback : callbackFunction: ('a -> 'b) -> dependencies: obj array -> ('a -> 'b)
     abstract useMemo : createFunction: (unit -> 'a) -> dependencies: obj array -> 'a
-    abstract memo: render: ('props -> ReactElement) * areEqual: ('props -> 'props -> bool) -> ('props -> ReactElement)
-    abstract createContext: defaultValue: 'a -> IContext<'a>
-    abstract useContext: ctx: IContext<'a> -> 'a
-    abstract forwardRef : render: ('props * IRefValue<'ref option> -> ReactElement) -> ('props -> IRefValue<'ref option> -> ReactElement)
+    abstract useReducer : ('state -> 'msg -> 'state) -> 'state -> ('state * ('msg -> unit))
+    abstract useRef<'t> : initial: 't -> Fable.React.IRefValue<'t>
+    abstract useState<'t> : initial:'t -> ('t * ('t -> unit))


### PR DESCRIPTION
While I was starting work on `StrictMode` I noticed that forwardRef was actually just sending the ref over as a prop, and printing a warning asking `did you forget to provide the ref?`. This PR fixes that.