### PR TITLE
Added grid-layout options to Styles

### DIFF
--- a/Feliz/Feliz.fsproj
+++ b/Feliz/Feliz.fsproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>A fresh retake of the React API in Fable, optimized for happiness</Description>
@@ -34,6 +34,7 @@
     <Compile Include="TextDecorationStyle.fs" />
     <Compile Include="TextDecorationLine.fs" />
     <Compile Include="TransitionProperty.fs" />
+    <Compile Include="GridTypes.fs" />
     <Compile Include="Styles.fs" />
     <Compile Include="Html.fs" />
     <Compile Include="React.fs" />

--- a/Feliz/GridTypes.fs
+++ b/Feliz/GridTypes.fs
@@ -1,0 +1,24 @@
+namespace Feliz.Styles
+
+open Fable.Core
+
+[<Erase>]
+type gridColumn =
+    static member inline span(value: string) : IGridSpan = unbox("span " + value)
+    static member inline span(value: string, count: int) : IGridSpan = unbox("span " + value + " " + (unbox<string> count))
+    static member inline span(value: int) : IGridSpan = unbox("span " + (unbox<string> value))
+
+[<Erase>]
+type gridRow =
+    static member inline span(value: string) : IGridSpan = unbox("span " + value)
+    static member inline span(value: string, count: int) : IGridSpan = unbox("span " + value + " " + (unbox<string> count))
+    static member inline span(value: int) : IGridSpan = unbox("span " + (unbox<string> value))
+
+[<Erase>]
+type grid =
+    static member inline namedLine(value: string) : IGridTemplateItem = unbox ("[" + value + "]")
+    static member inline namedLines(value: string[]) : IGridTemplateItem = unbox ("[" + (String.concat " " value) + "]")
+    static member inline namedLines(value: string list) : IGridTemplateItem = unbox ("[" + (String.concat " " value) + "]")
+    static member inline templateWidth(value: ICssUnit) : IGridTemplateItem = unbox value
+    static member inline templateWidth(value: int) : IGridTemplateItem = unbox ((unbox<string>value) + "px")
+    static member inline templateWidth(value: float) : IGridTemplateItem = unbox ((unbox<string>value) + "px")

--- a/Feliz/Length.fs
+++ b/Feliz/Length.fs
@@ -84,3 +84,6 @@ type length =
     static member inline auto : ICssUnit = unbox "auto"
     /// calculated length, frequency, angle, time, percentage, number or integer
     static member inline calc(value:string) : ICssUnit = unbox ("calc(" + (unbox<string>value) + ")")
+    /// Relative to width of the grid layout in correlation with the other fr's in the grid
+    static member inline fr(value: int) : ICssUnit = unbox ((unbox<string>value) + "fr")
+    

--- a/Feliz/StyleTypes.fs
+++ b/Feliz/StyleTypes.fs
@@ -43,3 +43,7 @@ type ICssUnit = interface end
 type ITransitionProperty = interface end
 
 type ITransformProperty = interface end
+
+type IGridSpan = interface end
+
+type IGridTemplateItem = interface end

--- a/Feliz/Styles.fs
+++ b/Feliz/Styles.fs
@@ -257,6 +257,1430 @@ type style =
     /// Sets the flex grow factor of a flex item main size. It specifies how much of the remaining
     /// space in the flex container should be assigned to the item (the flex grow factor).
     static member inline flexGrow (value: int) = Interop.mkStyle "flexGrow" value
