### PR TITLE
Fix React state update bug

### DIFF
--- a/Feliz.UseElmish/UseElmish.fs
+++ b/Feliz.UseElmish/UseElmish.fs
@@ -60,8 +60,12 @@ module UseElmishExtensions =
             let state = React.useRef(fst init)
             let ring = React.useRef(RingBuffer(10))
             let childState, setChildState = React.useState(fst init)
-            let setChildState () = JS.setTimeout(fun () -> setChildState state.current) 0 |> ignore
             let token = React.useCancellationToken()
+            let setChildState () = 
+                JS.setTimeout(fun () ->
+                    if not token.current.IsCancellationRequested then
+                        setChildState state.current
+                ) 0 |> ignore
 
             let rec dispatch (msg: 'Msg) =
                 promise {


### PR DESCRIPTION
Prevents a state update when the component does not wait for the update function to finish (such as a `Cmd` itself being the reason for the unmount).

If a component immediately unmounts during a dispatch, React throws `Can't perform a React state update on an unmounted component`. Checking if the token has requested a cancellation prevents this.