### PR TITLE
Fix prop.transform for Svg elements

### DIFF
--- a/Feliz/Length.fs
+++ b/Feliz/Length.fs
@@ -84,7 +84,3 @@ type length =
     static member inline auto : ICssUnit = unbox "auto"
     /// calculated length, frequency, angle, time, percentage, number or integer
     static member inline calc(value:string) : ICssUnit = unbox ("calc(" + (unbox<string>value) + ")")
-    /// There are times a unit is not appropriate, like an svg's translate.
-    static member inline nounit(value:int) : ICssUnit = unbox (unbox<string>value)
-    /// There are times a unit is not appropriate, like an svg's translate.
-    static member inline nounit(value:double) : ICssUnit = unbox (unbox<string>value)

--- a/Feliz/Length.fs
+++ b/Feliz/Length.fs
@@ -84,3 +84,7 @@ type length =
     static member inline auto : ICssUnit = unbox "auto"
     /// calculated length, frequency, angle, time, percentage, number or integer
     static member inline calc(value:string) : ICssUnit = unbox ("calc(" + (unbox<string>value) + ")")
+    /// There are times a unit is not appropriate, like an svg's translate.
+    static member inline nounit(value:int) : ICssUnit = unbox (unbox<string>value)
+    /// There are times a unit is not appropriate, like an svg's translate.
+    static member inline nounit(value:double) : ICssUnit = unbox (unbox<string>value)

--- a/Feliz/Properties.fs
+++ b/Feliz/Properties.fs
@@ -1770,7 +1770,10 @@ type prop =
         Interop.mkAttr "transform" (unbox<string> transform)
     /// Defines a list of transform definitions that are applied to an element and the element's children.
     static member inline transform (transforms: seq<ITransformProperty>) =
-        Interop.mkAttr "transform" (unbox<seq<string>> transforms |> String.concat " ")
+        let unitList = [ "px" ; "deg" ]
+        let removeUnits (s : string) =
+            List.fold (fun (ins:string) toReplace -> ins.Replace(toReplace,"")) s unitList
+        Interop.mkAttr "transform" (unbox<seq<string>> transforms |> Seq.map removeUnits |> String.concat " ")
 
     /// Sets the `type` attribute for the element.
     static member inline type' (value: string) = Interop.mkAttr "type" value

--- a/Feliz/Transform.fs
+++ b/Feliz/Transform.fs
@@ -24,7 +24,12 @@ type transform =
     /// Defines a 2D translation.
     static member inline translate(x: int, y: int) =
         unbox<ITransformProperty> (
-            "translate(" + (unbox<string> x) + "px," + (unbox<string> y) + "px)"
+            "translate(" + (unbox<string> x) + ", " + (unbox<string> y) + ")"
+        )
+    /// Defines a 2D translation.
+    static member inline translate(x: float, y: float) =
+        unbox<ITransformProperty> (
+            "translate(" + (unbox<string> x) + ", " + (unbox<string> y) + ")"
         )
     /// Defines a 2D translation.
     static member inline translate(x: ICssUnit, y: ICssUnit) =
@@ -35,7 +40,12 @@ type transform =
     /// Defines a 3D translation.
     static member inline translate3D(x: int, y: int, z: int) =
         unbox<ITransformProperty> (
-            "translate3d(" + (unbox<string> x) + "px," + (unbox<string> y) + "px," + (unbox<string> z) + "px)"
+            "translate3d(" + (unbox<string> x) + ", " + (unbox<string> y) + ", " + (unbox<string> z) + ")"
+        )
+    /// Defines a 3D translation.
+    static member inline translate3D(x: float, y: float, z: float) =
+        unbox<ITransformProperty> (
+            "translate3d(" + (unbox<string> x) + ", " + (unbox<string> y) + ", " + (unbox<string> z) + ")"
         )
     /// Defines a 3D translation.
     static member inline translate3D(x: ICssUnit, y: ICssUnit, z: ICssUnit) =
@@ -45,19 +55,28 @@ type transform =
 
     /// Defines a translation, using only the value for the X-axis.
     static member inline translateX(x: int) =
