### PR TITLE
Added useMediaQuery and useResponsive hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -204,3 +204,6 @@ tests.js.map
 dist
 .local-chromium
 1.bundle.js
+
+# JetBrains Rider
+.idea

--- a/Feliz.UseMediaQuery/Feliz.UseMediaQuery.fsproj
+++ b/Feliz.UseMediaQuery/Feliz.UseMediaQuery.fsproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <PackageVersion>0.1</PackageVersion>
+        <Authors>Jonas Bösch, Zaid Ajaj</Authors>
+        <Description>useMediaQuery hooks to build responsive websites </Description>
+        <PackageLicenseUrl>https://github.com/Zaid-Ajaj/Feliz/blob/master/LICENSE</PackageLicenseUrl>
+        <RepositoryUrl>https://github.com/Zaid-Ajaj/Feliz</RepositoryUrl>
+        <PackageTags>fsharp;fable;react;html;feliz</PackageTags>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <Content Include="*.fsproj; *.fs; *.js;" PackagePath="fable\" />
+        <Compile Include="UseMediaQuery.fs" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Fable.Browser.MediaQueryList" Version="1.1.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Feliz\Feliz.fsproj" />
+    </ItemGroup>
+
+</Project>

--- a/Feliz.UseMediaQuery/UseMediaQuery.fs
+++ b/Feliz.UseMediaQuery/UseMediaQuery.fs
@@ -1,0 +1,74 @@
+﻿module Feliz.UseMediaQuery
+
+open System
+open Browser
+open Browser.Types
+open Feliz
+
+[<RequireQualifiedAccess>]
+type ScreenSize =
+    | Mobile
+    | MobileLandscape
+    | Tablet
+    | Desktop
+    | WideScreen
+
+type Breakpoints = {
+    MobileLandscape: int
+    Tablet: int
+    Desktop: int
+    WideScreen: int
+}
+
+[<RequireQualifiedAccess>]
+module Breakpoints = 
+    let defaults = {
+        MobileLandscape = 576
+        Tablet = 768
+        Desktop = 1024
+        WideScreen = 1216
+    }
+
+let private makeQueries breakpoints =
+    let mobileQuery = sprintf "(max-width: %ipx)" breakpoints.MobileLandscape
+    let mobileLandscapeQuery = sprintf "(max-width: %ipx)" breakpoints.Tablet
+    let tabletQuery = sprintf "(max-width: %ipx)" breakpoints.Desktop
+    let desktopQuery = sprintf "(max-width: %ipx)" breakpoints.WideScreen
+    mobileQuery, mobileLandscapeQuery, tabletQuery, desktopQuery
+
+[<AutoOpen>]
+module UseMediaQueryExtension =
+     type React with
+        /// A hook for media queries, this hook will force a component 
+        /// to re-render when the specified media query changes.  
+        static member useMediaQuery (query: string) =
+            let (mq, setMq) = React.useState(fun () -> window.matchMedia(query))
+
+            React.useEffect(fun () ->
+                mq.addEventListener("change", fun e ->
+                    let mqEvent = unbox<MediaQueryList>(e)
+                    setMq mqEvent)
+                {new IDisposable with
+                     member this.Dispose() =
+                        mq.removeEventListener("change", fun _ -> ())}
+
+            , [| query :> obj |])
+
+            mq.matches
+
+        /// A hook for responsive design, this hook will force a component 
+        /// to re-render the components on resize.  
+        /// Returns a discriminated union with the new width.
+        static member useResponsive(?breakpoints: Breakpoints) =
+            let breakpoints = Option.defaultValue Breakpoints.defaults breakpoints
+            let m, l, t, d = makeQueries breakpoints
+            let mx = React.useMediaQuery m
+            let lx = React.useMediaQuery l
+            let tx = React.useMediaQuery t
+            let dx = React.useMediaQuery d
+            match mx, lx, tx, dx with
+            | true, _, _, _ -> ScreenSize.Mobile
+            | _, true, _, _ -> ScreenSize.MobileLandscape
+            | _, _, true, _ -> ScreenSize.Tablet
+            | _, _, _, true -> ScreenSize.Desktop
+            | _ -> ScreenSize.WideScreen

