### PR TITLE
Adds support for IDisposable option overloads

### DIFF
--- a/Feliz.UseElmish/UseElmish.fs
+++ b/Feliz.UseElmish/UseElmish.fs
@@ -83,10 +83,7 @@ module UseElmishExtensions =
 
             let dispatch = React.useCallbackRef(dispatch)
 
-            React.useEffectOnce(fun () ->
-                React.createDisposable <| fun () ->
-                    getDisposable state.current
-                    |> Option.iter (fun o -> o.Dispose()))
+            React.useEffectOnce(fun () -> getDisposable state.current)
 
             React.useEffect((fun () ->
                 state.current <- fst init

--- a/docs/App.fsproj
+++ b/docs/App.fsproj
@@ -1,57 +1,57 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
-    </PropertyGroup>
-    <ItemGroup>
-        <ProjectReference Include="..\Feliz\Feliz.fsproj" />
-        <ProjectReference Include="..\Feliz.Recharts\Feliz.Recharts.fsproj" />
-        <ProjectReference Include="..\Feliz.Markdown\Feliz.Markdown.fsproj" />
-        <ProjectReference Include="..\Feliz.PigeonMaps\Feliz.PigeonMaps.fsproj" />
-        <ProjectReference Include="..\Feliz.Popover\Feliz.Popover.fsproj" />
-        <ProjectReference Include="..\Feliz.UseDeferred\Feliz.UseDeferred.fsproj" />
-        <ProjectReference Include="..\Feliz.ElmishComponents\Feliz.ElmishComponents.fsproj" />
-        <ProjectReference Include="..\Feliz.RoughViz\Feliz.RoughViz.fsproj" />
-    </ItemGroup>
-    <ItemGroup>
-        <Compile Include="Urls.fs" />
-        <Compile Include="Recharts\AreaCharts\AreaChartFillByValue.fs" />
-        <Compile Include="Recharts/AreaCharts/SynchronizedAreaChart.fs" />
-        <Compile Include="Recharts/AreaCharts/Main.fs" />
-        <Compile Include="Recharts/AreaCharts/SimpleAreaChart.fs" />
-        <Compile Include="Recharts/AreaCharts/StackedAreaChart.fs" />
-        <Compile Include="Recharts/AreaCharts/TinyAreaChart.fs" />
-        <Compile Include="Recharts/AreaCharts/ResponsiveFullWidth.fs" />
-        <Compile Include="Recharts/AreaCharts/OptionalValues.fs" />
-        <Compile Include="Recharts/LineCharts/SimpleLineChart.fs" />
-        <Compile Include="Recharts/LineCharts/ResponsiveFullWidth.fs" />
-        <Compile Include="Recharts/LineCharts/CustomizedLabelLineChart.fs" />
-        <Compile Include="Recharts/LineCharts/OptionalValues.fs" />
-        <Compile Include="Recharts/LineCharts/BiaxialLineChart.fs" />
-        <Compile Include="Recharts/BarCharts/SimpleBarChart.fs" />
-        <Compile Include="Recharts/BarCharts/StackedBarChart.fs" />
-        <Compile Include="Recharts/BarCharts/MixBarChart.fs" />
-        <Compile Include="Recharts/BarCharts/TinyBarChart.fs" />
-        <Compile Include="Recharts/BarCharts/PositiveAndNegative.fs" />
-        <Compile Include="Recharts/PieCharts/CustomizedLabelPieChart.fs" />
-        <Compile Include="Recharts/PieCharts/TwoLevelPieChart.fs" />
-        <Compile Include="Recharts/PieCharts/StraightAngle.fs" />
-        <Compile Include="PigeonMaps.fs" />
-        <Compile Include="Popover.fs" />
-        <Compile Include="ElmishComponents.fs" />
-        <Compile Include="CodeSplitting.fs" />
-        <Compile Include="FPSCounter.fs" />
-        <Compile Include="DelayedComponent.fs" />
-        <Compile Include="UseDeferredExamples.fs" />
-        <Compile Include="UseElmishExamples.fs" />
-        <Compile Include="Examples.fs" />
-        <Compile Include="Tests.fs" />
-        <Compile Include="App.fs" />
-    </ItemGroup>
-    <ItemGroup />
-    <PropertyGroup>
-        <NpmDependencies>
-            <NpmPackage Name="react-highlight" Version="&gt;= 0.11.1" />
-        </NpmDependencies>
-    </PropertyGroup>
-    <Import Project="..\.paket\Paket.Restore.targets" />
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Feliz\Feliz.fsproj" />
+    <ProjectReference Include="..\Feliz.Recharts\Feliz.Recharts.fsproj" />
+    <ProjectReference Include="..\Feliz.Markdown\Feliz.Markdown.fsproj" />
+    <ProjectReference Include="..\Feliz.PigeonMaps\Feliz.PigeonMaps.fsproj" />
+    <ProjectReference Include="..\Feliz.Popover\Feliz.Popover.fsproj" />
+    <ProjectReference Include="..\Feliz.UseDeferred\Feliz.UseDeferred.fsproj" />
+    <ProjectReference Include="..\Feliz.ElmishComponents\Feliz.ElmishComponents.fsproj" />
+    <ProjectReference Include="..\Feliz.RoughViz\Feliz.RoughViz.fsproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Urls.fs" />
+    <Compile Include="Recharts\AreaCharts\AreaChartFillByValue.fs" />
+    <Compile Include="Recharts/AreaCharts/SynchronizedAreaChart.fs" />
+    <Compile Include="Recharts/AreaCharts/Main.fs" />
+    <Compile Include="Recharts/AreaCharts/SimpleAreaChart.fs" />
+    <Compile Include="Recharts/AreaCharts/StackedAreaChart.fs" />
+    <Compile Include="Recharts/AreaCharts/TinyAreaChart.fs" />
+    <Compile Include="Recharts/AreaCharts/ResponsiveFullWidth.fs" />
+    <Compile Include="Recharts/AreaCharts/OptionalValues.fs" />
+    <Compile Include="Recharts/LineCharts/SimpleLineChart.fs" />
+    <Compile Include="Recharts/LineCharts/ResponsiveFullWidth.fs" />
+    <Compile Include="Recharts/LineCharts/CustomizedLabelLineChart.fs" />
+    <Compile Include="Recharts/LineCharts/OptionalValues.fs" />
+    <Compile Include="Recharts/LineCharts/BiaxialLineChart.fs" />
+    <Compile Include="Recharts/BarCharts/SimpleBarChart.fs" />
+    <Compile Include="Recharts/BarCharts/StackedBarChart.fs" />
+    <Compile Include="Recharts/BarCharts/MixBarChart.fs" />
+    <Compile Include="Recharts/BarCharts/TinyBarChart.fs" />
+    <Compile Include="Recharts/BarCharts/PositiveAndNegative.fs" />
+    <Compile Include="Recharts/PieCharts/CustomizedLabelPieChart.fs" />
+    <Compile Include="Recharts/PieCharts/TwoLevelPieChart.fs" />
+    <Compile Include="Recharts/PieCharts/StraightAngle.fs" />
+    <Compile Include="PigeonMaps.fs" />
+    <Compile Include="Popover.fs" />
+    <Compile Include="ElmishComponents.fs" />
+    <Compile Include="CodeSplitting.fs" />
+    <Compile Include="FPSCounter.fs" />
+    <Compile Include="DelayedComponent.fs" />
+    <Compile Include="UseDeferredExamples.fs" />
+    <Compile Include="UseElmishExamples.fs" />
+    <Compile Include="Examples.fs" />
+    <Compile Include="Tests.fs" />
+    <Compile Include="App.fs" />
+  </ItemGroup>
+  <PropertyGroup>
+    <NpmDependencies>
+      <NpmPackage Name="react-highlight" Version="&gt;= 0.11.1" />
+    </NpmDependencies>
+  </PropertyGroup>
+  <Import Project="..\.paket\Paket.Restore.targets" />
 </Project>

--- a/package-lock.json
+++ b/package-lock.json
@@ -3,28 +3,28 @@
     "lockfileVersion": 1,
     "dependencies": {
         "@babel/code-frame": {
-            "version": "7.10.1",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
-            "integrity": "sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+            "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
             "dev": true,
             "requires": {
-                "@babel/highlight": "^7.10.1"
+                "@babel/highlight": "^7.10.4"
             }
         },
         "@babel/core": {
-            "version": "7.10.2",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.10.2.tgz",
-            "integrity": "sha512-KQmV9yguEjQsXqyOUGKjS4+3K8/DlOCE2pZcq4augdQmtTy5iv5EHtmMSJ7V4c1BIPjuwtZYqYLCq9Ga+hGBRQ==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.10.4.tgz",
+            "integrity": "sha512-3A0tS0HWpy4XujGc7QtOIHTeNwUgWaZc/WuS5YQrfhU67jnVmsD6OGPc1AKHH0LJHQICGncy3+YUjIhVlfDdcA==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.10.1",
-                "@babel/generator": "^7.10.2",
-                "@babel/helper-module-transforms": "^7.10.1",
-                "@babel/helpers": "^7.10.1",
-                "@babel/parser": "^7.10.2",
-                "@babel/template": "^7.10.1",
-                "@babel/traverse": "^7.10.1",
-                "@babel/types": "^7.10.2",
+                "@babel/code-frame": "^7.10.4",
+                "@babel/generator": "^7.10.4",
+                "@babel/helper-module-transforms": "^7.10.4",
+                "@babel/helpers": "^7.10.4",
+                "@babel/parser": "^7.10.4",
+                "@babel/template": "^7.10.4",
+                "@babel/traverse": "^7.10.4",
+                "@babel/types": "^7.10.4",
                 "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.1",
@@ -36,264 +36,264 @@
             }
         },
         "@babel/generator": {
-            "version": "7.10.2",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.2.tgz",
-            "integrity": "sha512-AxfBNHNu99DTMvlUPlt1h2+Hn7knPpH5ayJ8OqDWSeLld+Fi2AYBTC/IejWDM9Edcii4UzZRCsbUt0WlSDsDsA==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.4.tgz",
+            "integrity": "sha512-toLIHUIAgcQygFZRAQcsLQV3CBuX6yOIru1kJk/qqqvcRmZrYe6WavZTSG+bB8MxhnL9YPf+pKQfuiP161q7ng==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.10.2",
+                "@babel/types": "^7.10.4",
                 "jsesc": "^2.5.1",
                 "lodash": "^4.17.13",
                 "source-map": "^0.5.0"
             }
         },
         "@babel/helper-annotate-as-pure": {
-            "version": "7.10.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.1.tgz",
-            "integrity": "sha512-ewp3rvJEwLaHgyWGe4wQssC2vjks3E80WiUe2BpMb0KhreTjMROCbxXcEovTrbeGVdQct5VjQfrv9EgC+xMzCw==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.4.tgz",
+            "integrity": "sha512-XQlqKQP4vXFB7BN8fEEerrmYvHp3fK/rBkRFz9jaJbzK0B1DSfej9Kc7ZzE8Z/OnId1jpJdNAZ3BFQjWG68rcA==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.10.1"
+                "@babel/types": "^7.10.4"
             }
         },
         "@babel/helper-builder-react-jsx": {
-            "version": "7.10.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.10.1.tgz",
-            "integrity": "sha512-KXzzpyWhXgzjXIlJU1ZjIXzUPdej1suE6vzqgImZ/cpAsR/CC8gUcX4EWRmDfWz/cs6HOCPMBIJ3nKoXt3BFuw==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.10.4.tgz",
+            "integrity": "sha512-5nPcIZ7+KKDxT1427oBivl9V9YTal7qk0diccnh7RrcgrT/pGFOjgGw1dgryyx1GvHEpXVfoDF6Ak3rTiWh8Rg==",
             "dev": true,
             "requires": {
-                "@babel/helper-annotate-as-pure": "^7.10.1",
-                "@babel/types": "^7.10.1"
+                "@babel/helper-annotate-as-pure": "^7.10.4",
+                "@babel/types": "^7.10.4"
             }
         },
         "@babel/helper-builder-react-jsx-experimental": {
-            "version": "7.10.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx-experimental/-/helper-builder-react-jsx-experimental-7.10.1.tgz",
-            "integrity": "sha512-irQJ8kpQUV3JasXPSFQ+LCCtJSc5ceZrPFVj6TElR6XCHssi3jV8ch3odIrNtjJFRZZVbrOEfJMI79TPU/h1pQ==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx-experimental/-/helper-builder-react-jsx-experimental-7.10.4.tgz",
+            "integrity": "sha512-LyacH/kgQPgLAuaWrvvq1+E7f5bLyT8jXCh7nM67sRsy2cpIGfgWJ+FCnAKQXfY+F0tXUaN6FqLkp4JiCzdK8Q==",
             "dev": true,
             "requires": {
-                "@babel/helper-annotate-as-pure": "^7.10.1",
-                "@babel/helper-module-imports": "^7.10.1",
-                "@babel/types": "^7.10.1"
+                "@babel/helper-annotate-as-pure": "^7.10.4",
+                "@babel/helper-module-imports": "^7.10.4",
+                "@babel/types": "^7.10.4"
             }
         },
         "@babel/helper-function-name": {
-            "version": "7.10.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.1.tgz",
-            "integrity": "sha512-fcpumwhs3YyZ/ttd5Rz0xn0TpIwVkN7X0V38B9TWNfVF42KEkhkAAuPCQ3oXmtTRtiPJrmZ0TrfS0GKF0eMaRQ==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+            "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-get-function-arity": "^7.10.1",
-                "@babel/template": "^7.10.1",
-                "@babel/types": "^7.10.1"
+                "@babel/helper-get-function-arity": "^7.10.4",
+                "@babel/template": "^7.10.4",
+                "@babel/types": "^7.10.4"
             }
         },
         "@babel/helper-get-function-arity": {
-            "version": "7.10.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.1.tgz",
-            "integrity": "sha512-F5qdXkYGOQUb0hpRaPoetF9AnsXknKjWMZ+wmsIRsp5ge5sFh4c3h1eH2pRTTuy9KKAA2+TTYomGXAtEL2fQEw==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+            "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.10.1"
+                "@babel/types": "^7.10.4"
             }
         },
         "@babel/helper-member-expression-to-functions": {
-            "version": "7.10.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.1.tgz",
-            "integrity": "sha512-u7XLXeM2n50gb6PWJ9hoO5oO7JFPaZtrh35t8RqKLT1jFKj9IWeD1zrcrYp1q1qiZTdEarfDWfTIP8nGsu0h5g==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.4.tgz",
+            "integrity": "sha512-m5j85pK/KZhuSdM/8cHUABQTAslV47OjfIB9Cc7P+PvlAoBzdb79BGNfw8RhT5Mq3p+xGd0ZfAKixbrUZx0C7A==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.10.1"
+                "@babel/types": "^7.10.4"
             }
         },
         "@babel/helper-module-imports": {
-            "version": "7.10.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.1.tgz",
-            "integrity": "sha512-SFxgwYmZ3HZPyZwJRiVNLRHWuW2OgE5k2nrVs6D9Iv4PPnXVffuEHy83Sfx/l4SqF+5kyJXjAyUmrG7tNm+qVg==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
+            "integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.10.1"
+                "@babel/types": "^7.10.4"
             }
         },
         "@babel/helper-module-transforms": {
-            "version": "7.10.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.1.tgz",
-            "integrity": "sha512-RLHRCAzyJe7Q7sF4oy2cB+kRnU4wDZY/H2xJFGof+M+SJEGhZsb+GFj5j1AD8NiSaVBJ+Pf0/WObiXu/zxWpFg==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.4.tgz",
+            "integrity": "sha512-Er2FQX0oa3nV7eM1o0tNCTx7izmQtwAQsIiaLRWtavAAEcskb0XJ5OjJbVrYXWOTr8om921Scabn4/tzlx7j1Q==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-imports": "^7.10.1",
-                "@babel/helper-replace-supers": "^7.10.1",
-                "@babel/helper-simple-access": "^7.10.1",
-                "@babel/helper-split-export-declaration": "^7.10.1",
-                "@babel/template": "^7.10.1",
-                "@babel/types": "^7.10.1",
+                "@babel/helper-module-imports": "^7.10.4",
+                "@babel/helper-replace-supers": "^7.10.4",
+                "@babel/helper-simple-access": "^7.10.4",
+                "@babel/helper-split-export-declaration": "^7.10.4",
+                "@babel/template": "^7.10.4",
+                "@babel/types": "^7.10.4",
                 "lodash": "^4.17.13"
             }
         },
         "@babel/helper-optimise-call-expression": {
-            "version": "7.10.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.1.tgz",
-            "integrity": "sha512-a0DjNS1prnBsoKx83dP2falChcs7p3i8VMzdrSbfLhuQra/2ENC4sbri34dz/rWmDADsmF1q5GbfaXydh0Jbjg==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
+            "integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.10.1"
+                "@babel/types": "^7.10.4"
             }
         },
         "@babel/helper-plugin-utils": {
-            "version": "7.10.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
-            "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+            "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
             "dev": true
         },
         "@babel/helper-replace-supers": {
-            "version": "7.10.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.1.tgz",
-            "integrity": "sha512-SOwJzEfpuQwInzzQJGjGaiG578UYmyi2Xw668klPWV5n07B73S0a9btjLk/52Mlcxa+5AdIYqws1KyXRfMoB7A==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
+            "integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
             "dev": true,
             "requires": {
-                "@babel/helper-member-expression-to-functions": "^7.10.1",
-                "@babel/helper-optimise-call-expression": "^7.10.1",
-                "@babel/traverse": "^7.10.1",
-                "@babel/types": "^7.10.1"
+                "@babel/helper-member-expression-to-functions": "^7.10.4",
+                "@babel/helper-optimise-call-expression": "^7.10.4",
+                "@babel/traverse": "^7.10.4",
+                "@babel/types": "^7.10.4"
             }
         },
         "@babel/helper-simple-access": {
-            "version": "7.10.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.1.tgz",
-            "integrity": "sha512-VSWpWzRzn9VtgMJBIWTZ+GP107kZdQ4YplJlCmIrjoLVSi/0upixezHCDG8kpPVTBJpKfxTH01wDhh+jS2zKbw==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
+            "integrity": "sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==",
             "dev": true,
             "requires": {
-                "@babel/template": "^7.10.1",
-                "@babel/types": "^7.10.1"
+                "@babel/template": "^7.10.4",
+                "@babel/types": "^7.10.4"
             }
         },
         "@babel/helper-split-export-declaration": {
-            "version": "7.10.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.1.tgz",
-            "integrity": "sha512-UQ1LVBPrYdbchNhLwj6fetj46BcFwfS4NllJo/1aJsT+1dLTEnXJL0qHqtY7gPzF8S2fXBJamf1biAXV3X077g==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.4.tgz",
+            "integrity": "sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.10.1"
+                "@babel/types": "^7.10.4"
             }
         },
         "@babel/helper-validator-identifier": {
-            "version": "7.10.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz",
-            "integrity": "sha512-5vW/JXLALhczRCWP0PnFDMCJAchlBvM7f4uk/jXritBnIa6E1KmqmtrS3yn1LAnxFBypQ3eneLuXjsnfQsgILw==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+            "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
             "dev": true
         },
         "@babel/helpers": {
-            "version": "7.10.1",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.1.tgz",
-            "integrity": "sha512-muQNHF+IdU6wGgkaJyhhEmI54MOZBKsFfsXFhboz1ybwJ1Kl7IHlbm2a++4jwrmY5UYsgitt5lfqo1wMFcHmyw==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.4.tgz",
+            "integrity": "sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==",
             "dev": true,
             "requires": {
-                "@babel/template": "^7.10.1",
-                "@babel/traverse": "^7.10.1",
-                "@babel/types": "^7.10.1"
+                "@babel/template": "^7.10.4",
+                "@babel/traverse": "^7.10.4",
+                "@babel/types": "^7.10.4"
             }
         },
         "@babel/highlight": {
-            "version": "7.10.1",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.1.tgz",
-            "integrity": "sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+            "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
             "dev": true,
             "requires": {
-                "@babel/helper-validator-identifier": "^7.10.1",
+                "@babel/helper-validator-identifier": "^7.10.4",
                 "chalk": "^2.0.0",
                 "js-tokens": "^4.0.0"
             }
         },
         "@babel/parser": {
-            "version": "7.10.2",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.2.tgz",
-            "integrity": "sha512-PApSXlNMJyB4JiGVhCOlzKIif+TKFTvu0aQAhnTvfP/z3vVSN6ZypH5bfUNwFXXjRQtUEBNFd2PtmCmG2Py3qQ==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.4.tgz",
+            "integrity": "sha512-8jHII4hf+YVDsskTF6WuMB3X4Eh+PsUkC2ljq22so5rHvH+T8BzyL94VOdyFLNR8tBSVXOTbNHOKpR4TfRxVtA==",
             "dev": true
         },
         "@babel/plugin-syntax-jsx": {
-            "version": "7.10.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.10.1.tgz",
-            "integrity": "sha512-+OxyOArpVFXQeXKLO9o+r2I4dIoVoy6+Uu0vKELrlweDM3QJADZj+Z+5ERansZqIZBcLj42vHnDI8Rz9BnRIuQ==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.10.4.tgz",
+            "integrity": "sha512-KCg9mio9jwiARCB7WAcQ7Y1q+qicILjoK8LP/VkPkEKaf5dkaZZK1EcTe91a3JJlZ3qy6L5s9X52boEYi8DM9g==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.10.1"
+                "@babel/helper-plugin-utils": "^7.10.4"
             }
         },
         "@babel/plugin-transform-react-display-name": {
-            "version": "7.10.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.10.1.tgz",
-            "integrity": "sha512-rBjKcVwjk26H3VX8pavMxGf33LNlbocMHdSeldIEswtQ/hrjyTG8fKKILW1cSkODyRovckN/uZlGb2+sAV9JUQ==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.10.4.tgz",
+            "integrity": "sha512-Zd4X54Mu9SBfPGnEcaGcOrVAYOtjT2on8QZkLKEq1S/tHexG39d9XXGZv19VfRrDjPJzFmPfTAqOQS1pfFOujw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.10.1"
+                "@babel/helper-plugin-utils": "^7.10.4"
             }
         },
         "@babel/plugin-transform-react-jsx": {
-            "version": "7.10.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.10.1.tgz",
-            "integrity": "sha512-MBVworWiSRBap3Vs39eHt+6pJuLUAaK4oxGc8g+wY+vuSJvLiEQjW1LSTqKb8OUPtDvHCkdPhk7d6sjC19xyFw==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.10.4.tgz",
+            "integrity": "sha512-L+MfRhWjX0eI7Js093MM6MacKU4M6dnCRa/QPDwYMxjljzSCzzlzKzj9Pk4P3OtrPcxr2N3znR419nr3Xw+65A==",
             "dev": true,
             "requires": {
-                "@babel/helper-builder-react-jsx": "^7.10.1",
-                "@babel/helper-builder-react-jsx-experimental": "^7.10.1",
-                "@babel/helper-plugin-utils": "^7.10.1",
-                "@babel/plugin-syntax-jsx": "^7.10.1"
+                "@babel/helper-builder-react-jsx": "^7.10.4",
+                "@babel/helper-builder-react-jsx-experimental": "^7.10.4",
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/plugin-syntax-jsx": "^7.10.4"
             }
         },
         "@babel/plugin-transform-react-jsx-development": {
-            "version": "7.10.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.10.1.tgz",
-            "integrity": "sha512-XwDy/FFoCfw9wGFtdn5Z+dHh6HXKHkC6DwKNWpN74VWinUagZfDcEJc3Y8Dn5B3WMVnAllX8Kviaw7MtC5Epwg==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.10.4.tgz",
+            "integrity": "sha512-RM3ZAd1sU1iQ7rI2dhrZRZGv0aqzNQMbkIUCS1txYpi9wHQ2ZHNjo5TwX+UD6pvFW4AbWqLVYvKy5qJSAyRGjQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-builder-react-jsx-experimental": "^7.10.1",
-                "@babel/helper-plugin-utils": "^7.10.1",
-                "@babel/plugin-syntax-jsx": "^7.10.1"
+                "@babel/helper-builder-react-jsx-experimental": "^7.10.4",
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/plugin-syntax-jsx": "^7.10.4"
             }
         },
         "@babel/plugin-transform-react-jsx-self": {
-            "version": "7.10.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.10.1.tgz",
-            "integrity": "sha512-4p+RBw9d1qV4S749J42ZooeQaBomFPrSxa9JONLHJ1TxCBo3TzJ79vtmG2S2erUT8PDDrPdw4ZbXGr2/1+dILA==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.10.4.tgz",
+            "integrity": "sha512-yOvxY2pDiVJi0axdTWHSMi5T0DILN+H+SaeJeACHKjQLezEzhLx9nEF9xgpBLPtkZsks9cnb5P9iBEi21En3gg==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.10.1",
-                "@babel/plugin-syntax-jsx": "^7.10.1"
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/plugin-syntax-jsx": "^7.10.4"
             }
         },
         "@babel/plugin-transform-react-jsx-source": {
-            "version": "7.10.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.10.1.tgz",
-            "integrity": "sha512-neAbaKkoiL+LXYbGDvh6PjPG+YeA67OsZlE78u50xbWh2L1/C81uHiNP5d1fw+uqUIoiNdCC8ZB+G4Zh3hShJA==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.10.4.tgz",
+            "integrity": "sha512-FTK3eQFrPv2aveerUSazFmGygqIdTtvskG50SnGnbEUnRPcGx2ylBhdFIzoVS1ty44hEgcPoCAyw5r3VDEq+Ug==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.10.1",
-                "@babel/plugin-syntax-jsx": "^7.10.1"
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/plugin-syntax-jsx": "^7.10.4"
             }
         },
         "@babel/plugin-transform-react-pure-annotations": {
-            "version": "7.10.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.10.1.tgz",
-            "integrity": "sha512-mfhoiai083AkeewsBHUpaS/FM1dmUENHBMpS/tugSJ7VXqXO5dCN1Gkint2YvM1Cdv1uhmAKt1ZOuAjceKmlLA==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.10.4.tgz",
+            "integrity": "sha512-+njZkqcOuS8RaPakrnR9KvxjoG1ASJWpoIv/doyWngId88JoFlPlISenGXjrVacZUIALGUr6eodRs1vmPnF23A==",
             "dev": true,
             "requires": {
-                "@babel/helper-annotate-as-pure": "^7.10.1",
-                "@babel/helper-plugin-utils": "^7.10.1"
+                "@babel/helper-annotate-as-pure": "^7.10.4",
+                "@babel/helper-plugin-utils": "^7.10.4"
             }
         },
         "@babel/preset-react": {
-            "version": "7.10.1",
-            "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.10.1.tgz",
-            "integrity": "sha512-Rw0SxQ7VKhObmFjD/cUcKhPTtzpeviEFX1E6PgP+cYOhQ98icNqtINNFANlsdbQHrmeWnqdxA4Tmnl1jy5tp3Q==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.10.4.tgz",
+            "integrity": "sha512-BrHp4TgOIy4M19JAfO1LhycVXOPWdDbTRep7eVyatf174Hff+6Uk53sDyajqZPu8W1qXRBiYOfIamek6jA7YVw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.10.1",
-                "@babel/plugin-transform-react-display-name": "^7.10.1",
-                "@babel/plugin-transform-react-jsx": "^7.10.1",
-                "@babel/plugin-transform-react-jsx-development": "^7.10.1",
-                "@babel/plugin-transform-react-jsx-self": "^7.10.1",
-                "@babel/plugin-transform-react-jsx-source": "^7.10.1",
-                "@babel/plugin-transform-react-pure-annotations": "^7.10.1"
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/plugin-transform-react-display-name": "^7.10.4",
+                "@babel/plugin-transform-react-jsx": "^7.10.4",
+                "@babel/plugin-transform-react-jsx-development": "^7.10.4",
+                "@babel/plugin-transform-react-jsx-self": "^7.10.4",
+                "@babel/plugin-transform-react-jsx-source": "^7.10.4",
+                "@babel/plugin-transform-react-pure-annotations": "^7.10.4"
             }
         },
         "@babel/runtime": {
@@ -305,9 +305,9 @@
             }
         },
         "@babel/runtime-corejs3": {
-            "version": "7.10.2",
-            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.10.2.tgz",
-            "integrity": "sha512-+a2M/u7r15o3dV1NEizr9bRi+KUVnrs/qYxF0Z06DAPx/4VCWaz1WA7EcbE+uqGgt39lp5akWGmHsTseIkHkHg==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.10.4.tgz",
+            "integrity": "sha512-BFlgP2SoLO9HJX9WBwN67gHWMBhDX/eDz64Jajd6mR/UAUzqrNMm99d4qHnVaKscAElZoFiPv+JpR/Siud5lXw==",
             "dev": true,
             "requires": {
                 "core-js-pure": "^3.0.0",
@@ -315,40 +315,40 @@
             }
         },
         "@babel/template": {
-            "version": "7.10.1",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.1.tgz",
-            "integrity": "sha512-OQDg6SqvFSsc9A0ej6SKINWrpJiNonRIniYondK2ViKhB06i3c0s+76XUft71iqBEe9S1OKsHwPAjfHnuvnCig==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
+            "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.10.1",
-                "@babel/parser": "^7.10.1",
-                "@babel/types": "^7.10.1"
+                "@babel/code-frame": "^7.10.4",
+                "@babel/parser": "^7.10.4",
+                "@babel/types": "^7.10.4"
             }
         },
         "@babel/traverse": {
-            "version": "7.10.1",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.1.tgz",
-            "integrity": "sha512-C/cTuXeKt85K+p08jN6vMDz8vSV0vZcI0wmQ36o6mjbuo++kPMdpOYw23W2XH04dbRt9/nMEfA4W3eR21CD+TQ==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.4.tgz",
+            "integrity": "sha512-aSy7p5THgSYm4YyxNGz6jZpXf+Ok40QF3aA2LyIONkDHpAcJzDUqlCKXv6peqYUs2gmic849C/t2HKw2a2K20Q==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.10.1",
-                "@babel/generator": "^7.10.1",
-                "@babel/helper-function-name": "^7.10.1",
-                "@babel/helper-split-export-declaration": "^7.10.1",
-                "@babel/parser": "^7.10.1",
-                "@babel/types": "^7.10.1",
+                "@babel/code-frame": "^7.10.4",
+                "@babel/generator": "^7.10.4",
+                "@babel/helper-function-name": "^7.10.4",
+                "@babel/helper-split-export-declaration": "^7.10.4",
+                "@babel/parser": "^7.10.4",
+                "@babel/types": "^7.10.4",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0",
                 "lodash": "^4.17.13"
             }
         },
         "@babel/types": {
-            "version": "7.10.2",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.2.tgz",
-            "integrity": "sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==",
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
+            "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
             "dev": true,
             "requires": {
-                "@babel/helper-validator-identifier": "^7.10.1",
+                "@babel/helper-validator-identifier": "^7.10.4",
                 "lodash": "^4.17.13",
                 "to-fast-properties": "^2.0.0"
             }
@@ -418,52 +418,64 @@
             }
         },
         "@testing-library/dom": {
-            "version": "7.10.1",
-            "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.10.1.tgz",
-            "integrity": "sha512-shB6yx0eqoKya8V6zqV152MioYe6R4iIorT9LdGhGMZwvqny0GYMBqzKbAcxbTMlBmG0M0xaqO8AnzVEMuUamA==",
+            "version": "7.20.0",
+            "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.20.0.tgz",
+            "integrity": "sha512-TywaC+qDGm/Ro34kRYkFQPdT+pxSF4UjZGLIqcGfFQH5IGR43Y7sGLPnkieIW/GNsu337oxNsLUAgpI0JWhXHw==",
             "dev": true,
             "requires": {
-                "@babel/runtime": "^7.10.2",
-                "aria-query": "^4.0.2",
+                "@babel/runtime": "^7.10.3",
+                "@types/aria-query": "^4.2.0",
+                "aria-query": "^4.2.2",
                 "dom-accessibility-api": "^0.4.5",
                 "pretty-format": "^25.5.0"
-            }
-        },
-        "@testing-library/react": {
-            "version": "10.2.1",
-            "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-10.2.1.tgz",
-            "integrity": "sha512-pv2jZhiZgN1/alz1aImhSasZAOPg3er2Kgcfg9fzuw7aKPLxVengqqR1n0CJANeErR1DqORauQaod+gGUgAJOQ==",
-            "dev": true,
-            "requires": {
-                "@babel/runtime": "^7.10.2",
-                "@testing-library/dom": "^7.9.0"
-            }
-        },
-        "@testing-library/user-event": {
-            "version": "11.2.1",
-            "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-11.2.1.tgz",
-            "integrity": "sha512-dwXa4y+9mAp1+wR/1ufFjm5kUHsvJ5Y5dCdaWyU1CXIA7SNSHcEYVWHGjwZNGrxf00Jm16bN57z5gUMsXCzjSA==",
-            "dev": true,
-            "requires": {
-                "@babel/runtime": "^7.10.2"
             },
             "dependencies": {
                 "@babel/runtime": {
-                    "version": "7.10.2",
-                    "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
-                    "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.4.tgz",
+                    "integrity": "sha512-UpTN5yUJr9b4EX2CnGNWIvER7Ab83ibv0pcvvHc4UOdrBI5jb8bj+32cCwPX6xu0mt2daFNjYhoi+X7beH0RSw==",
                     "dev": true,
                     "requires": {
                         "regenerator-runtime": "^0.13.4"
                     }
-                },
-                "regenerator-runtime": {
-                    "version": "0.13.5",
-                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-                    "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
-                    "dev": true
                 }
             }
+        },
+        "@testing-library/react": {
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-10.4.3.tgz",
+            "integrity": "sha512-A/ydYXcwAcfY7vkPrfUkUTf9HQLL3/GtixTefcu3OyGQtAYQ7XBQj1S9FWbLEhfWa0BLwFwTBFS3Ao1O0tbMJg==",
+            "dev": true,
+            "requires": {
+                "@babel/runtime": "^7.10.3",
+                "@testing-library/dom": "^7.17.1"
+            },
+            "dependencies": {
+                "@babel/runtime": {
+                    "version": "7.10.4",
+                    "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.4.tgz",
+                    "integrity": "sha512-UpTN5yUJr9b4EX2CnGNWIvER7Ab83ibv0pcvvHc4UOdrBI5jb8bj+32cCwPX6xu0mt2daFNjYhoi+X7beH0RSw==",
+                    "dev": true,
+                    "requires": {
+                        "regenerator-runtime": "^0.13.4"
+                    }
+                }
+            }
+        },
+        "@testing-library/user-event": {
+            "version": "11.4.2",
+            "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-11.4.2.tgz",
+            "integrity": "sha512-Kut7G1L+ffozEhYTDNjV9C6RFbUfsKA05rGr1arwbSUoDZQ82OMmsyaXEDznT22Qc0PtZ1Hz3soX0pPosu8+Sw==",
+            "dev": true,
+            "requires": {
+                "@babel/runtime": "^7.10.2"
+            }
+        },
+        "@types/aria-query": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.0.tgz",
+            "integrity": "sha512-iIgQNzCm0v7QMhhe4Jjn9uRh+I6GoPmt03CbEtwx3ao8/EfoQcmgtqH4vQ5Db/lxiIGaWDv6nwvunuh0RyX0+A==",
+            "dev": true
         },
         "@types/color-name": {
             "version": "1.1.1",
@@ -482,9 +494,9 @@
             }
         },
         "@types/istanbul-lib-coverage": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.2.tgz",