-        unbox<ITransformProperty> ("translateX(" + (unbox<string> x) + "px)")
+        unbox<ITransformProperty> ("translateX(" + (unbox<string> x) + ")")
+    /// Defines a translation, using only the value for the X-axis.
+    static member inline translateX(x: float) =
+        unbox<ITransformProperty> ("translateX(" + (unbox<string> x) + ")")
     /// Defines a translation, using only the value for the X-axis.
     static member inline translateX(x: ICssUnit) =
         unbox<ITransformProperty> ("translateX(" + (unbox<string> x) + ")")
     /// Defines a translation, using only the value for the Y-axis
     static member inline translateY(y: int) =
-        unbox<ITransformProperty> ("translateY(" + (unbox<string> y) + "px)")
+        unbox<ITransformProperty> ("translateY(" + (unbox<string> y) + ")")
+    /// Defines a translation, using only the value for the Y-axis
+    static member inline translateY(y: float) =
+        unbox<ITransformProperty> ("translateY(" + (unbox<string> y) + ")")
     /// Defines a translation, using only the value for the Y-axis
     static member inline translateY(y: ICssUnit) =
         unbox<ITransformProperty> ("translateY(" + (unbox<string> y) + ")")
     /// Defines a 3D translation, using only the value for the Z-axis
     static member inline translateZ(z: int) =
-        unbox<ITransformProperty> ("translateZ(" + (unbox<string> z) + "px)")
+        unbox<ITransformProperty> ("translateZ(" + (unbox<string> z) + ")")
+    /// Defines a 3D translation, using only the value for the Z-axis
+    static member inline translateZ(z: float) =
+        unbox<ITransformProperty> ("translateZ(" + (unbox<string> z) + ")")
     /// Defines a 3D translation, using only the value for the Z-axis
     static member inline translateZ(z: ICssUnit) =
         unbox<ITransformProperty> ("translateZ(" + (unbox<string> z) + ")")

--- a/Feliz/Transform.fs
+++ b/Feliz/Transform.fs
@@ -24,12 +24,12 @@ type transform =
     /// Defines a 2D translation.
     static member inline translate(x: int, y: int) =
         unbox<ITransformProperty> (
-            "translate(" + (unbox<string> x) + ", " + (unbox<string> y) + ")"
+            "translate(" + (unbox<string> x) + "px," + (unbox<string> y) + "px)"
         )
     /// Defines a 2D translation.
     static member inline translate(x: float, y: float) =
         unbox<ITransformProperty> (
-            "translate(" + (unbox<string> x) + ", " + (unbox<string> y) + ")"
+            "translate(" + (unbox<string> x) + "px," + (unbox<string> y) + "px)"
         )
     /// Defines a 2D translation.
     static member inline translate(x: ICssUnit, y: ICssUnit) =
@@ -40,12 +40,12 @@ type transform =
     /// Defines a 3D translation.
     static member inline translate3D(x: int, y: int, z: int) =
         unbox<ITransformProperty> (
-            "translate3d(" + (unbox<string> x) + ", " + (unbox<string> y) + ", " + (unbox<string> z) + ")"
+            "translate3d(" + (unbox<string> x) + "px," + (unbox<string> y) + "px," + (unbox<string> z) + "px)"
         )
     /// Defines a 3D translation.
     static member inline translate3D(x: float, y: float, z: float) =
         unbox<ITransformProperty> (
-            "translate3d(" + (unbox<string> x) + ", " + (unbox<string> y) + ", " + (unbox<string> z) + ")"
+            "translate3d(" + (unbox<string> x) + "px," + (unbox<string> y) + "px," + (unbox<string> z) + "px)"
         )
     /// Defines a 3D translation.
     static member inline translate3D(x: ICssUnit, y: ICssUnit, z: ICssUnit) =
@@ -55,34 +55,39 @@ type transform =
 
     /// Defines a translation, using only the value for the X-axis.
     static member inline translateX(x: int) =
