### PR TITLE
Fix template

### DIFF
--- a/Feliz.Template/Feliz.Template.proj
+++ b/Feliz.Template/Feliz.Template.proj
@@ -15,6 +15,8 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
     <PackageReleaseNotes>Update dependencies</PackageReleaseNotes>
+    <!-- https://github.com/dotnet/templating/issues/2350#issuecomment-610431461 -->
+    <NoDefaultExcludes>true</NoDefaultExcludes>
   </PropertyGroup>
   <PropertyGroup>
     <ExcludeFromPackage>


### PR DESCRIPTION
Apparently, .gitignore and .gitattributes are not part of the template, so this is a quick fix to remove the broken references from App.sln.