-            "integrity": "sha512-rsZg7eL+Xcxsxk2XlBt9KcG8nOp9iYdKCOikY9x2RFJCyOdNj4MKPQty0e8oZr29vVAzKXr1BmR+kZauti3o1w==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
+            "integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==",
             "dev": true
         },
         "@types/istanbul-lib-report": {
@@ -814,13 +826,13 @@
             }
         },
         "aria-query": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.0.2.tgz",
-            "integrity": "sha512-S1G1V790fTaigUSM/Gd0NngzEfiMy9uTUfMyHhKhVyy4cH5O/eTuR01ydhGL0z4Za1PXFTRGH3qL8VhUQuEO5w==",
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
+            "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
             "dev": true,
             "requires": {
-                "@babel/runtime": "^7.7.4",
-                "@babel/runtime-corejs3": "^7.7.4"
+                "@babel/runtime": "^7.10.2",
+                "@babel/runtime-corejs3": "^7.10.2"
             }
         },
         "arr-diff": {
@@ -3353,15 +3365,9 @@
             }
         },
         "interpret": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
-            "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
-            "dev": true
-        },
-        "invert-kv": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-            "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+            "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
             "dev": true
         },
         "ip": {
@@ -3752,15 +3758,6 @@
             "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
             "dev": true
         },