-        unbox<ITransformProperty> ("translateX(" + (unbox<string> x) + ")")
+        unbox<ITransformProperty> ("translateX(" + (unbox<string> x) + "px)")
     /// Defines a translation, using only the value for the X-axis.
     static member inline translateX(x: float) =
-        unbox<ITransformProperty> ("translateX(" + (unbox<string> x) + ")")
+        unbox<ITransformProperty> ("translateX(" + (unbox<string> x) + "px)")
     /// Defines a translation, using only the value for the X-axis.
     static member inline translateX(x: ICssUnit) =
         unbox<ITransformProperty> ("translateX(" + (unbox<string> x) + ")")
     /// Defines a translation, using only the value for the Y-axis
     static member inline translateY(y: int) =
-        unbox<ITransformProperty> ("translateY(" + (unbox<string> y) + ")")
+        unbox<ITransformProperty> ("translateY(" + (unbox<string> y) + "px)")
     /// Defines a translation, using only the value for the Y-axis
     static member inline translateY(y: float) =
-        unbox<ITransformProperty> ("translateY(" + (unbox<string> y) + ")")
+        unbox<ITransformProperty> ("translateY(" + (unbox<string> y) + "px)")
     /// Defines a translation, using only the value for the Y-axis
     static member inline translateY(y: ICssUnit) =
         unbox<ITransformProperty> ("translateY(" + (unbox<string> y) + ")")
     /// Defines a 3D translation, using only the value for the Z-axis
     static member inline translateZ(z: int) =
-        unbox<ITransformProperty> ("translateZ(" + (unbox<string> z) + ")")
+        unbox<ITransformProperty> ("translateZ(" + (unbox<string> z) + "px)")
     /// Defines a 3D translation, using only the value for the Z-axis
     static member inline translateZ(z: float) =
-        unbox<ITransformProperty> ("translateZ(" + (unbox<string> z) + ")")
+        unbox<ITransformProperty> ("translateZ(" + (unbox<string> z) + "px)")
     /// Defines a 3D translation, using only the value for the Z-axis
     static member inline translateZ(z: ICssUnit) =
         unbox<ITransformProperty> ("translateZ(" + (unbox<string> z) + ")")
 
     /// Defines a 2D scale transformation.
     static member inline scale(x: int, y: int) =
+        unbox<ITransformProperty> (
+            "scale(" + (unbox<string> x) + "," + (unbox<string> y) + ")"
+        )
+    /// Defines a 2D scale transformation.
+    static member inline scale(x: float, y: float) =
         unbox<ITransformProperty> (
             "scale(" + (unbox<string> x) + "," + (unbox<string> y) + ")"
         )
@@ -104,16 +109,30 @@ type transform =
         unbox<ITransformProperty> (
             "scale3d(" + (unbox<string> x) + "," + (unbox<string> y) + "," + (unbox<string> z) + ")"
         )
+    /// Defines a 3D scale transformation
+    static member inline scale3D(x: float, y: float, z: float) =
+        unbox<ITransformProperty> (
+            "scale3d(" + (unbox<string> x) + "," + (unbox<string> y) + "," + (unbox<string> z) + ")"
+        )
 
     /// Defines a scale transformation by giving a value for the X-axis.
     static member inline scaleX(x: int) =
         unbox<ITransformProperty> ("scaleX(" + (unbox<string> x) + ")")
 
+    /// Defines a scale transformation by giving a value for the X-axis.
+    static member inline scaleX(x: float) =
+        unbox<ITransformProperty> ("scaleX(" + (unbox<string> x) + ")")
     /// Defines a scale transformation by giving a value for the Y-axis.
     static member inline scaleY(y: int) =
         unbox<ITransformProperty> ("scaleY(" + (unbox<string> y) + ")")
+    /// Defines a scale transformation by giving a value for the Y-axis.
+    static member inline scaleY(y: float) =
+        unbox<ITransformProperty> ("scaleY(" + (unbox<string> y) + ")")
     /// Defines a 3D translation, using only the value for the Z-axis
     static member inline scaleZ(z: int) =
