### PR TITLE
Add Html.textf

### DIFF
--- a/Feliz/Html.fs
+++ b/Feliz/Html.fs
@@ -712,6 +712,8 @@ type Html =
     static member inline text (value: string) : ReactElement = unbox value
     static member inline text (value: System.Guid) : ReactElement = unbox (string value)
 
+    static member inline textf fmt = Printf.kprintf Html.text fmt
+    
     static member inline textarea xs = Interop.createElement "textarea" xs
     static member inline textarea (children: #seq<ReactElement>) = Interop.reactElementWithChildren "textarea" children
     

--- a/tests/Tests.fs
+++ b/tests/Tests.fs
@@ -405,6 +405,36 @@ let textfComp = React.functionComponent(fun (input: {| str: string; i: int |}) -
         ]
     ])
 
+let htmlTextfComp = React.functionComponent(fun (input: {| str: string; i: int |}) ->
+    Html.div [
+        prop.children [
+            Html.div [
+                prop.testId "textf-str"
+                prop.children [
+                    Html.textf "Hello! %s" input.str
+                ]
+            ]
+            Html.div [
+                prop.testId "textf-int"
+                prop.children [
+                    Html.textf "Hello! %i" input.i
+                ]
+            ]
+            Html.div [
+                prop.testId "textf-two"
+                prop.children [
+                    Html.textf "Hello! %s %i" input.str input.i
+                ]
+            ]
+            Html.div [
+                prop.testId "textf-three"
+                prop.children [
+                    Html.textf "Hello! %s %i %s" input.str input.i (input.str + (string input.i))
+                ]
+            ]
+        ]
+    ])
+
 let felizTests = testList "Feliz Tests" [
 
     testCase "Html elements can be rendered" <| fun _ ->
@@ -658,6 +688,15 @@ let felizTests = testList "Feliz Tests" [
     testReact "can use string format as prop" <| fun _ ->
         let input = {| str = "hello"; i = 1 |}
         let render = RTL.render(textfComp input)
+
+        Expect.isTrue (render.getByTestId("textf-str").innerText = (sprintf "Hello! %s" input.str)) "Correctly accepts single string parameter"
+        Expect.isTrue (render.getByTestId("textf-int").innerText = (sprintf "Hello! %i" input.i)) "Correctly accepts single int parameter"
+        Expect.isTrue (render.getByTestId("textf-two").innerText = (sprintf "Hello! %s %i" input.str input.i)) "Correctly accepts two parameters"
+        Expect.isTrue (render.getByTestId("textf-three").innerText = (sprintf "Hello! %s %i %s" input.str input.i (input.str + (string input.i)))) "Correctly accepts three parameters"
+
+    testReact "can use string format directly from Html" <| fun _ ->
+        let input = {| str = "hello"; i = 1 |}
+        let render = RTL.render(htmlTextfComp input)
 
         Expect.isTrue (render.getByTestId("textf-str").innerText = (sprintf "Hello! %s" input.str)) "Correctly accepts single string parameter"
         Expect.isTrue (render.getByTestId("textf-int").innerText = (sprintf "Hello! %i" input.i)) "Correctly accepts single int parameter"


### PR DESCRIPTION
This one is shamelessly stolen from https://github.com/Zaid-Ajaj/Feliz/pull/213, as I noticed that I am using `sprintf` not only for props, but also for `Html.text`:

```fs
let render state _ =
    Html.div [
        Html.text (sprintf "Hello, %s! Go ahead and " state.Session.User)
        Html.a [ ... ]
        Html.text " your name."
    ]
```

This can now become

```fs
    Html.div [
        Html.textf "Hello, %s! Go ahead and " state.Session.User
        Html.a [ ... ]
        Html.text " your name."
    ]
```

I took over the tests, as it seems to make sense to test for the same cases (although the test arrangement with `Html.textf` within the children of another element is artificial).