-        "lcid": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
-            "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
-            "dev": true,
-            "requires": {
-                "invert-kv": "^2.0.0"
-            }
-        },
         "linked-list": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/linked-list/-/linked-list-0.1.0.tgz",
@@ -3885,15 +3882,6 @@
                 }
             }
         },
-        "map-age-cleaner": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
-            "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
-            "dev": true,
-            "requires": {
-                "p-defer": "^1.0.0"
-            }
-        },
         "map-cache": {
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
@@ -3943,17 +3931,6 @@
             "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
             "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
             "dev": true
-        },
-        "mem": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
-            "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
-            "dev": true,
-            "requires": {
-                "map-age-cleaner": "^0.1.1",
-                "mimic-fn": "^2.0.0",
-                "p-is-promise": "^2.0.0"
-            }
         },
         "memory-fs": {
             "version": "0.4.1",
@@ -4036,12 +4013,6 @@
             "requires": {
                 "mime-db": "1.44.0"
             }
-        },
-        "mimic-fn": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-            "dev": true
         },
         "minimalistic-assert": {
             "version": "1.0.1",
@@ -4502,33 +4473,10 @@
             "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
             "dev": true
         },
-        "os-locale": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
-            "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
-            "dev": true,
-            "requires": {
-                "execa": "^1.0.0",
-                "lcid": "^2.0.0",
-                "mem": "^4.0.0"
-            }
-        },
-        "p-defer": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-            "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
-            "dev": true
-        },
         "p-finally": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
             "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-            "dev": true