+        unbox<ITransformProperty> ("scaleZ(" + (unbox<string> z) + ")")
+    /// Defines a 3D translation, using only the value for the Z-axis
+    static member inline scaleZ(z: float) =
         unbox<ITransformProperty> ("scaleZ(" + (unbox<string> z) + ")")
     /// Defines a 2D rotation, the angle is specified in the parameter.
     static member inline rotate(deg: int) =

--- a/tests/Tests.fs
+++ b/tests/Tests.fs
@@ -759,25 +759,41 @@ let felizTests = testList "Feliz Tests" [
         Expect.equal (getTransform "test-translate3D") "translate3d(111em, 222em, 333em)" "translate3D should render"
 
     testReact "Combined translate(int) functions render correctly" <| fun _ ->
-        let render = RTL.render(Html.div [
+        let render = RTL.render(Html.g [
             prop.testId "test-combined-translate"
-            prop.style [
-                style.transform [
+            prop.transform [
                     transform.translateX 1
                     transform.translateY 2
                     transform.translateZ 3
                     transform.translate(11, 22)
                     transform.translate3D(111, 222, 333)
-                ]
+            ]
+        ])
+        let renderedTransform = (render.getByTestId "test-combined-translate").getAttribute "transform"
+        Expect.isTrue (renderedTransform.Contains "translateX(1)") "translateX should render"
+        Expect.isTrue (renderedTransform.Contains "translateY(2)") "translateY should render"
+        Expect.isTrue (renderedTransform.Contains "translateZ(3)") "translateZ should render"
+        Expect.isTrue (renderedTransform.Contains "translate(11, 22)") "translate should render"
+        Expect.isTrue (renderedTransform.Contains "translate3d(111, 222, 333)") "translate3D should render"
+
+    testReact "Combined translate(float) functions render correctly" <| fun _ ->
+        let render = RTL.render(Html.g [
+            prop.testId "test-combined-translate"
+            prop.transform [
+                    transform.translateX 1.1
+                    transform.translateY 2.2
+                    transform.translateZ 3.3
+                    transform.translate(11.1, 22.2)
+                    transform.translate3D(111.1, 222.2, 333.3)
             ]
         ])
 
-        let renderedTransform = getStyle<string> "transform" (render.getByTestId "test-combined-translate")
-        Expect.isTrue (renderedTransform.Contains "translateX(1px)") "translateX should render"
-        Expect.isTrue (renderedTransform.Contains "translateY(2px)") "translateY should render"
-        Expect.isTrue (renderedTransform.Contains "translateZ(3px)") "translateZ should render"
-        Expect.isTrue (renderedTransform.Contains "translate(11px, 22px)") "translate should render"
-        Expect.isTrue (renderedTransform.Contains "translate3d(111px, 222px, 333px)") "translate3D should render"
+        let renderedTransform = (render.getByTestId "test-combined-translate").getAttribute "transform"
+        Expect.isTrue (renderedTransform.Contains "translateX(1.1)") "translateX should render"
+        Expect.isTrue (renderedTransform.Contains "translateY(2.2)") "translateY should render"
+        Expect.isTrue (renderedTransform.Contains "translateZ(3.3)") "translateZ should render"
+        Expect.isTrue (renderedTransform.Contains "translate(11.1, 22.2)") "translate should render"
+        Expect.isTrue (renderedTransform.Contains "translate3d(111.1, 222.2, 333.3)") "translate3D should render"
 
     testReact "Combined translate(ICssUnit) functions render correctly" <| fun _ ->
         let render = RTL.render(Html.div [

--- a/tests/Tests.fs
+++ b/tests/Tests.fs
@@ -758,13 +758,33 @@ let felizTests = testList "Feliz Tests" [
         Expect.equal (getTransform "test-translate") "translate(11em, 22em)" "translate should render"
         Expect.equal (getTransform "test-translate3D") "translate3d(111em, 222em, 333em)" "translate3D should render"
 
-    testReact "Combined translate(int) functions render correctly" <| fun _ ->
+    testReact "Combined translate functions render correctly for style.transform" <| fun _ ->
+        let render = RTL.render(Html.div [
+            prop.testId "test-combined-translate"
+            prop.style [
+                style.transform [
+                    transform.translateX 1
+                    transform.translateY 2.2
+                    transform.translateZ (length.em 3.3)
+                    transform.translate(11,22)
+                    transform.translate3D(111,222,333)
+                ]
+            ]
+        ])
+        let renderedTransform = getStyle<string> "transform" (render.getByTestId "test-combined-translate")
+        Expect.isTrue (renderedTransform.Contains "translateX(1px)") "translateX should render"
+        Expect.isTrue (renderedTransform.Contains "translateY(2.2px)") "translateY should render"
+        Expect.isTrue (renderedTransform.Contains "translateZ(3.3em)") "translateZ should render"
+        Expect.isTrue (renderedTransform.Contains "translate(11px, 22px)") "translate should render"
+        Expect.isTrue (renderedTransform.Contains "translate3d(111px, 222px, 333px)") "translate3D should render"
+
+    testReact "Combined translate(int) functions render correctly for prop.transform" <| fun _ ->
         let render = RTL.render(Html.g [
             prop.testId "test-combined-translate"
             prop.transform [
                     transform.translateX 1
                     transform.translateY 2
-                    transform.translateZ 3
+                    transform.translateZ (length.px 3)
                     transform.translate(11, 22)
                     transform.translate3D(111, 222, 333)
             ]
@@ -773,16 +793,16 @@ let felizTests = testList "Feliz Tests" [
         Expect.isTrue (renderedTransform.Contains "translateX(1)") "translateX should render"
         Expect.isTrue (renderedTransform.Contains "translateY(2)") "translateY should render"
         Expect.isTrue (renderedTransform.Contains "translateZ(3)") "translateZ should render"
-        Expect.isTrue (renderedTransform.Contains "translate(11, 22)") "translate should render"
-        Expect.isTrue (renderedTransform.Contains "translate3d(111, 222, 333)") "translate3D should render"
+        Expect.isTrue (renderedTransform.Contains "translate(11,22)") "translate should render"
+        Expect.isTrue (renderedTransform.Contains "translate3d(111,222,333)") "translate3D should render"
 
-    testReact "Combined translate(float) functions render correctly" <| fun _ ->
+    testReact "Combined translate(float) functions render correctly for prop.transform" <| fun _ ->
         let render = RTL.render(Html.g [
             prop.testId "test-combined-translate"
             prop.transform [
                     transform.translateX 1.1
                     transform.translateY 2.2
-                    transform.translateZ 3.3
+                    transform.translateZ (length.px 3.3)
                     transform.translate(11.1, 22.2)
                     transform.translate3D(111.1, 222.2, 333.3)
             ]
@@ -792,8 +812,8 @@ let felizTests = testList "Feliz Tests" [
         Expect.isTrue (renderedTransform.Contains "translateX(1.1)") "translateX should render"
         Expect.isTrue (renderedTransform.Contains "translateY(2.2)") "translateY should render"
         Expect.isTrue (renderedTransform.Contains "translateZ(3.3)") "translateZ should render"
-        Expect.isTrue (renderedTransform.Contains "translate(11.1, 22.2)") "translate should render"
-        Expect.isTrue (renderedTransform.Contains "translate3d(111.1, 222.2, 333.3)") "translate3D should render"
+        Expect.isTrue (renderedTransform.Contains "translate(11.1,22.2)") "translate should render"
+        Expect.isTrue (renderedTransform.Contains "translate3d(111.1,222.2,333.3)") "translate3D should render"
 
     testReact "Combined translate(ICssUnit) functions render correctly" <| fun _ ->
         let render = RTL.render(Html.div [


### PR DESCRIPTION
Feliz.transform.translate is an example where this change is useful. The
function accepts `ICssUnit * ICssUnit`. However, the SVG spec does not
expect a unit for the numbers given in the translate part of a
transformation. This allows the api to remain the same (no sudden change
on what is expected), but outputs what is need to have transformations work.