+    /// Sets the width of each individual grid column in pixels.
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-template-columns: 199.5px 99.5px 99.5px;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// gridTemplateColumns: [199.5;99.5;99.5]
+    /// ```
+    static member inline gridTemplateColumns(value: float list) =
+        let addPixels = fun x -> x + "px"
+        Interop.mkStyle "gridTemplateColumns" ((List.map addPixels >> String.concat " ") (unbox<string list> value))
+    /// Sets the width of each individual grid column in pixels.
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-template-columns: 199.5px 99.5px 99.5px;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// gridTemplateColumns: [|199.5;99.5;99.5|]
+    /// ```
+    static member inline gridTemplateColumns(value: float[]) =
+        let addPixels = fun x -> x + "px"
+        Interop.mkStyle "gridTemplateColumns" ((Array.map addPixels >> String.concat " ") (unbox<string[]> value))
+    /// Sets the width of each individual grid column in pixels.
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-template-columns: 100px 200px 100px;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// gridTemplateColumns: [100; 200; 100]
+    /// ```
+    static member inline gridTemplateColumns(value: int list) =
+        let addPixels = fun x -> x + "px"
+        Interop.mkStyle "gridTemplateColumns" ((List.map addPixels >> String.concat " ") (unbox<string list> value))
+    /// Sets the width of each individual grid column in pixels.
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-template-columns: 100px 200px 100px;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// gridTemplateColumns: [|100; 200; 100|]
+    /// ```
+    static member inline gridTemplateColumns(value: int[]) =
+        let addPixels = fun x -> x + "px"
+        Interop.mkStyle "gridTemplateColumns" ((Array.map addPixels >> String.concat " ") (unbox<string[]> value))
+    /// Sets the width of each individual grid column.
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-template-columns: 1fr 1fr 2fr;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// gridTemplateColumns: [length.fr 1; length.fr 1; length.fr 2]
+    /// ```
+    static member inline gridTemplateColumns(value: ICssUnit list) =
+        Interop.mkStyle "gridTemplateColumns" (String.concat " " (unbox<string list> value))
+    /// Sets the width of each individual grid column.
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-template-columns: 1fr 1fr 2fr;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// gridTemplateColumns: [|length.fr 1; length.fr 1; length.fr 2|]
+    /// ```
+    static member inline gridTemplateColumns(value: ICssUnit[]) =
+        Interop.mkStyle "gridTemplateColumns" (String.concat " " (unbox<string[]> value))
+    /// Sets the width of each individual grid column. It can also name the lines between them
+    /// There can be multiple names for the same line
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-template-columns: [first-line] auto [first-line-end second-line-start] 100px [second-line-end];
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridTemplateColumns [
+    ///     grid.namedLine "first-line"
+    ///     grid.templateWidth length.auto
+    ///     grid.namedLines ["first-line-end second-line-start"]
+    ///     grid.templateWidth 100
+    ///     grid.namedLine "second-line-end"
+    /// ]
+    /// ```
+    static member inline gridTemplateColumns(value: IGridTemplateItem list) =
+        Interop.mkStyle "gridTemplateColumns" (String.concat " " (unbox<string list>value))
+    /// Sets the width of each individual grid column. It can also name the lines between them
+    /// There can be multiple names for the same line
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-template-columns: [first-line] auto [first-line-end second-line-start] 100px [second-line-end];
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridTemplateColumns [|
+    ///     grid.namedLine "first-line"
+    ///     grid.templateWidth length.auto
+    ///     grid.namedLines [|"first-line-end second-line-start"|]
+    ///     grid.templateWidth 100
+    ///     grid.namedLine "second-line-end"
+    /// |]
+    /// ```
+    static member inline gridTemplateColumns(value: IGridTemplateItem[]) =
+        Interop.mkStyle "gridTemplateColumns" (String.concat " " (unbox<string[]>value))
+    /// Sets the width of a number of grid columns to the defined width in pixels
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-template-columns: repeat(3, 99.5px);
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridTemplateColumns (3, 99.5)
+    /// ```
+    static member inline gridTemplateColumns(count: int, size: float) =
+        Interop.mkStyle "gridTemplateColumns" (
+            "repeat(" +
+            (unbox<string>count) + ", " +
+            (unbox<string>size) + "px)"
+        )
+    /// Sets the width of a number of grid columns to the defined width in pixels
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-template-columns: repeat(3, 100px);
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridTemplateColumns (3, 100)
+    /// ```
+    static member inline gridTemplateColumns(count: int, size: int) =
+        Interop.mkStyle "gridTemplateColumns" (
+            "repeat(" +
+            (unbox<string>count) + ", " +
+            (unbox<string>size) + "px)"
+        )
+    /// Sets the width of a number of grid columns to the defined width
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-template-columns: repeat(3, 1fr);
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridTemplateColumns (3, length.fr 1)
+    /// ```
+    static member inline gridTemplateColumns(count: int, size: ICssUnit) =
+        Interop.mkStyle "gridTemplateColumns" (
+            "repeat(" +
+            (unbox<string>count) + ", " +
+            (unbox<string>size) + ")"
+        )
+    /// Sets the width of a number of grid columns to the defined width in pixels, as well as naming the lines between them
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-template-columns: repeat(3, 1.5px [col-start]);
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridTemplateColumns (3, 1.5, "col-start")
+    /// ```
+    static member inline gridTemplateColumns(count: int, size: float, areaName: string) =
+        Interop.mkStyle "gridTemplateColumns" (
+            "repeat(" +
+            (unbox<string>count) + ", " +
+            (unbox<string>size) + "px [" +
+            areaName + "])"
+        )
+    /// Sets the width of a number of grid columns to the defined width in pixels, as well as naming the lines between them
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-template-columns: repeat(3, 10px [col-start]);
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridTemplateColumns (3, 10, "col-start")
+    /// ```
+    static member inline gridTemplateColumns(count: int, size: int, areaName: string) =
+        Interop.mkStyle "gridTemplateColumns" (
+            "repeat(" +
+            (unbox<string>count) + ", " +
+            (unbox<string>size) + "px [" +
+            areaName + "])"
+        )
+    /// Sets the width of a number of grid columns to the defined width, as well as naming the lines between them
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-template-columns: repeat(3, 1fr [col-start]);
+    /// ``` 
+    /// **F#
+    /// ```f#
+    /// style.gridTemplateColumns (3, length.fr 1, "col-start")
+    /// ```
+    static member inline gridTemplateColumns(count: int, size: ICssUnit, areaName: string) =
+        Interop.mkStyle "gridTemplateColumns" (
+            "repeat(" +
+            (unbox<string>count) + ", " +
+            (unbox<string>size) + " [" +
+            areaName + "])"
+        )
+    /// Sets the width of a number of grid rows to the defined width in pixels
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-template-rows: 99.5px 199.5px 99.5px;
+    /// ``` 
+    /// **F#
+    /// ```f#
+    /// style.gridTemplateRows [99.5; 199.5; 99.5]
+    /// ```
+    static member inline gridTemplateRows(value: float list) =
+        let addPixels = (fun x -> x + "px")
+        Interop.mkStyle "gridTemplateRows" ((List.map addPixels >> String.concat " ") (unbox<string list> value))
+    /// Sets the width of a number of grid rows to the defined width in pixels
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-template-rows: 99.5px 199.5px 99.5px;
+    /// ``` 
+    /// **F#
+    /// ```f#
+    /// style.gridTemplateRows [|99.5; 199.5; 99.5|]
+    /// ```
+    static member inline gridTemplateRows(value: float[]) =
+        let addPixels = (fun x -> x + "px")
+        Interop.mkStyle "gridTemplateRows" ((Array.map addPixels >> String.concat " ") (unbox<string[]> value))
+    /// Sets the width of a number of grid rows to the defined width
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-template-rows: 100px 200px 100px;
+    /// ``` 
+    /// **F#
+    /// ```f#
+    /// style.gridTemplateRows [100, 200, 100]
+    /// ```
+    static member inline gridTemplateRows(value: int list) =
+        let addPixels = (fun x -> x + "px")
+        Interop.mkStyle "gridTemplateRows" ((List.map addPixels >> String.concat " ") (unbox<string list> value))
+    /// Sets the width of a number of grid rows to the defined width in pixels
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-template-rows: 100px 200px 100px;
+    /// ``` 
+    /// **F#
+    /// ```f#
+    /// style.gridTemplateRows [|100; 200; 100|]
+    /// ```
+    static member inline gridTemplateRows(value: int[]) =
+        let addPixels = (fun x -> x + "px")
+        Interop.mkStyle "gridTemplateRows" ((Array.map addPixels >> String.concat " ") (unbox<string[]> value))
+    /// Sets the width of a number of grid rows to the defined width
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-template-rows: 1fr 10% 250px auto;
+    /// ``` 
+    /// **F#
+    /// ```f#
+    /// style.gridTemplateRows [length.fr 1; length.percent 10; length.px 250; length.auto]
+    /// ```
+    static member inline gridTemplateRows(value: ICssUnit list) =
+        Interop.mkStyle "gridTemplateRows" (String.concat " " (unbox<string list> value))
+    /// Sets the width of a number of grid rows to the defined width
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-template-rows: 1fr 10% 250px auto;
+    /// ``` 
+    /// **F#
+    /// ```f#
+    /// style.gridTemplateRows [|length.fr 1; length.percent 10; length.px 250; length.auto|]
+    /// ```
+    static member inline gridTemplateRows(value: ICssUnit[]) =
+        Interop.mkStyle "gridTemplateRows" (String.concat " " (unbox<string[]> value))
+    /// Sets the width of a number of grid rows to the defined width as well as naming the spaces between
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-template-rows: [row-1-start] 1fr [row-1-end row-2-start] 1fr [row-2-end];
+    /// ``` 
+    /// **F#
+    /// ```f#
+    /// style.gridTemplateRows [
+    ///     grid.namedLine "row-1-start"
+    ///     grid.templateWidth (length.fr 1)
+    ///     grid.namedLines ["row-1-end"; "row-2-start"]
+    ///     grid.templateWidth (length.fr 1)
+    ///     grid.namedLine "row-2-end"
+    /// ]
+    /// ```
+    static member inline gridTemplateRows(value: IGridTemplateItem list) =
+        Interop.mkStyle "gridTemplateRows" (String.concat " " (unbox<string list>value))
+    /// Sets the width of a number of grid rows to the defined width as well as naming the spaces between
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-template-rows: [row-1-start] 1fr [row-1-end row-2-start] 1fr [row-2-end];
+    /// ``` 
+    /// **F#
+    /// ```f#
+    /// style.gridTemplateRows [|
+    ///     grid.namedLine "row-1-start"
+    ///     grid.templateWidth (length.fr 1)
+    ///     grid.namedLines [|"row-1-end"; "row-2-start"|]
+    ///     grid.templateWidth (length.fr 1)
+    ///     grid.namedLine "row-2-end"
+    /// |]
+    /// ```
+    static member inline gridTemplateRows(value: IGridTemplateItem[]) =
+        Interop.mkStyle "gridTemplateRows" (String.concat " " (unbox<string[]>value))
+    /// Sets the width of a number of grid rows to the defined width in pixels
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-template-rows: repeat(3, 199.5);
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridTemplateRows (3, 199.5)
+    /// ```
+    static member inline gridTemplateRows(count: int, size: float) =
+        Interop.mkStyle "gridTemplateRows" (
+            "repeat("+
+            (unbox<string>count) + ", " +
+            (unbox<string>size) + "px)"
+        )
+    /// Sets the width of a number of grid rows to the defined width in pixels
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-template-rows: repeat(3, 100px);
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridTemplateRows (3, 100)
+    /// ```
+    static member inline gridTemplateRows(count: int, size: int) =
+        Interop.mkStyle "gridTemplateRows" (
+            "repeat("+
+            (unbox<string>count) + ", " +
+            (unbox<string>size) + "px)"
+        )
+    /// Sets the width of a number of grid rows to the defined width
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-template-rows: repeat(3, 10%);
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridTemplateRows (3, length.percent 10)
+    /// ```
+    static member inline gridTemplateRows(count: int, size: ICssUnit) =
+        Interop.mkStyle "gridTemplateRows" (
+            "repeat("+
+            (unbox<string>count) + ", " +
+            (unbox<string>size) + ")"
+        )
+    /// Sets the width of a number of grid rows to the defined width in pixels as well as naming the spaces between
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-template-rows: repeat(3, 75.5, [row]);
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridTemplateRows (3, 75.5, "row")
+    /// ```
+    static member inline gridTemplateRows(count: int, size: float, areaName: string) =
+        Interop.mkStyle "gridTemplateRows" (
+            "repeat("+
+            (unbox<string>count) + ", " +
+            (unbox<string>size) + "px [" +
+            areaName + "])"
+        )
+    /// Sets the width of a number of grid rows to the defined width in pixels as well as naming the spaces between
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-template-rows: repeat(3, 100px, [row]);
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridTemplateRows (3, 100, "row")
+    /// ```
+    static member inline gridTemplateRows(count: int, size: int, areaName: string) =
+        Interop.mkStyle "gridTemplateRows" (
+            "repeat("+
+            (unbox<string>count) + ", " +
+            (unbox<string>size) + "px [" +
+            areaName + "])"
+        )
+    /// Sets the width of a number of grid rows to the defined width in pixels as well as naming the spaces between
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-template-rows: repeat(3, 10%, [row]);
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridTemplateRows (3, length.percent 10, "row")
+    /// ```
+    static member inline gridTemplateRows(count: int, size: ICssUnit, areaName: string) =
+        Interop.mkStyle "gridTemplateRows" (
+            "repeat("+
+            (unbox<string>count) + ", " +
+            (unbox<string>size) + " [" +
+            areaName + "])"
+        )
+    /// 2D representation of grid layout as blocks with names
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-template-areas:
+    ///     'header header header header'
+    ///     'nav nav . sidebar'
+    ///     'footer footer footer footer';
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridTemplateAreas [
+    ///     ["header"; "header"; "header"; "header" ]
+    ///     ["nav"   ; "nav"   ; "."     ; "sidebar"]
+    ///     ["footer"; "footer"; "footer"; "footer" ]
+    /// ]
+    /// ```
+    static member inline gridTemplateAreas(value: string list list) =
+        let wrapLine = (fun x -> "'" + x + "'")
+        let lines = List.map (String.concat " " >> wrapLine) value
+        let block = String.concat "\n" lines
+        Interop.mkStyle "gridTemplateAreas" block
+    /// 2D representation of grid layout as blocks with names
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-template-areas:
+    ///     'header header header header'
+    ///     'nav nav . sidebar'
+    ///     'footer footer footer footer';
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridTemplateAreas [|
+    ///     [|"header"; "header"; "header"; "header" |]
+    ///     [|"nav"   ; "nav"   ; "."     ; "sidebar"|]
+    ///     [|"footer"; "footer"; "footer"; "footer" |]
+    /// |]
+    /// ```
+    static member inline gridTemplateAreas(value: string[][]) =
+        let wrapLine = (fun x -> "'" + x + "'")
+        let lines = Array.map (String.concat " " >> wrapLine) value
+        let block = String.concat "\n" lines
+        Interop.mkStyle "gridTemplateAreas" block
+    /// One-dimensional alternative to the nested list. For column-based layouts
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-template-areas: 'first second third fourth';
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridTemplateAreas ["first"; "second"; "third"; "fourth"]
+    /// ```
+    static member inline gridTemplateAreas(value: string list) =
+        let block = (String.concat " ") value
+        Interop.mkStyle "gridTemplateAreas" ("'" + block + "'")
+    /// One-dimensional alternative to the nested list. For column-based layouts
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-template-areas: 'first second third fourth';
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridTemplateAreas [|"first"; "second"; "third"; "fourth"|]
+    /// ```
+    static member inline gridTemplateAreas(value: string[]) =
+        let block = (String.concat " ") value
+        Interop.mkStyle "gridTemplateAreas" ("'" + block + "'")
+    /// Specifies the size of the grid lines. You can think of it like
+    /// setting the width of the gutters between the columns.
+    /// 
+    /// **CSS**
+    /// ```css
+    /// column-gap: 1.5px;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.columnGap 1.5
+    /// ```
+    static member inline columnGap(value: float) =
+        Interop.mkStyle "columnGap" (unbox<string> value + "px")
+    /// Specifies the size of the grid lines. You can think of it like
+    /// setting the width of the gutters between the columns.
+    /// 
+    /// **CSS**
+    /// ```css
+    /// column-gap: 10px;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.columnGap 10
+    /// ```
+    static member inline columnGap(value: int) =
+        Interop.mkStyle "columnGap" (unbox<string> value + "px")
+    /// Specifies the size of the grid lines. You can think of it like
+    /// setting the width of the gutters between the columns.
+    /// 
+    /// **CSS**
+    /// ```css
+    /// column-gap: 1em;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.columnGap (length.em 1)
+    /// ```
+    static member inline columnGap(value: ICssUnit) =
+        Interop.mkStyle "columnGap" value
+    /// Specifies the size of the grid lines. You can think of it like
+    /// setting the width of the gutters between the rows.
+    /// 
+    /// **CSS**
+    /// ```css
+    /// row-gap: 2.5px;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.rowGap 2.5
+    /// ```
+    static member inline rowGap(value: float) =
+        Interop.mkStyle "rowGap" (unbox<string> value + "px")
+    /// Specifies the size of the grid lines. You can think of it like
+    /// setting the width of the gutters between the rows.
+    /// 
+    /// **CSS**
+    /// ```css
+    /// row-gap: 10px;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.rowGap 10
+    /// ```
+    static member inline rowGap(value: int) =
+        Interop.mkStyle "rowGap" (unbox<string> value + "px")
+    /// Specifies the size of the grid lines. You can think of it like
+    /// setting the width of the gutters between the rows.
+    /// 
+    /// **CSS**
+    /// ```css
+    /// row-gap: 1em;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.rowGap (length.em 1)
+    /// ```
+    static member inline rowGap(value: ICssUnit) =
+        Interop.mkStyle "rowGap" value
+    /// Specifies the size of the grid lines. You can think of it like
+    /// setting the width of the gutters between the rows/columns.
+    /// 
+    /// _Shorthand for `rowGap` and `columnGap`_
+    /// 
+    /// **CSS**
+    /// ```css
+    /// gap: 1em 2em;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gap (length.em 1, length.em 2)
+    /// ```
+    static member inline gap(rowGap: ICssUnit, columnGap: ICssUnit) =
+        Interop.mkStyle "gap" (
+            (unbox<string> rowGap) + " " +
+            (unbox<string> columnGap)
+        )
+    /// Specifies the size of the grid lines. You can think of it like
+    /// setting the width of the gutters between the rows/columns.
+    /// 
+    /// _Shorthand for `rowGap` and `columnGap`_
+    /// 
+    /// **CSS**
+    /// ```css
+    /// gap: 1em 3.5px;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gap (length.em 1, 3.5)
+    /// ```
+    static member inline gap(rowGap: ICssUnit, columnGap: float) =
+        Interop.mkStyle "gap" (
+            (unbox<string> rowGap) + " " +
+            (unbox<string> columnGap) + "px"
+        )
+    /// Specifies the size of the grid lines. You can think of it like
+    /// setting the width of the gutters between the rows/columns.
+    /// 
+    /// _Shorthand for `rowGap` and `columnGap`_
+    /// 
+    /// **CSS**
+    /// ```css
+    /// gap: 1em 10px;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gap (length.em 1, 10)
+    /// ```
+    static member inline gap(rowGap: ICssUnit, columnGap: int) =
+        Interop.mkStyle "gap" (
+            (unbox<string> rowGap) + " " +
+            (unbox<string> columnGap) + "px"
+        )
+    /// Specifies the size of the grid lines. You can think of it like
+    /// setting the width of the gutters between the rows/columns.
+    /// 
+    /// _Shorthand for `rowGap` and `columnGap`_
+    /// 
+    /// **CSS**
+    /// ```css
+    /// gap: 10px 1em;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gap (10, length.em 1)
+    /// ```
+    static member inline gap(rowGap: int, columnGap: ICssUnit) =
+        Interop.mkStyle "gap" (
+            (unbox<string> rowGap) + "px " +
+            (unbox<string> columnGap)
+        )
+    /// Specifies the size of the grid lines. You can think of it like
+    /// setting the width of the gutters between the rows/columns.
+    /// 
+    /// _Shorthand for `rowGap` and `columnGap`_
+    /// 
+    /// **CSS**
+    /// ```css
+    /// gap: 10px 1.5px;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gap (10, 1.5)
+    /// ```
+    static member inline gap(rowGap: int, columnGap: float) =
+        Interop.mkStyle "gap" (
+            (unbox<string> rowGap) + "px " +
+            (unbox<string> columnGap) + "px"
+        )
+    /// Specifies the size of the grid lines. You can think of it like
+    /// setting the width of the gutters between the rows/columns.
+    /// 
+    /// _Shorthand for `rowGap` and `columnGap`_
+    /// 
+    /// **CSS**
+    /// ```css
+    /// gap: 10px 15px;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gap (10, 15)
+    /// ```
+    static member inline gap(rowGap: int, columnGap: int) =
+        Interop.mkStyle "gap" (
+            (unbox<string> rowGap) + "px " +
+            (unbox<string> columnGap) + "px"
+        )
+    /// Specifies the size of the grid lines. You can think of it like
+    /// setting the width of the gutters between the rows/columns.
+    /// 
+    /// _Shorthand for `rowGap` and `columnGap`_
+    /// 
+    /// **CSS**
+    /// ```css
+    /// gap: 2.5px 15%;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gap (2.5, length.percent 15)
+    /// ```
+    static member inline gap(rowGap: float, columnGap: ICssUnit) =
+        Interop.mkStyle "gap" (
+            (unbox<string> rowGap) + "px " +
+            (unbox<string> columnGap)
+        )
+    /// Specifies the size of the grid lines. You can think of it like
+    /// setting the width of the gutters between the rows/columns.
+    /// 
+    /// _Shorthand for `rowGap` and `columnGap`_
+    /// 
+    /// **CSS**
+    /// ```css
+    /// gap: 1.5px 1.5px;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gap (1.5, 1.5)
+    /// ```
+    static member inline gap(rowGap: float, columnGap: float) =
+        Interop.mkStyle "gap" (
+            (unbox<string> rowGap) + "px " +
+            (unbox<string> columnGap) + "px"
+        )
+    /// Specifies the size of the grid lines. You can think of it like
+    /// setting the width of the gutters between the rows/columns.
+    /// 
+    /// _Shorthand for `rowGap` and `columnGap`_
+    /// 
+    /// **CSS**
+    /// ```css
+    /// gap: 1.5px 10px;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gap (1.5, 10)
+    /// ```
+    static member inline gap(rowGap: float, columnGap: int) =
+        Interop.mkStyle "gap" (
+            (unbox<string> rowGap) + "px " +
+            (unbox<string> columnGap) + "px"
+        )
+    /// Sets where an item in the grid starts
+    /// The value can be one of the following options:
+    /// - a named line
+    /// - a numbered line
+    /// - span until a named line was hit
+    /// - span over a specified number of lines
+    /// 
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-column-start: col2;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridColumnStart "col2"
+    /// ```
+    static member inline gridColumnStart(value: string) = Interop.mkStyle "gridColumnStart" value
+    /// Sets where an item in the grid starts
+    /// The value can be one of the following options:
+    /// - a named line
+    /// - a numbered line
+    /// - span until a named line was hit
+    /// - span over a specified number of lines
+    /// 
+    /// 
+    /// When there are multiple named lines with the same name, you can specify which one by count
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-column-start: col 2;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridColumnStart ("col", 2)
+    /// ```
+    static member inline gridColumnStart(value: string, count: int) =
+        Interop.mkStyle "gridColumnStart" (value + " " + (unbox<string>count))
+    /// Sets where an item in the grid starts
+    /// The value can be one of the following options:
+    /// - a named line
+    /// - a numbered line
+    /// - span until a named line was hit
+    /// - span over a specified number of lines
+    /// 
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-column-start: 2;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridColumnStart 2
+    /// ```
+    static member inline gridColumnStart(value: int) = Interop.mkStyle "gridColumnStart" value
+    /// Sets where an item in the grid starts
+    /// The value can be one of the following options:
+    /// - a named line
+    /// - a numbered line
+    /// - span until a named line was hit
+    /// - span over a specified number of lines
+    /// 
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-column-start: span odd-col;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridColumnStart (gridColumn.span "odd-col")
+    /// ```
+    static member inline gridColumnStart(value: IGridSpan) = Interop.mkStyle "gridColumnStart" value
+    /// Sets where an item in the grid ends
+    /// The value can be one of the following options:
+    /// - a named line
+    /// - a numbered line
+    /// - span until a named line was hit
+    /// - span over a specified number of lines
+    /// 
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-column-end: col-2;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridColumnEnd "col-2"
+    /// ```
+    static member inline gridColumnEnd(value: string) = Interop.mkStyle "gridColumnEnd" value
+    /// Sets where an item in the grid ends
+    /// The value can be one of the following options:
+    /// - a named line
+    /// - a numbered line
+    /// - span until a named line was hit
+    /// - span over a specified number of lines
+    /// 
+    /// 
+    /// _When there are multiple named lines with the same name, you can specify which one by count_
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-column-end: odd-col 2;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridColumnEnd ("odd-col", 2)
+    /// ```
+    static member inline gridColumnEnd(value: string, count: int) =
+        Interop.mkStyle "gridColumnEnd" (value + " " + (unbox<string> count))
+    /// Sets where an item in the grid ends
+    /// The value can be one of the following options:
+    /// - a named line
+    /// - a numbered line
+    /// - span until a named line was hit
+    /// - span over a specified number of lines
+    /// 
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-column-end: 2;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridColumnEnd 2
+    /// ```
+    static member inline gridColumnEnd(value: int) = Interop.mkStyle "gridColumnEnd" value
+    /// Sets where an item in the grid ends
+    /// The value can be one of the following options:
+    /// - a named line
+    /// - a numbered line
+    /// - span until a named line was hit
+    /// - span over a specified number of lines
+    /// 
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-column-end: span 2;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridColumnEnd (gridColumn.span 2)
+    /// ```
+    static member inline gridColumnEnd(value: IGridSpan) = Interop.mkStyle "gridColumnEnd" value
+    /// Sets where an item in the grid starts
+    /// The value can be one of the following options:
+    /// - a named line
+    /// - a numbered line
+    /// - span until a named line was hit
+    /// - span over a specified number of lines
+    /// 
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-row-start: col2;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridRowStart "col2"
+    /// ```
+    static member inline gridRowStart(value: string) = Interop.mkStyle "gridRowStart" value
+    /// Sets where an item in the grid starts
+    /// The value can be one of the following options:
+    /// - a named line
+    /// - a numbered line
+    /// - span until a named line was hit
+    /// - span over a specified number of lines
+    /// 
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-row-start: col 2;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridRowStart ("col", 2)
+    /// ```
+    static member inline gridRowStart(value: string, count: int) =
+        Interop.mkStyle "gridRowStart" (value + " " + (unbox<string>count))
+    /// Sets where an item in the grid starts
+    /// The value can be one of the following options:
+    /// - a named line
+    /// - a numbered line
+    /// - span until a named line was hit
+    /// - span over a specified number of lines
+    /// 
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-row-start: 2;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridRowStart 2
+    /// ```
+    static member inline gridRowStart(value: int) = Interop.mkStyle "gridRowStart" value
+    /// Sets where an item in the grid starts
+    /// The value can be one of the following options:
+    /// - a named line
+    /// - a numbered line
+    /// - span until a named line was hit
+    /// - span over a specified number of lines
+    /// 
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-row-start: span odd-col;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridRowStart (gridRow.span "odd-col")
+    /// ```
+    static member inline gridRowStart(value: IGridSpan) = Interop.mkStyle "gridRowStart" value
+    /// Sets where an item in the grid ends
+    /// The value can be one of the following options:
+    /// - a named line
+    /// - a numbered line
+    /// - span until a named line was hit
+    /// - span over a specified number of lines
+    /// 
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-row-end: col-2;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridRowEnd "col-2"
+    /// ```
+    static member inline gridRowEnd(value: string) = Interop.mkStyle "gridRowEnd" value
+    /// Sets where an item in the grid ends
+    /// The value can be one of the following options:
+    /// - a named line
+    /// - a numbered line
+    /// - span until a named line was hit
+    /// - span over a specified number of lines
+    /// 
+    /// 
+    /// _When there are multiple named lines with the same name, you can specify which one by count_
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-row-end: odd-col 2;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridRowEnd ("odd-col", 2)
+    /// ```
+    static member inline gridRowEnd(value: string, count: int) =
+        Interop.mkStyle "gridRowEnd" (value + " " + (unbox<string> count))
+    /// Sets where an item in the grid ends
+    /// The value can be one of the following options:
+    /// - a named line
+    /// - a numbered line
+    /// - span until a named line was hit
+    /// - span over a specified number of lines
+    /// 
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-row-end: 2;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridRowEnd 2
+    /// ```
+    static member inline gridRowEnd(value: int) = Interop.mkStyle "gridRowEnd" value
+    /// Sets where an item in the grid ends
+    /// The value can be one of the following options:
+    /// - a named line
+    /// - a numbered line
+    /// - span until a named line was hit
+    /// - span over a specified number of lines
+    /// 
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-row-end: span 2;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridRowEnd (gridRow.span 2)
+    /// ```
+    static member inline gridRowEnd(value: IGridSpan) = Interop.mkStyle "gridRowEnd" value
+    /// Determines a grid item’s location within the grid by referring to specific grid lines.
+    /// start is the line where the item begins, end' is the line where it ends.
+    /// They can be one of the following options:
+    /// - a named line
+    /// - a numbered line
+    /// - span until a named line was hit
+    /// - span over a specified number of lines
+    /// 
+    /// 
+    /// _Shorthand for `gridColumnStart` and `gridColumnEnds`_
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-column: col-2 / col-4;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridColumn ("col-2", "col-4")
+    /// ```
+    static member inline gridColumn(start: string, end': string) =
+        Interop.mkStyle "gridColumn" (start + " / " + end')
+    /// Determines a grid item’s location within the grid by referring to specific grid lines.
+    /// start is the line where the item begins, end' is the line where it ends.
+    /// They can be one of the following options:
+    /// - a named line
+    /// - a numbered line
+    /// - span until a named line was hit
+    /// - span over a specified number of lines
+    /// 
+    /// 
+    /// _Shorthand for `gridColumnStart` and `gridColumnEnds`_
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-column: col-2 / 4;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridColumn ("col-2", 4)
+    /// ```
+    static member inline gridColumn(start: string, end': int) =
+        Interop.mkStyle "gridColumn" (start + " / " + (unbox<string>end'))
+    /// Determines a grid item’s location within the grid by referring to specific grid lines.
+    /// start is the line where the item begins, end' is the line where it ends.
+    /// They can be one of the following options:
+    /// - a named line
+    /// - a numbered line
+    /// - span until a named line was hit
+    /// - span over a specified number of lines
+    /// 
+    /// 
+    /// _Shorthand for `gridColumnStart` and `gridColumnEnds`_
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-column: col-2 / span 2;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridColumn ("col-2", gridColumn.span 2)
+    /// ```
+    static member inline gridColumn(start: string, end': IGridSpan) =
+        Interop.mkStyle "gridColumn" (start + " / " + (unbox<string>end'))
+    /// Determines a grid item’s location within the grid by referring to specific grid lines.
+    /// start is the line where the item begins, end' is the line where it ends.
+    /// They can be one of the following options:
+    /// - a named line
+    /// - a numbered line
+    /// - span until a named line was hit
+    /// - span over a specified number of lines
+    /// 
+    /// 
+    /// _Shorthand for `gridColumnStart` and `gridColumnEnds`_
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-column: 1/ col-4;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridColumn (1, "col-4")
+    /// ```
+    static member inline gridColumn(start: int, end': string) =
+        Interop.mkStyle "gridColumn" ((unbox<string>start) + " / " + end')
+    /// Determines a grid item’s location within the grid by referring to specific grid lines.
+    /// start is the line where the item begins, end' is the line where it ends.
+    /// They can be one of the following options:
+    /// - a named line
+    /// - a numbered line
+    /// - span until a named line was hit
+    /// - span over a specified number of lines
+    /// 
+    /// 
+    /// _Shorthand for `gridColumnStart` and `gridColumnEnds`_
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-column: 1 / 3;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridColumn (1, 3)
+    /// ```
+    static member inline gridColumn(start: int, end': int) =
+        Interop.mkStyle "gridColumn" ((unbox<string>start) + " / " + (unbox<string>end'))
+    /// Determines a grid item’s location within the grid by referring to specific grid lines.
+    /// start is the line where the item begins, end' is the line where it ends.
+    /// They can be one of the following options:
+    /// - a named line
+    /// - a numbered line
+    /// - span until a named line was hit
+    /// - span over a specified number of lines
+    /// 
+    /// 
+    /// _Shorthand for `gridColumnStart` and `gridColumnEnds`_
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-column: 1 / span 2;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridColumn (1, gridColumn.span 2)
+    /// ```
+    static member inline gridColumn(start: int, end': IGridSpan) =
+        Interop.mkStyle "gridColumn" ((unbox<string>start) + " / " + (unbox<string>end'))
+    /// Determines a grid item’s location within the grid by referring to specific grid lines.
+    /// start is the line where the item begins, end' is the line where it ends.
+    /// They can be one of the following options:
+    /// - a named line
+    /// - a numbered line
+    /// - span until a named line was hit
+    /// - span over a specified number of lines
+    /// 
+    /// 
+    /// _Shorthand for `gridColumnStart` and `gridColumnEnds`_
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-column: span 2 / col-3;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridColumn (gridColumn.span 2, "col-3")
+    /// ```
+    static member inline gridColumn(start: IGridSpan, end': string) =
+        Interop.mkStyle "gridColumn" ((unbox<string>start) + " / " + end')
+    /// Determines a grid item’s location within the grid by referring to specific grid lines.
+    /// start is the line where the item begins, end' is the line where it ends.
+    /// They can be one of the following options:
+    /// - a named line
+    /// - a numbered line
+    /// - span until a named line was hit
+    /// - span over a specified number of lines
+    /// 
+    /// 
+    /// _Shorthand for `gridColumnStart` and `gridColumnEnds`_
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-column: span 2 / 4;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridColumn (gridColumn.span 2, 4)
+    /// ```
+    static member inline gridColumn(start: IGridSpan, end': int) =
+        Interop.mkStyle "gridColumn" ((unbox<string>start) + " / " + (unbox<string>end'))
+    /// Determines a grid item’s location within the grid by referring to specific grid lines.
+    /// start is the line where the item begins, end' is the line where it ends.
+    /// They can be one of the following options:
+    /// - a named line
+    /// - a numbered line
+    /// - span until a named line was hit
+    /// - span over a specified number of lines
+    /// 
+    /// 
+    /// _Shorthand for `gridColumnStart` and `gridColumnEnds`_
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-column: span 2 / span 3;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridColumn (gridColumn.span 2, gridColumn.span 3)
+    /// ```
+    static member inline gridColumn(start: IGridSpan, end': IGridSpan) =
+        Interop.mkStyle "gridColumn" ((unbox<string>start) + " / " + (unbox<string>end'))
+    /// Determines a grid item’s location within the grid by referring to specific grid lines.
+    /// start is the line where the item begins, end' is the line where it ends.
+    /// They can be one of the following options:
+    /// - a named line
+    /// - a numbered line
+    /// - span until a named line was hit
+    /// - span over a specified number of lines
+    /// 
+    /// 
+    /// _Shorthand for `gridRowStart` and `gridRowEnds`_
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-row: row-2 / row-4;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridRow ("row-2", "row-4")
+    /// ```
+    static member inline gridRow(start: string, end': string) =
+        Interop.mkStyle "gridRow" (start + " / " + end')
+    /// Determines a grid item’s location within the grid by referring to specific grid lines.
+    /// start is the line where the item begins, end' is the line where it ends.
+    /// They can be one of the following options:
+    /// - a named line
+    /// - a numbered line
+    /// - span until a named line was hit
+    /// - span over a specified number of lines
+    /// 
+    /// 
+    /// _Shorthand for `gridRowStart` and `gridRowEnds`_
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-row: row-2 / 4;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridRow ("row-2", 4)
+    /// ```
+    static member inline gridRow(start: string, end': int) =
+        Interop.mkStyle "gridRow" (start + " / " + (unbox<string>end'))
+    /// Determines a grid item’s location within the grid by referring to specific grid lines.
+    /// start is the line where the item begins, end' is the line where it ends.
+    /// They can be one of the following options:
+    /// - a named line
+    /// - a numbered line
+    /// - span until a named line was hit
+    /// - span over a specified number of lines
+    /// 
+    /// 
+    /// _Shorthand for `gridRowStart` and `gridRowEnds`_
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-row: row-2 / span "odd-row";
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridRow ("row-2", gridRow.span 2)
+    /// ```
+    static member inline gridRow(start: string, end': IGridSpan) =
+        Interop.mkStyle "gridRow" (start + " / " + (unbox<string>end'))
+    /// Determines a grid item’s location within the grid by referring to specific grid lines.
+    /// start is the line where the item begins, end' is the line where it ends.
+    /// They can be one of the following options:
+    /// - a named line
+    /// - a numbered line
+    /// - span until a named line was hit
+    /// - span over a specified number of lines
+    /// 
+    /// 
+    /// _Shorthand for `gridRowStart` and `gridRowEnds`_
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-row: 2 / row-3;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridRow (2, "row-3")
+    /// ```
+    static member inline gridRow(start: int, end': string) =
+        Interop.mkStyle "gridRow" ((unbox<string>start) + " / " + end')
+    /// Determines a grid item’s location within the grid by referring to specific grid lines.
+    /// start is the line where the item begins, end' is the line where it ends.
+    /// They can be one of the following options:
+    /// - a named line
+    /// - a numbered line
+    /// - span until a named line was hit
+    /// - span over a specified number of lines
+    /// 
+    /// 
+    /// _Shorthand for `gridRowStart` and `gridRowEnds`_
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-row: 2 / 4;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridRow (2, 4)
+    /// ```
+    static member inline gridRow(start: int, end': int) =
+        Interop.mkStyle "gridRow" ((unbox<string>start) + " / " + (unbox<string>end'))
+    /// Determines a grid item’s location within the grid by referring to specific grid lines.
+    /// start is the line where the item begins, end' is the line where it ends.
+    /// They can be one of the following options:
+    /// - a named line
+    /// - a numbered line
+    /// - span until a named line was hit
+    /// - span over a specified number of lines
+    /// 
+    /// 
+    /// _Shorthand for `gridRowStart` and `gridRowEnds`_
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-row: 2 / span 3;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridRow (2, gridRow.span 3)
+    /// ```
+    static member inline gridRow(start: int, end': IGridSpan) =
+        Interop.mkStyle "gridRow" ((unbox<string>start) + " / " + (unbox<string>end'))
+    /// Determines a grid item’s location within the grid by referring to specific grid lines.
+    /// start is the line where the item begins, end' is the line where it ends.
+    /// They can be one of the following options:
+    /// - a named line
+    /// - a numbered line
+    /// - span until a named line was hit
+    /// - span over a specified number of lines
+    /// 
+    /// 
+    /// _Shorthand for `gridRowStart` and `gridRowEnds`_
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-row: span 2 / "row-4";
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridRow (gridRow.span 2, "row-4")
+    /// ```
+    static member inline gridRow(start: IGridSpan, end': string) =
+        Interop.mkStyle "gridRow" ((unbox<string>start) + " / " + end')
+    /// Determines a grid item’s location within the grid by referring to specific grid lines.
+    /// start is the line where the item begins, end' is the line where it ends.
+    /// They can be one of the following options:
+    /// - a named line
+    /// - a numbered line
+    /// - span until a named line was hit
+    /// - span over a specified number of lines
+    /// 
+    /// 
+    /// _Shorthand for `gridRowStart` and `gridRowEnds`_
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-row: span 2 / 3;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridRow (gridRow.span 2, 3)
+    /// ```
+    static member inline gridRow(start: IGridSpan, end': int) =
+        Interop.mkStyle "gridRow" ((unbox<string>start) + " / " + (unbox<string>end'))
+    /// Determines a grid item’s location within the grid by referring to specific grid lines.
+    /// start is the line where the item begins, end' is the line where it ends.
+    /// They can be one of the following options:
+    /// - a named line
+    /// - a numbered line
+    /// - span until a named line was hit
+    /// - span over a specified number of lines
+    /// 
+    /// 
+    /// _Shorthand for `gridRowStart` and `gridRowEnds`_
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-row: span 2 / span 3;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridRow (gridRow.span 2, gridRow.span 3)
+    /// ```
+    static member inline gridRow(start: IGridSpan, end': IGridSpan) =
+        Interop.mkStyle "gridRow" ((unbox<string>start) + " / " + (unbox<string>end'))
+    /// Sets the named grid area the item is placed in
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-area: header;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridArea "header"
+    /// ```
+    static member inline gridArea(value: string) =
+        Interop.mkStyle "gridArea" value
+    /// Shorthand for `grid-template-areas`, `grid-template-columns` and `grid-template-rows`.
+    /// 
+    /// Documentation: https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template
+    /// 
+    /// **CSS**
+    /// ```css
+    /// grid-template:  [header-top] 'a a a'      [header-bottom]
+    ///                   [main-top] 'b b b' 1fr  [main-bottom]
+    ///                              / auto 1fr auto;
+    /// ```
+    /// **F#**
+    /// ```f#
+    /// style.gridTemplate "[header-top] 'a a a'      [header-bottom] " +
+    ///                      "[main-top] 'b b b' 1fr  [main-bottom] " +
+    ///                                "/ auto 1fr auto"
+    /// ```
+    static member inline gridTemplate(value: string) =
+        Interop.mkStyle "gridTemplate" value
     /// Sets the length of time a transition animation should take to complete. By default, the
     /// value is 0s, meaning that no animation will occur.
     static member inline transitionDuration(timespan: TimeSpan) =


### PR DESCRIPTION
Implemented fully typed and overloaded style options to nicely work with the CSS grid layout in Feliz.
Also enriched the comments (and editor tooltips) with code usage examples for easier usage.

See References here:
[https://css-tricks.com/snippets/css/complete-guide-grid](https://css-tricks.com/snippets/css/complete-guide-grid)
[https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout)

There are a few things that I couldn't implement (yet):
- [grid-template](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template) - I couldn't find a way of properly representing this in F#. It is only a shorthand and no actually missing functionality
- [grid-area](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-area) - The additional overloads as shorthand for `grid-column-end` + `grid-column-start` + `grid-row-end` + `grid-row-start` would have meant 4^2^3 = 4096 overloads for all possible combinations of `string` - `int` - `float` - `IGridSpan`