-        },
-        "p-is-promise": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
-            "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
             "dev": true
         },
         "p-limit": {
@@ -6720,9 +6668,9 @@
             "dev": true
         },
         "v8-compile-cache": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz",
-            "integrity": "sha512-CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
+            "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==",
             "dev": true
         },
         "vary": {
@@ -6936,87 +6884,24 @@
             }
         },
         "webpack-cli": {
-            "version": "3.3.11",
-            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.11.tgz",
-            "integrity": "sha512-dXlfuml7xvAFwYUPsrtQAA9e4DOe58gnzSxhgrO/ZM/gyXTBowrsYeubyN4mqGhYdpXMFNyQ6emjJS9M7OBd4g==",
+            "version": "3.3.12",
+            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.12.tgz",
+            "integrity": "sha512-NVWBaz9k839ZH/sinurM+HcDvJOTXwSjYp1ku+5XKeOC03z8v5QitnK/x+lAxGXFyhdayoIf/GOpv85z3/xPag==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.2",
-                "cross-spawn": "6.0.5",
-                "enhanced-resolve": "4.1.0",
-                "findup-sync": "3.0.0",
-                "global-modules": "2.0.0",
-                "import-local": "2.0.0",
-                "interpret": "1.2.0",
-                "loader-utils": "1.2.3",
-                "supports-color": "6.1.0",
-                "v8-compile-cache": "2.0.3",
-                "yargs": "13.2.4"
+                "chalk": "^2.4.2",
+                "cross-spawn": "^6.0.5",
+                "enhanced-resolve": "^4.1.1",
+                "findup-sync": "^3.0.0",
+                "global-modules": "^2.0.0",
+                "import-local": "^2.0.0",
+                "interpret": "^1.4.0",
+                "loader-utils": "^1.4.0",
+                "supports-color": "^6.1.0",
+                "v8-compile-cache": "^2.1.1",
+                "yargs": "^13.3.2"
             },
             "dependencies": {
-                "ansi-regex": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-                    "dev": true
-                },
-                "emojis-list": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-                    "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
-                    "dev": true
-                },
-                "enhanced-resolve": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz",
-                    "integrity": "sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "memory-fs": "^0.4.0",
-                        "tapable": "^1.0.0"
-                    }
-                },
-                "json5": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-                    "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-                    "dev": true,
-                    "requires": {
-                        "minimist": "^1.2.0"
-                    }
-                },
-                "loader-utils": {
-                    "version": "1.2.3",
-                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
-                    "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
-                    "dev": true,
-                    "requires": {
-                        "big.js": "^5.2.2",
-                        "emojis-list": "^2.0.0",
-                        "json5": "^1.0.1"
-                    }
-                },
-                "string-width": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-                    "dev": true,
-                    "requires": {
-                        "emoji-regex": "^7.0.1",
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^5.1.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^4.1.0"
-                    }
-                },
                 "supports-color": {
                     "version": "6.1.0",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
@@ -7024,25 +6909,6 @@
                     "dev": true,
                     "requires": {
                         "has-flag": "^3.0.0"
-                    }
-                },
-                "yargs": {
-                    "version": "13.2.4",
-                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.4.tgz",
-                    "integrity": "sha512-HG/DWAJa1PAnHT9JAhNa8AbAv3FPaiLzioSjCcmuXXhP8MlpHO5vwls4g4j6n30Z74GVQj8Xa62dWVx1QCGklg==",
-                    "dev": true,
-                    "requires": {
-                        "cliui": "^5.0.0",
-                        "find-up": "^3.0.0",
-                        "get-caller-file": "^2.0.1",
-                        "os-locale": "^3.1.0",
-                        "require-directory": "^2.1.1",
-                        "require-main-filename": "^2.0.0",
-                        "set-blocking": "^2.0.0",
-                        "string-width": "^3.0.0",
-                        "which-module": "^2.0.0",
-                        "y18n": "^4.0.0",
-                        "yargs-parser": "^13.1.0"
                     }
                 }
             }