--- a/Feliz.sln
+++ b/Feliz.sln
@@ -51,6 +51,8 @@ Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Fable.ReactTestingLibrary",
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Feliz.RoughViz", "Feliz.RoughViz\Feliz.RoughViz.fsproj", "{63AC765A-8559-4715-AF14-ECD702C5C437}"
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Feliz.UseMediaQuery", "Feliz.UseMediaQuery\Feliz.UseMediaQuery.fsproj", "{0E225B46-28B4-4ADF-8116-13A47207F7B4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -217,6 +219,18 @@ Global
 		{63AC765A-8559-4715-AF14-ECD702C5C437}.Release|x64.Build.0 = Release|Any CPU
 		{63AC765A-8559-4715-AF14-ECD702C5C437}.Release|x86.ActiveCfg = Release|Any CPU
 		{63AC765A-8559-4715-AF14-ECD702C5C437}.Release|x86.Build.0 = Release|Any CPU
+		{0E225B46-28B4-4ADF-8116-13A47207F7B4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0E225B46-28B4-4ADF-8116-13A47207F7B4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0E225B46-28B4-4ADF-8116-13A47207F7B4}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0E225B46-28B4-4ADF-8116-13A47207F7B4}.Debug|x64.Build.0 = Debug|Any CPU
+		{0E225B46-28B4-4ADF-8116-13A47207F7B4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0E225B46-28B4-4ADF-8116-13A47207F7B4}.Debug|x86.Build.0 = Debug|Any CPU
+		{0E225B46-28B4-4ADF-8116-13A47207F7B4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0E225B46-28B4-4ADF-8116-13A47207F7B4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0E225B46-28B4-4ADF-8116-13A47207F7B4}.Release|x64.ActiveCfg = Release|Any CPU
+		{0E225B46-28B4-4ADF-8116-13A47207F7B4}.Release|x64.Build.0 = Release|Any CPU
+		{0E225B46-28B4-4ADF-8116-13A47207F7B4}.Release|x86.ActiveCfg = Release|Any CPU
+		{0E225B46-28B4-4ADF-8116-13A47207F7B4}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/docs/App.fs
+++ b/docs/App.fs
@@ -203,6 +203,9 @@ let samples = [
     "parallel-deferred", DelayedComponent.render {| load = UseDeferredExamples.parallelDeferred |}
     "use-elmish-basic", DelayedComponent.render {| load = UseElmishExamples.counter |}
     "use-elmish-combined", DelayedComponent.render {| load = UseElmishExamples.counterCombined |}
+    "use-media-query", DelayedComponent.render {| load = UseMediaQueryExamples.useMediaQueryExample |}
+    "use-responsive", DelayedComponent.render {| load = UseMediaQueryExamples.useResponsiveExample |}
+    "use-responsive-custom", DelayedComponent.render {| load = UseMediaQueryExamples.useResponsiveCustomBreakpointsExample |}
     "rough-bar-chart", roughBarChart()
     "rough-horizontal-bar-chart", roughHorizontalBarChart()
     "dynamic-rough-chart", dynamicRoughChart()
@@ -492,6 +495,7 @@ let allItems = React.functionComponent(fun (input: {| state: State; dispatch: Ms
                     nestedMenuItem "Feliz.UseDeferred" [ Urls.UseDeferred ]
                     nestedMenuItem "Feliz.UseElmish" [ Urls.UseElmish ]
                     nestedMenuItem "Feliz.UseWorker" [ Urls.UseWorker ]
+                    nestedMenuItem "Feliz.UseMediaQuery" [ Urls.UseMediaQuery ]
                 ]
 
                 nestedMenuList "Components" [ Urls.Components ] [
@@ -688,6 +692,7 @@ let content = React.functionComponent(fun (input: {| state: State; dispatch: Msg
         | [ Urls.UseDeferred ] -> lazyView MarkdownLoader.load [ "Feliz.UseDeferred"; "Index.md" ]
         | [ Urls.UseElmish ] -> lazyView MarkdownLoader.load [ "Feliz.UseElmish"; "Index.md" ]
         | [ Urls.UseWorker ] -> lazyView MarkdownLoader.load [ readme "Shmew" "Feliz.UseWorker" ]
+        | [ Urls.UseMediaQuery ] -> lazyView MarkdownLoader.load [ "Feliz.UseMediaQuery"; "Index.md" ]
         | _ -> Html.div [ for segment in input.state.CurrentPath -> Html.p segment ]
     | PathPrefix [ Urls.Components ] (Some res) ->
         match res with

--- a/docs/App.fsproj
+++ b/docs/App.fsproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Feliz.UseMediaQuery\Feliz.UseMediaQuery.fsproj" />
     <ProjectReference Include="..\Feliz\Feliz.fsproj" />
     <ProjectReference Include="..\Feliz.Recharts\Feliz.Recharts.fsproj" />
     <ProjectReference Include="..\Feliz.Markdown\Feliz.Markdown.fsproj" />
@@ -44,6 +45,7 @@
     <Compile Include="DelayedComponent.fs" />
     <Compile Include="UseDeferredExamples.fs" />
     <Compile Include="UseElmishExamples.fs" />
+    <Compile Include="UseMediaQueryExamples.fs" />
     <Compile Include="Examples.fs" />
     <Compile Include="Tests.fs" />
     <Compile Include="App.fs" />

--- a/docs/Urls.fs
+++ b/docs/Urls.fs
@@ -87,6 +87,7 @@ let [<Literal>] UseEffect = "UseEffect"
 let [<Literal>] UseReducer = "UseReducer"
 let [<Literal>] UseState = "UseState"
 let [<Literal>] UseElmish = "UseElmish"
+let [<Literal>] UseMediaQuery = "UseMediaQuery"
 
 // ____________________________________________________
 

--- a/docs/UseMediaQueryExamples.fs
+++ b/docs/UseMediaQueryExamples.fs
@@ -1,0 +1,78 @@
+[<RequireQualifiedAccess>]
+module UseMediaQueryExamples
+
+open Browser
+open Feliz
+open Elmish
+open Feliz.UseMediaQuery
+
+let useResponsiveExample = React.functionComponent(fun () ->
+(*
+    // default breakpoints
+    {
+        MobileLandscape = 576
+        Tablet = 768
+        Desktop = 1024
+        WideScreen = 1216
+    }
+*)
+    
+    let width = React.useResponsive()
+
+    Html.div [
+        let text = 
+            match width with
+            | ScreenSize.Mobile -> "Mobile"
+            | ScreenSize.MobileLandscape -> "MobileLandscape"
+            | ScreenSize.Tablet -> "Tablet"
+            | ScreenSize.Desktop -> "Desktop"
+            | ScreenSize.WideScreen -> "WideScreen"
+        prop.children [
+            Html.h1 text
+            Html.p "Resize your screen to get the media query hook to re-render the component with updated information."
+        ]
+    ]
+)
+
+let useResponsiveCustomBreakpointsExample = React.functionComponent(fun () ->
+    let customBreakpoints = {
+        MobileLandscape = 600
+        Tablet = 960
+        Desktop = 1280
+        WideScreen = 1920
+    }
+
+    let width = React.useResponsive(customBreakpoints)
+
+    Html.div [
+        let text = 
+            match width with
+            | ScreenSize.Mobile -> "Mobile"
+            | ScreenSize.MobileLandscape -> "MobileLandscape"
+            | ScreenSize.Tablet -> "Tablet"
+            | ScreenSize.Desktop -> "Desktop"
+            | ScreenSize.WideScreen -> "WideScreen"
+        prop.children [
+            Html.h1 text
+            Html.p "Resize your screen to get the media query hook to re-render the component with updated information."
+        ]
+    ]
+)
+
+
+let useMediaQueryExample = React.functionComponent(fun () ->
+    let matches = React.useMediaQuery("(max-width: 850px)")
+
+    Html.div [
+        let text = 
+            if matches then 
+                "850px or less"
+            else
+                "More than 850px"
+                
+        prop.children [
+            Html.h1 text
+            Html.p "Resize your screen to get the media query hook to re-render the component with updated information."
+        ]
+    ]
+)

--- a/public/Feliz.UseMediaQuery/Index.md
+++ b/public/Feliz.UseMediaQuery/Index.md
@@ -1,0 +1,81 @@
+# Feliz.UseMediaQuery [![Nuget](https://img.shields.io/nuget/v/Feliz.UseMediaQuery.svg?maxAge=0&colorB=brightgreen)](https://www.nuget.org/packages/Feliz.UseMediaQuery)
+
+Build React components with responsive behavior for different devices. 
+
+## UseMediaQuery 
+
+UseMediaQuery allows you to pass in all kinds of media queries as string.
+ 
+```fsharp:use-media-query
+let useMediaQueryExample = React.functionComponent(fun () ->
+    let matches = React.useMediaQuery("(max-width: 850px)")
+
+    Html.div [
+        let text = 
+            if matches then 
+                "850px or less"
+            else
+                "More than 850px"
+                
+        prop.children [
+            Html.h1 text
+            Html.p "Resize your screen to get the media query hook to re-render the component with updated information."
+        ]
+    ]
+)
+
+```
+## UseResponsive 
+
+UseResponsive allows you to pass in a record type with the 
+breakpoints in px. Use the default ones or define them yourself.
+ 
+```fsharp:use-responsive
+let useResponsiveExample = React.functionComponent(fun () ->
+    // defaults = {MobileLandscape = 576; Tablet = 768; Desktop = 1024; WideScreen = 1216}
+    let width = React.useResponsive()
+
+    Html.div [
+        let text = 
+            match width with
+            | ScreenSize.Mobile -> "Mobile"
+            | ScreenSize.MobileLandscape -> "MobileLandscape"
+            | ScreenSize.Tablet -> "Tablet"
+            | ScreenSize.Desktop -> "Desktop"
+            | ScreenSize.WideScreen -> "WideScreen"
+        prop.children [
+            Html.h1 text
+            Html.p "Resize your screen to get the media query hook to re-render the component with updated information."
+        ]
+    ]
+)
+```
+
+To define custom breakpoints, just pass in a breakpoints record with your preferred widths.
+
+```fsharp:use-responsive-custom
+let useResponsiveCustomBreakpointsExample = React.functionComponent(fun () ->
+    let customBreakpoints = {
+        MobileLandscape = 600
+        Tablet = 960
+        Desktop = 1280
+        WideScreen = 1920
+    }
+
+    let width = React.useResponsive(customBreakpoints)
+
+    Html.div [
+        let text = 
+            match width with
+            | ScreenSize.Mobile -> "Mobile"
+            | ScreenSize.MobileLandscape -> "MobileLandscape"
+            | ScreenSize.Tablet -> "Tablet"
+            | ScreenSize.Desktop -> "Desktop"
+            | ScreenSize.WideScreen -> "WideScreen"
+        prop.children [
+            Html.h1 text
+            Html.p "Resize your screen to get the media query hook to re-render the component with updated information."
+        ]
+    ]
+)
+```


### PR DESCRIPTION
Added two hooks for media queries

**useMediaQuery**
Allows to make arbitrary media queries from a string, returns a boolean (```matches```)

**useResponsive** 
Returns a screensize DU to get the responsive mode. Can be customized with custom widths for the breakpoints.

Additional example code can be found [here](https://github.com/l3m/Feliz.UseMediaQuery-Example/blob/master/src/App.fs).

```fsharp
let render = React.functionComponent(fun () ->
    let width = React.useResponsive(defaultBreakpoints)
    
    Html.div [
        prop.style [
            let bgColor = 
                match width with
                | ScreenSize.Mobile -> color.white
                | ScreenSize.MobileLandscape -> color.whiteSmoke
                | ScreenSize.Tablet -> color.darkGray
                | ScreenSize.Desktop -> color.gray
                | ScreenSize.WideScreen -> color.red
            style.backgroundColor bgColor
        ]
   ])
```


![Feliz UseMediaQuery-example](https://user-images.githubusercontent.com/230547/86513772-34ecae00-be0d-11ea-8aa6-d84a28e438d4.gif)
