### PR TITLE
Feliz v1.17 with new [Hook] attribute

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "fable": {
-      "version": "3.0.0-nagareyama-beta-002",
+      "version": "3.0.0-nagareyama-rc-007",
       "commands": [
         "fable"
       ]

--- a/Feliz.CompilerPlugins/AstUtils.fs
+++ b/Feliz.CompilerPlugins/AstUtils.fs
@@ -70,6 +70,10 @@ let isRecord (compiler: PluginHelper) (fableType: Fable.Type) =
     | Fable.Type.DeclaredType (entity, genericArgs) -> compiler.GetEntity(entity).IsFSharpRecord
     | _ -> false
 
+let isReactElement (fableType: Fable.Type) =
+    match fableType with
+    | Fable.Type.DeclaredType (entity, genericArgs) -> entity.QualifiedName.EndsWith "ReactElement"
+    | _ -> false
 
 let recordHasField name (compiler: PluginHelper) (fableType: Fable.Type) =
     match fableType with

--- a/Feliz.CompilerPlugins/Feliz.CompilerPlugins.fsproj
+++ b/Feliz.CompilerPlugins/Feliz.CompilerPlugins.fsproj
@@ -6,14 +6,15 @@
     <PackageLicenseUrl>https://github.com/Zaid-Ajaj/Feliz/blob/master/LICENSE</PackageLicenseUrl>
     <PackageTags>fsharp;fable;react;html</PackageTags>
     <Authors>Zaid Ajaj</Authors>
-    <Version>0.3.0</Version>
+    <Version>0.4.0</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageReleaseNotes>Update AST version</PackageReleaseNotes>
+    <PackageReleaseNotes>Implement [Hook] Attribute</PackageReleaseNotes>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AstUtils.fs" />
     <Compile Include="ReactComponent.fs" />
+    <Compile Include="Hook.fs" />
     <Compile Include="PrimitiveElement.fs" />
     <Compile Include="PrimitiveElementWithChildren.fs" />
   </ItemGroup>

--- a/Feliz.CompilerPlugins/Hook.fs
+++ b/Feliz.CompilerPlugins/Hook.fs
@@ -1,0 +1,41 @@
+namespace Feliz
+
+open Fable
+open Fable.AST
+
+/// <summary>Applies to custom defined React hooks to ensure the generated code starts with "use" in order for fast-refresh to pick it up</summary>
+type HookAttribute() =
+    inherit MemberDeclarationPluginAttribute()
+    override _.FableMinimumVersion = "3.0"
+
+    /// <summary>Transforms call-site into createElement calls</summary>
+    override _.TransformCall(compiler, memb, expr) =
+        let membArgs = memb.CurriedParameterGroups |> List.concat
+        match expr with
+        | Fable.Call(callee, info, typeInfo, range) ->
+            let callee =
+                match callee with
+                | Fable.Expr.IdentExpr ident ->
+                    // capitalize same-file references
+                    Fable.Expr.IdentExpr { ident with Name = "use" + ident.Name }
+                | Fable.Expr.Import(importInfo, fableType, sourceLocation) ->
+                    // capitalize component imports from different modules/files
+                    let selector = "use" + importInfo.Selector
+                    let modifiedImportInfo = { importInfo with Selector = selector }
+                    Fable.Expr.Import(modifiedImportInfo, fableType, sourceLocation)
+                | _ ->
+                    callee
+
+            Fable.Call(callee, info, typeInfo, range)
+
+        | _ ->
+            expr
+
+    override this.Transform(compiler, decl) =
+        if decl.Info.IsValue || decl.Info.IsGetter || decl.Info.IsSetter then
+            // Invalid attribute usage
+            let errorMessage = sprintf "Expecting a function declation for %s when using [<Hook>]" decl.Name
+            compiler.LogWarning(errorMessage, ?range=decl.Body.Range)
+            decl
+        else
+            { decl with Name = "use" + decl.Name }

--- a/Feliz.CompilerPlugins/ReactComponent.fs
+++ b/Feliz.CompilerPlugins/ReactComponent.fs
@@ -61,6 +61,11 @@ type ReactComponentAttribute(exportDefault: bool) =
             let errorMessage = sprintf "Expecting a function declation for %s when using [<ReactComponent>]" decl.Name
             compiler.LogWarning(errorMessage, ?range=decl.Body.Range)
             decl
+        else if not (AstUtils.isReactElement decl.Body.Type) then
+            // output of a React function component must be a ReactElement
+            let errorMessage = sprintf "Expected function %s to return a ReactElement when using [<ReactComponent>]" decl.Name
+            compiler.LogWarning(errorMessage, ?range=decl.Body.Range)
+            decl
         else
             // TODO: make sure isRecord works with records
             if decl.Args.Length = 1 && AstUtils.isRecord compiler decl.Args.[0].Type then

--- a/Feliz.Delay/Feliz.Delay.fsproj
+++ b/Feliz.Delay/Feliz.Delay.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <PackageVersion>0.2.1</PackageVersion>
+    <PackageVersion>0.3.0</PackageVersion>
     <Authors>Cody Johnson, Zaid Ajaj</Authors>
     <Description>Adds easy to use delayed rendering</Description>
     <PackageLicenseUrl>https://github.com/Zaid-Ajaj/Feliz/blob/master/LICENSE</PackageLicenseUrl>
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="4.7.0" />
+    <PackageReference Update="FSharp.Core" Version="4.7.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Feliz\Feliz.fsproj" />

--- a/Feliz.Markdown/Feliz.Markdown.fsproj
+++ b/Feliz.Markdown/Feliz.Markdown.fsproj
@@ -6,7 +6,7 @@
         <PackageIconUrl></PackageIconUrl>
         <PackageTags>fsharp;fable;react;html</PackageTags>
         <Authors>Zaid Ajaj</Authors>
-        <Version>1.2.0</Version>
+        <Version>1.3.0</Version>
         <TargetFramework>netstandard2.0</TargetFramework>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
@@ -25,6 +25,6 @@
         <Content Include="*.fsproj; *.fs; *.js;" PackagePath="fable\" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Update="FSharp.Core" Version="4.7.0" />
+        <PackageReference Update="FSharp.Core" Version="4.7.2" />
     </ItemGroup>
 </Project>

--- a/Feliz.PigeonMaps/Feliz.PigeonMaps.fsproj
+++ b/Feliz.PigeonMaps/Feliz.PigeonMaps.fsproj
@@ -6,7 +6,7 @@
         <PackageIconUrl></PackageIconUrl>
         <PackageTags>fsharp;fable;react;html</PackageTags>
         <Authors>Zaid Ajaj</Authors>
-        <Version>2.3.0</Version>
+        <Version>2.4.0</Version>
         <TargetFramework>netstandard2.0</TargetFramework>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageReleaseNotes>Update Feliz dependency</PackageReleaseNotes>
@@ -29,6 +29,6 @@
         <Content Include="*.fsproj; *.fs; *.js;" PackagePath="fable\" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Update="FSharp.Core" Version="4.7.0" />
+        <PackageReference Update="FSharp.Core" Version="4.7.2" />
     </ItemGroup>
 </Project>

--- a/Feliz.Popover/Feliz.Popover.fsproj
+++ b/Feliz.Popover/Feliz.Popover.fsproj
@@ -6,7 +6,7 @@
         <PackageIconUrl></PackageIconUrl>
         <PackageTags>fsharp;fable;react;html</PackageTags>
         <Authors>Zaid Ajaj</Authors>
-        <Version>2.2.0</Version>
+        <Version>2.3.0</Version>
         <TargetFramework>netstandard2.0</TargetFramework>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageReleaseNotes>Update Feliz dependency</PackageReleaseNotes>
@@ -26,6 +26,6 @@
         <Content Include="*.fsproj; *.fs; *.js;" PackagePath="fable\" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Update="FSharp.Core" Version="4.7.0" />
+        <PackageReference Update="FSharp.Core" Version="4.7.2" />
     </ItemGroup>
 </Project>

--- a/Feliz.Recharts/Feliz.Recharts.fsproj
+++ b/Feliz.Recharts/Feliz.Recharts.fsproj
@@ -6,7 +6,7 @@
         <PackageIconUrl></PackageIconUrl>
         <PackageTags>fsharp;fable;react;html</PackageTags>
         <Authors>Zaid Ajaj</Authors>
-        <Version>3.0.0</Version>
+        <Version>3.1.0</Version>
         <TargetFramework>netstandard2.0</TargetFramework>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageReleaseNotes>Distinguished types for the various charts instead of a generic IReactProperty</PackageReleaseNotes>
@@ -46,6 +46,6 @@
         <Content Include="*.fsproj; *.fs; *.js;" PackagePath="fable\" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Update="FSharp.Core" Version="4.7.0" />
+        <PackageReference Update="FSharp.Core" Version="4.7.2" />
     </ItemGroup>
 </Project>

--- a/Feliz.RoughViz/Feliz.RoughViz.fsproj
+++ b/Feliz.RoughViz/Feliz.RoughViz.fsproj
@@ -6,7 +6,7 @@
         <PackageIconUrl></PackageIconUrl>
         <PackageTags>fsharp;fable;react;html;feliz</PackageTags>
         <Authors>Zaid Ajaj</Authors>
-        <Version>1.3.0</Version>
+        <Version>1.4.0</Version>
         <TargetFramework>netstandard2.0</TargetFramework>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageReleaseNotes>Update Feliz dependency</PackageReleaseNotes>
@@ -27,6 +27,6 @@
         <Content Include="*.fsproj; *.fs; *.js;" PackagePath="fable\" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Update="FSharp.Core" Version="4.7.0" />
+        <PackageReference Update="FSharp.Core" Version="4.7.2" />
     </ItemGroup>
 </Project>

--- a/Feliz.UseDeferred/Feliz.UseDeferred.fsproj
+++ b/Feliz.UseDeferred/Feliz.UseDeferred.fsproj
@@ -6,10 +6,10 @@
         <PackageIconUrl></PackageIconUrl>
         <PackageTags>fsharp;fable;react;html;feliz</PackageTags>
         <Authors>Zaid Ajaj</Authors>
-        <Version>1.3.0</Version>
+        <Version>1.4.0</Version>
         <TargetFramework>netstandard2.0</TargetFramework>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <PackageReleaseNotes>Update Feliz dependency</PackageReleaseNotes>
+        <PackageReleaseNotes>Update Feliz dependency and use [Hook]</PackageReleaseNotes>
     </PropertyGroup>
     <ItemGroup>
         <Compile Include="UseDeferred.fs" />
@@ -21,6 +21,6 @@
         <Content Include="*.fsproj; *.fs; *.js;" PackagePath="fable\" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Update="FSharp.Core" Version="4.7.0" />
+        <PackageReference Update="FSharp.Core" Version="4.7.2" />
     </ItemGroup>
 </Project>

--- a/Feliz.UseDeferred/UseDeferred.fs
+++ b/Feliz.UseDeferred/UseDeferred.fs
@@ -60,6 +60,7 @@ open Feliz
 [<AutoOpen>]
 module ReactHookExtensions =
     type React with
+        [<Hook>]
         static member useDeferred(operation: Async<'T>, dependencies: obj array) =
             let (deferred, setDeferred) = React.useState(Deferred.HasNotStartedYet)
             let token = React.useCancellationToken()
@@ -79,6 +80,7 @@ module ReactHookExtensions =
 
             deferred
 
+        [<Hook>]
         static member useDeferredCallback(operation: 'TIn -> Async<'TOut>, setDeferred: Deferred<'TOut> -> unit) =
             let cancellationToken = React.useRef(new System.Threading.CancellationTokenSource())
             let executeOperation arg = async {
@@ -104,9 +106,10 @@ module ReactHookExtensions =
 
             start
 
+        [<Hook>]
         static member useDeferredParallel<'T, 'U, 'Key when 'Key : comparison>(deferred: Deferred<'T>, map: 'T -> ('Key * Async<'U>) list) =
-            let (data, setData) = React.useState(Map.empty)
-            let addData = React.useCallbackRef(fun (key, value) -> setData(Map.add key value data))
+            let (data, setData) = React.useStateWithUpdater(Map.empty)
+            let addData = React.useCallbackRef(fun (key, value) -> setData(fun prev -> Map.add key value prev))
             let token = React.useCancellationToken()
             let mapKeyedOperatons (operations: ('Key * Async<'U>) list) = [
                 for (key, operation) in operations do

--- a/Feliz.UseElmish/Feliz.UseElmish.fsproj
+++ b/Feliz.UseElmish/Feliz.UseElmish.fsproj
@@ -6,10 +6,10 @@
         <PackageIconUrl></PackageIconUrl>
         <PackageTags>fsharp;fable;react;html;feliz</PackageTags>
         <Authors>Zaid Ajaj</Authors>
-        <Version>1.4.1</Version>
+        <Version>1.5.0</Version>
         <TargetFramework>netstandard2.0</TargetFramework>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <PackageReleaseNotes>Fix IDisposable overloads</PackageReleaseNotes>
+        <PackageReleaseNotes>Update Feliz dependency, use [Hook]</PackageReleaseNotes>
     </PropertyGroup>
     <ItemGroup>
         <Compile Include="UseElmish.fs" />
@@ -21,7 +21,7 @@
         <Content Include="*.fsproj; *.fs; *.js;" PackagePath="fable\" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Update="FSharp.Core" Version="4.7.0" />
+        <PackageReference Update="FSharp.Core" Version="4.7.2" />
         <PackageReference Include="Fable.Promise" Version="2.0.0" />
         <PackageReference Include="Fable.Elmish" Version="3.0.6" />
     </ItemGroup>

--- a/Feliz.UseElmish/UseElmish.fs
+++ b/Feliz.UseElmish/UseElmish.fs
@@ -56,12 +56,13 @@ module UseElmishExtensions =
         | _ -> None
 
     type React with
+        [<Hook>]
         static member useElmish<'State,'Msg> (init: 'State * Cmd<'Msg>, update: 'Msg -> 'State -> 'State * Cmd<'Msg>, dependencies: obj[]) =
             let state = React.useRef(fst init)
             let ring = React.useRef(RingBuffer(10))
             let childState, setChildState = React.useState(fst init)
             let token = React.useCancellationToken()
-            let setChildState () = 
+            let setChildState () =
                 JS.setTimeout(fun () ->
                     if not token.current.IsCancellationRequested then
                         setChildState state.current
@@ -83,9 +84,9 @@ module UseElmishExtensions =
 
             let dispatch = React.useCallbackRef(dispatch)
 
-            React.useEffect((fun () -> 
-                React.createDisposable(fun () -> 
-                    getDisposable state.current 
+            React.useEffect((fun () ->
+                React.createDisposable(fun () ->
+                    getDisposable state.current
                     |> Option.iter (fun o -> o.Dispose())
                 )
             ), dependencies)
@@ -102,13 +103,16 @@ module UseElmishExtensions =
 
             (childState, dispatch)
 
+        [<Hook>]
         static member inline useElmish<'State,'Msg> (init: 'State * Cmd<'Msg>, update: 'Msg -> 'State -> 'State * Cmd<'Msg>) =
             React.useElmish(init, update, [||])
 
+        [<Hook>]
         static member useElmish<'State,'Msg> (init: unit -> 'State * Cmd<'Msg>, update: 'Msg -> 'State -> 'State * Cmd<'Msg>, dependencies: obj[]) =
             let init = React.useMemo(init, dependencies)
 
             React.useElmish(init, update, dependencies)
 
+        [<Hook>]
         static member inline useElmish<'State,'Msg> (init: unit -> 'State * Cmd<'Msg>, update: 'Msg -> 'State -> 'State * Cmd<'Msg>) =
             React.useElmish(init, update, [||])

--- a/Feliz.UseMediaQuery/Feliz.UseMediaQuery.fsproj
+++ b/Feliz.UseMediaQuery/Feliz.UseMediaQuery.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <PackageVersion>1.3.0</PackageVersion>
+    <PackageVersion>1.4.0</PackageVersion>
     <Authors>Jonas Bösch, Zaid Ajaj</Authors>
     <Description>useMediaQuery hooks to build responsive websites </Description>
     <PackageLicenseUrl>https://github.com/Zaid-Ajaj/Feliz/blob/master/LICENSE</PackageLicenseUrl>
@@ -20,7 +20,7 @@
     <PackageReference Include="Fable.Browser.MediaQueryList" Version="1.1.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="4.7.0" />
+    <PackageReference Update="FSharp.Core" Version="4.7.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Feliz\Feliz.fsproj" />

--- a/Feliz.UseMediaQuery/UseMediaQuery.fs
+++ b/Feliz.UseMediaQuery/UseMediaQuery.fs
@@ -28,7 +28,7 @@ module Breakpoints =
         WideScreen = 1216
     }
 
-let inline private maxWidth (breakpoint: int) = 
+let inline private maxWidth (breakpoint: int) =
     "(max-width: " + (unbox<string> breakpoint) + "px)"
 
 let private makeQueries breakpoints =
@@ -49,6 +49,7 @@ module UseMediaQueryExtension =
      type React with
         /// A hook for media queries, this hook will force a component
         /// to re-render when the specified media query changes.
+        [<Hook>]
         static member useMediaQuery (mediaQuery: string) =
             let mq, setMq = React.useState(fun () -> window.matchMedia(mediaQuery).matches)
 
@@ -57,7 +58,7 @@ module UseMediaQueryExtension =
                 let handler = fun () -> setMq mediaQueryList.matches
 
                 handler()
-                
+
                 addListener mediaQueryList handler
 
                 React.createDisposable(fun () -> removeListener mediaQueryList handler)
@@ -68,6 +69,7 @@ module UseMediaQueryExtension =
         /// A hook for responsive design, this hook will force a component
         /// to re-render the components on resize.
         /// Returns a discriminated union with the new width.
+        [<Hook>]
         static member useResponsive(?breakpoints: Breakpoints) =
             let breakpoints = Option.defaultValue Breakpoints.defaults breakpoints
             let m, l, t, d = makeQueries breakpoints

--- a/Feliz/Feliz.fsproj
+++ b/Feliz/Feliz.fsproj
@@ -7,10 +7,10 @@
     <PackageLicenseUrl>https://github.com/Zaid-Ajaj/Feliz/blob/master/LICENSE</PackageLicenseUrl>
     <PackageTags>fsharp;fable;react;html</PackageTags>
     <Authors>Zaid Ajaj</Authors>
-    <Version>1.16.2</Version>
+    <Version>1.17.0</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageReleaseNotes>Only implement [ReactComponent], hide [PrimitiveElement] for now for another release</PackageReleaseNotes>
+    <PackageReleaseNotes>Implement prop.wrap for textarea elements and introduce [Hook] attribute</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <NpmDependencies>

--- a/Feliz/React.fs
+++ b/Feliz/React.fs
@@ -69,30 +69,36 @@ type React =
     static member inline keyedFragment(key: System.Guid, xs) = Fable.React.Helpers.fragment [ !!("key", string key) ] xs
 
     /// The `useState` hook that create a state variable for React function components from a initialization function.
+    [<Hook>]
     static member useState<'t>(initializer: unit -> 't) = Interop.reactApi.useState<unit -> 't,'t>(initializer)
 
     /// Accepts a reducer and returns the current state paired with a dispatch.
+    [<Hook>]
     static member useReducer(update, initialState) = Interop.reactApi.useReducer update initialState
 
     /// The `useEffect` hook that creates a disposable effect for React function components
     /// This effect has no dependencies which means the effect is re-executed on every re-render.
     /// To make the effect run once (for example you subscribe once to web sockets) then provide an empty array
     /// for the dependencies: `React.useEffect(disposableEffect, [| |])`.
+    [<Hook>]
     static member useEffect(effect: unit -> #IDisposable) : unit = ReactInterop.useEffect(effect)
     /// The `useEffect` hook that creates a disposable effect for React function components
     /// This effect has no dependencies which means the effect is re-executed on every re-render.
     /// To make the effect run once (for example you subscribe once to web sockets) then provide an empty array
     /// for the dependencies: `React.useEffect(disposableEffect, [| |])`.
+    [<Hook>]
     static member inline useEffect(effect: unit -> #IDisposable option) = React.useEffect(effect >> Helpers.optDispose)
     /// The `useEffect` hook that creates a disposable effect for React function components.
     /// This effect takes a array of *dependencies*.
     /// Whenever any of these dependencies change, the effect is re-executed. To execute the effect only once,
     /// you have to explicitly provide an empty array for the dependencies: `React.useEffect(effect, [| |])`.
+    [<Hook>]
     static member useEffect(effect: unit -> #IDisposable, dependencies: obj []) : unit = ReactInterop.useEffectWithDeps effect dependencies
     /// The `useEffect` hook that creates a disposable effect for React function components.
     /// This effect takes a array of *dependencies*.
     /// Whenever any of these dependencies change, the effect is re-executed. To execute the effect only once,
     /// you have to explicitly provide an empty array for the dependencies: `React.useEffect(effect, [| |])`.
+    [<Hook>]
     static member inline useEffect(effect: unit -> #IDisposable option, dependencies: obj []) = React.useEffect(effect >> Helpers.optDispose, dependencies)
 
     /// The `useLayoutEffect` hook that creates a disposable effect for React function components
@@ -100,28 +106,33 @@ type React =
     /// To make the effect run once (for example you subscribe once to web sockets) then provide an empty array
     /// for the dependencies: `React.useLayoutEffect(disposableEffect, [| |])`.
     /// The signature is identical to useEffect, but it fires synchronously after all DOM mutations. Use this to read layout from the DOM and synchronously re-render. Updates scheduled inside useLayoutEffect will be flushed synchronously, before the browser has a chance to paint.
+    [<Hook>]
     static member useLayoutEffect(effect: unit -> #IDisposable) : unit = ReactInterop.useLayoutEffect(effect)
     /// The `useLayoutEffect` hook that creates a disposable effect for React function components
     /// This effect has no dependencies which means the effect is re-executed on every re-render.
     /// To make the effect run once (for example you subscribe once to web sockets) then provide an empty array
     /// for the dependencies: `React.useLayoutEffect(disposableEffect, [| |])`.
     /// The signature is identical to useEffect, but it fires synchronously after all DOM mutations. Use this to read layout from the DOM and synchronously re-render. Updates scheduled inside useLayoutEffect will be flushed synchronously, before the browser has a chance to paint.
+    [<Hook>]
     static member inline useLayoutEffect(effect: unit -> #IDisposable option) = React.useLayoutEffect(effect >> Helpers.optDispose)
     /// The `useLayoutEffect` hook that creates a disposable effect for React function components.
     /// This effect takes a array of *dependencies*.
     /// Whenever any of these dependencies change, the effect is re-executed. To execute the effect only once,
     /// you have to explicitly provide an empty array for the dependencies: `React.useLayoutEffect(effect, [| |])`.
     /// The signature is identical to useEffect, but it fires synchronously after all DOM mutations. Use this to read layout from the DOM and synchronously re-render. Updates scheduled inside useLayoutEffect will be flushed synchronously, before the browser has a chance to paint.
+    [<Hook>]
     static member useLayoutEffect(effect: unit -> #IDisposable, dependencies: obj []) : unit = ReactInterop.useLayoutEffectWithDeps effect dependencies
     /// The `useLayoutEffect` hook that creates a disposable effect for React function components.
     /// This effect takes a array of *dependencies*.
     /// Whenever any of these dependencies change, the effect is re-executed. To execute the effect only once,
     /// you have to explicitly provide an empty array for the dependencies: `React.useLayoutEffect(effect, [| |])`.
     /// The signature is identical to useEffect, but it fires synchronously after all DOM mutations. Use this to read layout from the DOM and synchronously re-render. Updates scheduled inside useLayoutEffect will be flushed synchronously, before the browser has a chance to paint.
+    [<Hook>]
     static member inline useLayoutEffect(effect: unit -> #IDisposable option, dependencies: obj []) =
         React.useLayoutEffect(effect >> Helpers.optDispose, dependencies)
     /// The signature is identical to useEffect, but it fires synchronously after all DOM mutations. Use this to read layout from the DOM and synchronously re-render. Updates scheduled inside useLayoutEffect will be flushed synchronously, before the browser has a chance to paint.
     /// This effect is executed on every (re)render
+    [<Hook>]
     static member useLayoutEffect(effect: unit -> unit) =
         ReactInterop.useLayoutEffect
             (fun _ ->
@@ -129,6 +140,7 @@ type React =
                 React.createDisposable(ignore))
 
     /// The signature is identical to useEffect, but it fires synchronously after all DOM mutations. Use this to read layout from the DOM and synchronously re-render. Updates scheduled inside useLayoutEffect will be flushed synchronously, before the browser has a chance to paint.
+    [<Hook>]
     static member useLayoutEffect(effect: unit -> unit, dependencies: obj []) =
         ReactInterop.useLayoutEffectWithDeps
             (fun _ ->
@@ -136,26 +148,32 @@ type React =
                 React.createDisposable(ignore))
             dependencies
 
+    [<Hook>]
     static member inline useLayoutEffectOnce(effect: unit -> unit) =
          React.useLayoutEffect(effect, [| |])
 
+    [<Hook>]
     static member inline useLayoutEffectOnce(effect: unit -> #IDisposable) =
         React.useLayoutEffect(effect, [| |])
 
+    [<Hook>]
     static member inline useLayoutEffectOnce(effect: unit -> #IDisposable option) =
         React.useLayoutEffect(effect, [| |])
 
     /// React hook to define and use an effect only once when a function component renders for the first time.
     /// This an alias for `React.useEffect(effect, [| |])` which explicitly provide an empty array for the dependencies of the effect which means the effect will only run once.
+    [<Hook>]
     static member useEffectOnce(effect: unit -> unit) =
         React.useEffect(effect, [| |])
 
     /// React hook to define and use a disposable effect only once when a function component renders for the first time.
     /// This an alias for `React.useEffect(effect, [| |])` which explicitly provide an empty array for the dependencies of the effect which means the effect will only run once.
+    [<Hook>]
     static member useEffectOnce(effect: unit -> #IDisposable) =
         React.useEffect(effect, [| |])
     /// React hook to define and use a disposable effect only once when a function component renders for the first time.
     /// This an alias for `React.useEffect(effect, [| |])` which explicitly provide an empty array for the dependencies of the effect which means the effect will only run once.
+    [<Hook>]
     static member useEffectOnce(effect: unit -> #IDisposable option) =
         React.useEffect(effect >> Helpers.optDispose, [| |])
 
@@ -164,6 +182,7 @@ type React =
     ///
     /// To make the effect run only once, write: `React.useEffect(effect, [| |])` which explicitly states
     /// that this effect has no dependencies and should only run once on initial render.
+    [<Hook>]
     static member useEffect(effect: unit -> unit) : unit =
         ReactInterop.useEffect
             (fun _ ->
@@ -173,6 +192,7 @@ type React =
     /// The `useEffect` hook that creates an effect for React function components. This effect takes a array of *dependencies*.
     /// Whenever any of these dependencies change, the effect is re-executed. To execute the effect only once,
     /// you have to explicitly provide an empty array for the dependencies: `React.useEffect(effect, [| |])`.
+    [<Hook>]
     static member useEffect(effect: unit -> unit, dependencies: obj []) : unit =
         ReactInterop.useEffectWithDeps
             (fun _ ->
@@ -181,10 +201,12 @@ type React =
             dependencies
 
     /// Can be used to display a label for custom hooks in React DevTools.
+    [<Hook>]
     static member useDebugValue(value: string) =
         ReactInterop.useDebugValueWithFormatter(value, id)
 
     /// Can be used to display a label for custom hooks in React DevTools.
+    [<Hook>]
     static member useDebugValue(value: 't, formatter: 't -> string) =
         ReactInterop.useDebugValueWithFormatter(value, formatter)
 
@@ -195,25 +217,30 @@ type React =
     /// <param name='callbackFunction'>A callback function to be memoized.</param>
     /// <param name='dependencies'>An array of dependencies upon which the callback function depends.
     /// If not provided, defaults to empty array, representing dependencies that never change.</param>
+    [<Hook>]
     static member useCallback(callbackFunction: 'a -> 'b, ?dependencies: obj array) =
         Interop.reactApi.useCallback callbackFunction (defaultArg dependencies [||])
 
     /// Returns a mutable ref object whose .current property is initialized to the passed argument (initialValue). The returned object will persist for the full lifetime of the component.
     ///
     /// Essentially, useRef is like a container that can hold a mutable value in its .current property.
+    [<Hook>]
     static member useRef(initialValue) = Interop.reactApi.useRef(initialValue)
 
     /// A specialized version of React.useRef() that creates a reference to an input element.
     ///
     /// Useful for controlling the internal properties and methods that element, for example to enable focus().
+    [<Hook>]
     static member useInputRef() : IRefValue<HTMLInputElement option> = React.useRef(None)
 
     /// A specialized version of React.useRef() that creates a reference to a button element.
+    [<Hook>]
     static member useButtonRef() : IRefValue<HTMLButtonElement option> = React.useRef(None)
 
     /// A specialized version of React.useRef() that creates a reference to a generic HTML element.
     ///
     /// Useful for controlling the internal properties and methods that element, for integration with third-party libraries that require a Html element.
+    [<Hook>]
     static member useElementRef() : IRefValue<HTMLElement option> = React.useRef(None)
 
     /// <summary>
@@ -223,6 +250,7 @@ type React =
     /// <param name='createFunction'>A create function returning a value to be memoized.</param>
     /// <param name='dependencies'>An array of dependencies upon which the create function depends.
     /// If not provided, defaults to empty array, representing dependencies that never change.</param>
+    [<Hook>]
     static member useMemo(createFunction: unit -> 'a, ?dependencies: obj array) =
         Interop.reactApi.useMemo createFunction (defaultArg dependencies [||])
 
@@ -370,6 +398,7 @@ type React =
     /// The current context value is determined by the value prop of the nearest Provider component above the calling component in the tree.
     /// </summary>
     /// <param name='contextObject'>A context object returned from a previous React.createContext call.</param>
+    [<Hook>]
     static member useContext(contextObject: Fable.React.IContext<'a>) = Interop.reactApi.useContext contextObject
 
     /// <summary>
@@ -382,6 +411,7 @@ type React =
     /// dependency declarations and never causes a re-render.
     /// </summary>
     /// <param name='callback'>The function call.</param>
+    [<Hook>]
     static member useCallbackRef(callback: ('a -> 'b)) =
         let lastRenderCallbackRef = React.useRef(callback)
 
@@ -490,6 +520,7 @@ type React =
     /// </summary>
     /// <param name='ref'>The ref you want to override.</param>
     /// <param name='createHandle'>A function that returns a new ref with changed behavior.</param>
+    [<Hook>]
     static member useImperativeHandle(ref: IRefValue<'t>, createHandle: unit -> 't) =
         Interop.reactApi.useImperativeHandleNoDeps ref createHandle
 
@@ -502,12 +533,14 @@ type React =
     /// <param name='ref'>The ref you want to override.</param>
     /// <param name='createHandle'>A function that returns a new ref with changed behavior.</param>
     /// <param name='dependencies'>An array of dependencies upon which the imperative handle function depends.</param>
+    [<Hook>]
     static member useImperativeHandle(ref: IRefValue<'t>, createHandle: unit -> 't, dependencies: obj []) =
         Interop.reactApi.useImperativeHandle ref createHandle dependencies
 
     /// <summary>
     /// Creates a CancellationToken that is cancelled when a component is unmounted.
     /// </summary>
+    [<Hook>]
     static member inline useCancellationToken () =
         let cts = React.useRef(new System.Threading.CancellationTokenSource())
         let token = React.useRef(cts.current.Token)
@@ -542,6 +575,7 @@ module ReactOverloadMagic =
                 disposables
                 |> Array.iter (fun d -> d.current.Dispose())
             )
+
         /// Creates a disposable instance by merging multiple IDisposable refs.
         static member inline createDisposable([<ParamArray>] disposables: IRefValue<#IDisposable option> []) =
             React.createDisposable(fun () ->
@@ -550,4 +584,5 @@ module ReactOverloadMagic =
             )
 
         /// The `useState` hook that create a state variable for React function components.
+        [<Hook>]
         static member useState<'t>(initial: 't) = Interop.reactApi.useState<'t,'t>(initial)


### PR DESCRIPTION
This PR implements a new `[<Hook>]` attribute. This attribute is to be applied on custom defined hooks which ensures that the declaration *and* call site are prepended with "use" as required by fast-refresh in React. This means that hooks that generate code like `Feliz_React_useState_blah123` now becomes `useFeliz_React_useState_blah123`. It is not pretty but it fulfills the requirement. 

I have applied this attribute to all the implemented hooks in the repository within Feliz, Feliz.UseElmish, Feliz.UseDeferred, Feliz.UseMediaQuery and updated them all to latest Feliz (fixes #271) 

Of course, this release also includes #275 by @ThisFunctionalTom (thanks a lot 🙇 for the PR)

I know I've been able to use fast-refresh properly without enforcing the hooks to start with "use" but that might have been the case for small components in a small demo application. I think this is better, I will be testing this thoroughly and complain to the React team if it doesn't work 😁 