--- a/package.json
+++ b/package.json
@@ -14,17 +14,17 @@
         "url": "https://github.com/Zaid-Ajaj/Elmish.Toastr.git"
     },
     "devDependencies": {
-        "@babel/core": "^7.10.2",
-        "@babel/preset-react": "^7.10.1",
-        "@testing-library/react": "^10.2.1",
-        "@testing-library/user-event": "^11.2.1",
+        "@babel/core": "^7.10.4",
+        "@babel/preset-react": "^7.10.4",
+        "@testing-library/react": "^10.4.3",
+        "@testing-library/user-event": "^11.4.2",
         "fable-compiler": "^2.10.1",
         "fable-loader": "^2.1.9",
         "gh-pages": "^2.2.0",
         "mocha": "^6.2.3",
         "remotedev": "^0.2.7",
         "webpack": "^4.43.0",
-        "webpack-cli": "^3.3.11",
+        "webpack-cli": "^3.3.12",
         "webpack-dev-server": "^3.11.0"
     },
     "dependencies": {

--- a/paket.lock
+++ b/paket.lock
@@ -4,12 +4,12 @@ NUGET
     Fable.Browser.Blob (1.1) - restriction: >= netstandard2.0
       Fable.Core (>= 3.0) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.6.2) - restriction: >= netstandard2.0
