### PR TITLE
Fix overload resolution issues

### DIFF
--- a/Feliz/React.fs
+++ b/Feliz/React.fs
@@ -57,30 +57,6 @@ type React =
     /// Creates a disposable instance by providing the implementation of the dispose member.
     static member createDisposable(dispose: unit -> unit) =
         { new IDisposable with member _.Dispose() = dispose() }
-    /// Creates a disposable instance by merging multiple IDisposables.
-    static member inline createDisposable([<ParamArray>] disposables: IDisposable []) =
-        React.createDisposable(fun () ->
-            disposables
-            |> Array.iter (fun d -> d.Dispose())
-        )
-    /// Creates a disposable instance by merging multiple IDisposable options.
-    static member inline createDisposable([<ParamArray>] disposables: IDisposable option []) =
-        React.createDisposable(fun () ->
-            disposables
-            |> Array.iter (Option.iter (fun d -> d.Dispose()))
-        )
-    /// Creates a disposable instance by merging multiple IDisposable refs.
-    static member inline createDisposable([<ParamArray>] disposables: IRefValue<IDisposable> []) =
-        React.createDisposable(fun () ->
-            disposables
-            |> Array.iter (fun d -> d.current.Dispose())
-        )
-    /// Creates a disposable instance by merging multiple IDisposable refs.
-    static member inline createDisposable([<ParamArray>] disposables: IRefValue<IDisposable option> []) =
-        React.createDisposable(fun () ->
-            disposables
-            |> Array.iter (fun d -> d.current |> Option.iter (fun d -> d.Dispose()))
-        )
         
     /// The `React.fragment` component lets you return multiple elements in your `render()` method without creating an additional DOM element.
     static member inline fragment xs = Fable.React.Helpers.fragment [] xs
@@ -525,5 +501,30 @@ type React =
 [<AutoOpen>]
 module ReactOverloadMagic =
     type React with
+        /// Creates a disposable instance by merging multiple IDisposables.
+        static member inline createDisposable([<ParamArray>] disposables: IDisposable []) =
+            React.createDisposable(fun () ->
+                disposables
+                |> Array.iter (fun d -> d.Dispose())
+            )
+        /// Creates a disposable instance by merging multiple IDisposable options.
+        static member inline createDisposable([<ParamArray>] disposables: IDisposable option []) =
+            React.createDisposable(fun () ->
+                disposables
+                |> Array.iter (Option.iter (fun d -> d.Dispose()))
+            )
+        /// Creates a disposable instance by merging multiple IDisposable refs.
+        static member inline createDisposable([<ParamArray>] disposables: IRefValue<IDisposable> []) =
+            React.createDisposable(fun () ->
+                disposables
+                |> Array.iter (fun d -> d.current.Dispose())
+            )
+        /// Creates a disposable instance by merging multiple IDisposable refs.
+        static member inline createDisposable([<ParamArray>] disposables: IRefValue<IDisposable option> []) =
+            React.createDisposable(fun () ->
+                disposables
+                |> Array.iter (fun d -> d.current |> Option.iter (fun d -> d.Dispose()))
+            )
+        
         /// The `useState` hook that create a state variable for React function components.
         static member useState<'t>(initial: 't) = Interop.reactApi.useState<'t,'t>(initial)

--- a/tests/Tests.fsproj
+++ b/tests/Tests.fsproj
@@ -3,6 +3,7 @@
         <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
+        <ProjectReference Include="..\Feliz.UseElmish\Feliz.UseElmish.fsproj" />
         <ProjectReference Include="..\Feliz\Feliz.fsproj" />
         <ProjectReference Include="..\Feliz.Recharts\Feliz.Recharts.fsproj" />
         <ProjectReference Include="..\Feliz.Markdown\Feliz.Markdown.fsproj" />


### PR DESCRIPTION
The latest change caused some issues with downstream libraries like `Feliz.UseElmish` properly resolving the overloads to `React.createDisposable`, this change fixes that issue.

```bash
Feliz.UseElmish.1.2.2/UseElmish.fs(86,13): (89,59) error FSHARP: A unique overload for method 'useEffectOnce' could not be determined based on type information prior to this program point. A type annotation may be needed.
[1]
[1] Known type of argument: (unit -> 'a)
[1]
[1] Candidates:
[1]  - static member React.useEffectOnce : effect:(unit -> System.IDisposable option) -> unit
[1]  - static member React.useEffectOnce : effect:(unit -> System.IDisposable) -> unit
[1]  - static member React.useEffectOnce : effect:(unit -> unit) -> unit (code 41)
UseElmish.fs(87,17): (87,39) error FSHARP: A unique overload for method 'createDisposable' could not be determined based on type information prior to this program point. A type annotation may be needed.
[1]
[1] Known type of argument: (unit -> unit)
[1]
[1] Candidates:
[1]  - static member React.createDisposable : [<System.ParamArray>] disposables:IRefValue<System.IDisposable option> [] -> System.IDisposable
[1]  - static member React.createDisposable : [<System.ParamArray>] disposables:IRefValue<System.IDisposable option> [] -> System.IDisposable
[1]  - static member React.createDisposable : [<System.ParamArray>] disposables:IRefValue<System.IDisposable> [] -> System.IDisposable
[1]  - static member React.createDisposable : [<System.ParamArray>] disposables:IRefValue<System.IDisposable> [] -> System.IDisposable
[1]  - static member React.createDisposable : [<System.ParamArray>] disposables:System.IDisposable [] -> System.IDisposable
[1]  - static member React.createDisposable : [<System.ParamArray>] disposables:System.IDisposable [] -> System.IDisposable
[1]  - static member React.createDisposable : [<System.ParamArray>] disposables:System.IDisposable option [] -> System.IDisposable
[1]  - static member React.createDisposable : [<System.ParamArray>] disposables:System.IDisposable option [] -> System.IDisposable
[1]  - static member React.createDisposable : dispose:(unit -> unit) -> System.IDisposable (code 41)
```