### PR TITLE
Provide default fallback for suspense

### DIFF
--- a/Feliz/React.fs
+++ b/Feliz/React.fs
@@ -422,7 +422,7 @@ type React =
     /// </summary>
     /// <param name='children'>The elements that will be rendered within the suspense block.</param>
     static member suspense(children: ReactElement list) =
-        Interop.reactApi.createElement(Interop.reactApi.Suspense, None, children)
+        Interop.reactApi.createElement(Interop.reactApi.Suspense, {| fallback = Html.none |} |> JsInterop.toPlainJsObj, children)
     /// <summary>
     /// Lets you specify a loading indicator whenever a child element is not yet ready 
     /// to render.


### PR DESCRIPTION
Makes the suspense usage better when a fallback isn't provided.

![suspense](https://user-images.githubusercontent.com/11186595/82510237-b8f20d00-9acf-11ea-8894-0e923b605694.gif)