-    Fable.Browser.Dom (1.1) - restriction: >= netstandard2.0
+    Fable.Browser.Dom (1.2) - restriction: >= netstandard2.0
       Fable.Browser.Blob (>= 1.1) - restriction: >= netstandard2.0
       Fable.Browser.Event (>= 1.0) - restriction: >= netstandard2.0
       Fable.Browser.WebStorage (>= 1.0) - restriction: >= netstandard2.0
       Fable.Core (>= 3.0) - restriction: >= netstandard2.0
-      FSharp.Core (>= 4.6.2) - restriction: >= netstandard2.0
+      FSharp.Core (>= 4.7) - restriction: >= netstandard2.0
     Fable.Browser.Event (1.0) - restriction: >= netstandard2.0
       Fable.Core (>= 3.0) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.5.2) - restriction: >= netstandard2.0
@@ -32,25 +32,25 @@ NUGET
       Fable.Elmish (>= 3.0) - restriction: >= netstandard2.0
       Fable.React (>= 5.1) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.6.2) - restriction: >= netstandard2.0
-    Fable.React (6.0)
+    Fable.React (6.2)
       Fable.Browser.Dom (>= 1.0) - restriction: >= netstandard2.0
       Fable.Core (>= 3.1.5) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7) - restriction: >= netstandard2.0
-    Fable.SimpleHttp (2.6)
+    Fable.SimpleHttp (3.0)
       Fable.Browser.Dom (>= 1.0) - restriction: >= netstandard2.0
       Fable.Browser.XMLHttpRequest (>= 1.1) - restriction: >= netstandard2.0
       Fable.Core (>= 3.0) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.6.2) - restriction: >= netstandard2.0
-    Feliz (0.68.3) - restriction: >= netstandard2.0
-      Fable.Core (>= 3.1.1) - restriction: >= netstandard2.0
-      Fable.React (>= 5.3.2) - restriction: >= netstandard2.0
+    Feliz (1.5) - restriction: >= netstandard2.0
+      Fable.Core (>= 3.1.5) - restriction: >= netstandard2.0
+      Fable.React (>= 6.0) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7) - restriction: >= netstandard2.0
-    Feliz.Router (1.7.1)
-      Fable.Core (>= 3.1.2) - restriction: >= netstandard2.0
+    Feliz.Router (2.1)
+      Fable.Core (>= 3.1.5) - restriction: >= netstandard2.0
       Fable.Elmish (>= 3.0.5) - restriction: >= netstandard2.0
-      Feliz (>= 0.68.3) - restriction: >= netstandard2.0
+      Feliz (>= 1.0) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7) - restriction: >= netstandard2.0
-    FSharp.Core (4.7)
+    FSharp.Core (4.7.2)
     Zanaptak.TypedCssClasses (0.2)
       FSharp.Core (>= 4.3.4) - restriction: || (>= net452) (>= netstandard2.0)
 


### PR DESCRIPTION
There's a somewhat common pattern that when working with objects than interface `System.IDisposable` asynchronously that to properly make sure they get disposed when the element unmounts that they're stored as a `IRefValue<System.IDisposable option>`. 

This is a bit annoying to work with as you need to do: 
```fs
React.createDisposable(fun () -> myRef.current |> Option.iter (fun myDisposable -> myDisposable.Dispose()))
``` 

This PR adds an overload such that you can just return `myRef.current` at the end of your effect.

As you can see from the diff of `useElmish`:
![image](https://user-images.githubusercontent.com/11186595/86431738-2e4e2180-bcbb-11ea-843b-3e56ae43614b.png)
