### PR TITLE
Update roughViz and add pie charts

### DIFF
--- a/Feliz.RoughViz/Feliz.RoughViz.fsproj
+++ b/Feliz.RoughViz/Feliz.RoughViz.fsproj
@@ -13,6 +13,7 @@
     </PropertyGroup>
     <ItemGroup>
         <Compile Include="BarChart.fs" />
+        <Compile Include="PieChart.fs" />
         <Compile Include="RoughViz.fs" />
     </ItemGroup>
     <ItemGroup>
@@ -20,7 +21,7 @@
     </ItemGroup>
     <PropertyGroup>
         <NpmDependencies>
-            <NpmPackage Name="rough-viz" Version="&gt;= 1.0.6 &lt; 2.0.0" ResolutionStrategy="max" />
+            <NpmPackage Name="@inocan/rough-viz" Version="&gt;= 1.2.0 &lt; 2.0.0" ResolutionStrategy="max" />
         </NpmDependencies>
     </PropertyGroup>
     <ItemGroup>

--- a/Feliz.RoughViz/PieChart.fs
+++ b/Feliz.RoughViz/PieChart.fs
@@ -1,0 +1,64 @@
+namespace Feliz.RoughViz
+
+open Fable.Core
+open Fable.Core.JsInterop
+
+type IPieChartProperty = interface end
+
+type pieChart =
+    static member data(points: (string * float) seq) =
+        let labels = [| for (label, value) in points -> label |]
+        let values = [| for (label, value) in points -> value |]
+        let result = toPlainJsObj {| labels = labels; values = values; |}
+        unbox<IPieChartProperty> ("data", result)
+
+    /// Array of colors for each arc. Default: ['coral', 'skyblue', '#66c2a5', 'tan', '#8da0cb', '#e78ac3', '#a6d854', '#ffd92f', 'tan', 'orange'].
+    static member inline colors(colorNames: string[]) = unbox<IPieChartProperty> ("colors", colorNames)
+    static member inline height(value: int) = unbox<IPieChartProperty> ("height", value)
+    static member inline height(value: float) = unbox<IPieChartProperty> ("height", value)
+    /// Chart bowing. Default = 0
+    static member inline bowing(value: float) = unbox<IPieChartProperty> ("bowing", value)
+    /// Weight of inner paths' color. Default: 0.5
+    static member inline fillWeight(value: float) = unbox<IPieChartProperty> ("fillWeight", value)
+    /// Font family to use
+    static member inline font(fontFamily: string) = unbox<IPieChartProperty> ("font", fontFamily)
+    /// Color for each bar on hover
+    static member inline highlight(colorName: string) = unbox<IPieChartProperty> ("highlight", colorName)
+    static member inline strokeWidth(width: int) = unbox<IPieChartProperty> ("strokeWidth", width)
+    static member inline title(chartTitle: string) = unbox<IPieChartProperty> ("title", chartTitle)
+    static member inline titleFontSize(fontSize:int) = unbox<IPieChartProperty> ("titleFontSize", unbox<string> fontSize + "px")
+    static member inline titleFontSize(fontSize:float) = unbox<IPieChartProperty> ("titleFontSize", unbox<string> fontSize + "px")
+    static member inline titleFontSize(fontSize: string) = unbox<IPieChartProperty> ("titleFontSize", fontSize)
+    static member inline tooltipFontSize(fontSize:int) = unbox<IPieChartProperty> ("tooltipFontSize", unbox<string> fontSize + "px")
+    static member inline tooltipFontSize(fontSize:float) = unbox<IPieChartProperty> ("tooltipFontSize", unbox<string> fontSize + "px")
+    static member inline tooltipFontSize(fontSize: string) = unbox<IPieChartProperty> ("tooltipFontSize", fontSize)
+    static member inline roughness(value: int) = unbox<IPieChartProperty> ("roughness", abs value)
+    /// Whether or not chart is interactive. True by default.
+    static member inline interactive (value: bool) = unbox<IPieChartProperty> ("interactive", value)
+    /// Whether or not to add legend. Default: 'true'.
+    static member inline legend (value: bool) = unbox<IPieChartProperty> ("legend", value)
+    /// Chart simplification. Default is 0.2.
+    static member inline simplification(value: float) = unbox<IPieChartProperty> ("simplification", value)
+    /// Padding between bars. Default: 0.1.
+    static member inline padding(value: float) = unbox<IPieChartProperty>("padding", value)
+    /// Margin of the chart. By default => margin(top=50, right=20, left=100, bottom=70)
+    static member margin(?top: int, ?right: int, ?left: int, ?bottom: int) =
+        let margin = createObj [
+            "top" ==> Option.defaultValue 50 top
+            "right" ==> Option.defaultValue 20 right
+            "left" ==> Option.defaultValue 100 left
+            "bottom" ==> Option.defaultValue 70 bottom
+        ]
+
+        unbox<IPieChartProperty> ("margin", margin)
+
+[<Erase>]
+module pieChart =
+    [<Erase>]
+    type fillStyle =
+        static member inline hachure = unbox<IPieChartProperty> ("fillStyle", "hachure")
+        static member inline crossHatch = unbox<IPieChartProperty> ("fillStyle", "cross-hatch")
+        static member inline zigzag = unbox<IPieChartProperty> ("fillStyle", "zigzag")
+        static member inline dashed = unbox<IPieChartProperty> ("fillStyle", "dashed")
+        static member inline solid = unbox<IPieChartProperty> ("fillStyle", "solid")
+        static member inline zigzagLine = unbox<IPieChartProperty> ("fillStyle", "zigzag-line")

--- a/Feliz.RoughViz/RoughViz.fs
+++ b/Feliz.RoughViz/RoughViz.fs
@@ -22,6 +22,7 @@ module internal Interop =
     let objectAssign (x: obj) (y: obj) = jsNative
     let createBarChart (config: obj) : unit = import "createBarChart" "./createChart.js"
     let createHorizontalBarChart (config: obj) : unit = import "createHorizontalBarChart" "./createChart.js"
+    let createPieChart (config: obj) : unit = import "createPieChart" "./createChart.js"
     [<Emit("new ResizeObserver($0)")>]
     let createResizeObserver(handler: IObserverEntry array -> unit) : IResizeObserver = jsNative
 
@@ -31,6 +32,7 @@ module RoughViz =
     type private ChartType =
         | Bar
         | HorizontalBar
+        | Pie
 
     let private buildChart = React.functionComponent("RoughViz", fun (props: {| chartType: ChartType; config: obj list |}) ->
         let elementId = React.useRef("RoughViz" + (Guid.NewGuid().ToString().Substring(10)))
@@ -53,6 +55,7 @@ module RoughViz =
                 match props.chartType with
                 | Bar -> Interop.createBarChart config
                 | HorizontalBar -> Interop.createHorizontalBarChart config
+                | Pie -> Interop.createPieChart config
 
                 observer.current.observe element
 
@@ -110,3 +113,5 @@ module RoughViz =
     let barChart (properties: IBarChartProperty list) = buildChart {| chartType = Bar; config = unbox properties |}
 
     let horizontalBarChart (properties: IBarChartProperty list) = buildChart {| chartType = HorizontalBar; config = unbox properties |}
+
+    let pieChart (properties: IPieChartProperty list) = buildChart {| chartType = Pie; config = unbox properties |}

--- a/Feliz.RoughViz/createChart.js
+++ b/Feliz.RoughViz/createChart.js
@@ -1,5 +1,7 @@
-import RoughViz from 'rough-viz/dist/roughviz.min'
+import * as RoughViz from '@inocan/rough-viz'
 
 export const createBarChart = (config) => new RoughViz.Bar(config)
 
 export const createHorizontalBarChart = (config) => new RoughViz.BarH(config)
+
+export const createPieChart = (config) => new RoughViz.Pie(config)

--- a/docs/App.fs
+++ b/docs/App.fs
@@ -210,6 +210,15 @@ let roughHorizontalBarChart = React.functionComponent(fun () ->
         barChart.highlight color.lightGreen
     ])
 
+let roughPieChart = React.functionComponent(fun () ->
+    RoughViz.pieChart [
+        pieChart.title "Fruit Sales"
+        pieChart.data fruitSales
+        pieChart.roughness 3
+        pieChart.fillStyle.crossHatch
+        pieChart.highlight color.lightGreen
+    ])
+
 let dynamicRoughChart = React.functionComponent(fun () ->
     let (data, setData) = React.useStateWithUpdater [
         ("point1", 70.0)
@@ -325,6 +334,7 @@ let samples = [
     "use-responsive-custom", DelayedComponent.render {| load = UseMediaQueryExamples.useResponsiveCustomBreakpointsExample |}
     "rough-bar-chart", roughBarChart()
     "rough-horizontal-bar-chart", roughHorizontalBarChart()
+    "rough-pie-chart", roughPieChart()
     "dynamic-rough-chart", dynamicRoughChart()
     "delay-simple", DelayedComponent.render {| load = DelayExamples.simpleDelay |}
     "delay-fallback", DelayedComponent.render {| load = DelayExamples.delayWithCustomFallback |}

--- a/package-lock.json
+++ b/package-lock.json
@@ -430,6 +430,16 @@
                 "to-fast-properties": "^2.0.0"
             }
         },
+        "@inocan/rough-viz": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@inocan/rough-viz/-/rough-viz-1.2.0.tgz",
+            "integrity": "sha512-KmXM7ytm/rJtOiCy+tcKv9/KMg5gVA0Ib+h1ORNbdD/8U7Bylqw66uEobr+NtuYM11KY4zrUbyCc6csatiRNVQ==",
+            "requires": {
+                "d3": "6",
+                "native-dash": "^1.5.0",
+                "roughjs": "4"
+            }
+        },
         "@jest/types": {
             "version": "26.3.0",
             "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
@@ -1132,6 +1142,16 @@
             "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
             "dev": true,
             "optional": true
+        },
+        "bindings": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "file-uri-to-path": "1.0.0"
+            }
         },
         "bluebird": {
             "version": "3.7.2",
@@ -1906,15 +1926,135 @@
             "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
             "dev": true
         },
+        "d3": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/d3/-/d3-6.2.0.tgz",
+            "integrity": "sha512-aH+kx55J8vRBh4K4k9GN4EbNO3QnZsXy4XBfrnr4fL2gQuszUAPQU3fV2oObO2iSpreRH/bG/wfvO+hDu2+e9w==",
+            "requires": {
+                "d3-array": "2",
+                "d3-axis": "2",
+                "d3-brush": "2",
+                "d3-chord": "2",
+                "d3-color": "2",
+                "d3-contour": "2",
+                "d3-delaunay": "5",
+                "d3-dispatch": "2",
+                "d3-drag": "2",
+                "d3-dsv": "2",
+                "d3-ease": "2",
+                "d3-fetch": "2",
+                "d3-force": "2",
+                "d3-format": "2",
+                "d3-geo": "2",
+                "d3-hierarchy": "2",
+                "d3-interpolate": "2",
+                "d3-path": "2",
+                "d3-polygon": "2",
+                "d3-quadtree": "2",
+                "d3-random": "2",
+                "d3-scale": "3",
+                "d3-scale-chromatic": "2",
+                "d3-selection": "2",
+                "d3-shape": "2",
+                "d3-time": "2",
+                "d3-time-format": "3",
+                "d3-timer": "2",
+                "d3-transition": "2",
+                "d3-zoom": "2"
+            },
+            "dependencies": {
+                "d3-array": {
+                    "version": "2.8.0",
+                    "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.8.0.tgz",
+                    "integrity": "sha512-6V272gsOeg7+9pTW1jSYOR1QE37g95I3my1hBmY+vOUNHRrk9yt4OTz/gK7PMkVAVDrYYq4mq3grTiZ8iJdNIw=="
+                },
+                "d3-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
+                    "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ=="
+                },
+                "d3-format": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-2.0.0.tgz",
+                    "integrity": "sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA=="
+                },
+                "d3-interpolate": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
+                    "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
+                    "requires": {
+                        "d3-color": "1 - 2"
+                    }
+                },
+                "d3-path": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-2.0.0.tgz",
+                    "integrity": "sha512-ZwZQxKhBnv9yHaiWd6ZU4x5BtCQ7pXszEV9CU6kRgwIQVQGLMv1oiL4M+MK/n79sYzsj+gcgpPQSctJUsLN7fA=="
+                },
+                "d3-scale": {
+                    "version": "3.2.3",
+                    "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.2.3.tgz",
+                    "integrity": "sha512-8E37oWEmEzj57bHcnjPVOBS3n4jqakOeuv1EDdQSiSrYnMCBdMd3nc4HtKk7uia8DUHcY/CGuJ42xxgtEYrX0g==",
+                    "requires": {
+                        "d3-array": "^2.3.0",
+                        "d3-format": "1 - 2",
+                        "d3-interpolate": "1.2.0 - 2",
+                        "d3-time": "1 - 2",
+                        "d3-time-format": "2 - 3"
+                    }
+                },
+                "d3-shape": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-2.0.0.tgz",
+                    "integrity": "sha512-djpGlA779ua+rImicYyyjnOjeubyhql1Jyn1HK0bTyawuH76UQRWXd+pftr67H6Fa8hSwetkgb/0id3agKWykw==",
+                    "requires": {
+                        "d3-path": "1 - 2"
+                    }
+                },
+                "d3-time": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.0.0.tgz",
+                    "integrity": "sha512-2mvhstTFcMvwStWd9Tj3e6CEqtOivtD8AUiHT8ido/xmzrI9ijrUUihZ6nHuf/vsScRBonagOdj0Vv+SEL5G3Q=="
+                },
+                "d3-time-format": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
+                    "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
+                    "requires": {
+                        "d3-time": "1 - 2"
+                    }
+                }
+            }
+        },
         "d3-array": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
             "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
         },
         "d3-axis": {
-            "version": "1.0.12",
-            "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-1.0.12.tgz",
-            "integrity": "sha512-ejINPfPSNdGFKEOAtnBtdkpr24c4d4jsei6Lg98mxf424ivoDP2956/5HDpIAtmHo85lqT4pruy+zEgvRUBqaQ=="
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-2.0.0.tgz",
+            "integrity": "sha512-9nzB0uePtb+u9+dWir+HTuEAKJOEUYJoEwbJPsZ1B4K3iZUgzJcSENQ05Nj7S4CIfbZZ8/jQGoUzGKFznBhiiQ=="
+        },
+        "d3-brush": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-2.1.0.tgz",
+            "integrity": "sha512-cHLLAFatBATyIKqZOkk/mDHUbzne2B3ZwxkzMHvFTCZCmLaXDpZRihQSn8UNXTkGD/3lb/W2sQz0etAftmHMJQ==",
+            "requires": {
+                "d3-dispatch": "1 - 2",
+                "d3-drag": "2",
+                "d3-interpolate": "1 - 2",
+                "d3-selection": "2",
+                "d3-transition": "2"
+            }
+        },
+        "d3-chord": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-2.0.0.tgz",
+            "integrity": "sha512-D5PZb7EDsRNdGU4SsjQyKhja8Zgu+SHZfUSO5Ls8Wsn+jsAKUUGkcshLxMg9HDFxG3KqavGWaWkJ8EpU8ojuig==",
+            "requires": {
+                "d3-path": "1 - 2"
+            }
         },
         "d3-collection": {
             "version": "1.0.7",
@@ -1926,28 +2066,100 @@
             "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
             "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
         },
+        "d3-contour": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-2.0.0.tgz",
+            "integrity": "sha512-9unAtvIaNk06UwqBmvsdHX7CZ+NPDZnn8TtNH1myW93pWJkhsV25JcgnYAu0Ck5Veb1DHiCv++Ic5uvJ+h50JA==",
+            "requires": {
+                "d3-array": "2"
+            },
+            "dependencies": {
+                "d3-array": {
+                    "version": "2.8.0",
+                    "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.8.0.tgz",
+                    "integrity": "sha512-6V272gsOeg7+9pTW1jSYOR1QE37g95I3my1hBmY+vOUNHRrk9yt4OTz/gK7PMkVAVDrYYq4mq3grTiZ8iJdNIw=="
+                }
+            }
+        },
+        "d3-delaunay": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-5.3.0.tgz",
+            "integrity": "sha512-amALSrOllWVLaHTnDLHwMIiz0d1bBu9gZXd1FiLfXf8sHcX9jrcj81TVZOqD4UX7MgBZZ07c8GxzEgBpJqc74w==",
+            "requires": {
+                "delaunator": "4"
+            }
+        },
+        "d3-dispatch": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-2.0.0.tgz",
+            "integrity": "sha512-S/m2VsXI7gAti2pBoLClFFTMOO1HTtT0j99AuXLoGFKO6deHDdnv6ZGTxSTTUTgO1zVcv82fCOtDjYK4EECmWA=="
+        },
+        "d3-drag": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-2.0.0.tgz",
+            "integrity": "sha512-g9y9WbMnF5uqB9qKqwIIa/921RYWzlUDv9Jl1/yONQwxbOfszAWTCm8u7HOTgJgRDXiRZN56cHT9pd24dmXs8w==",
+            "requires": {
+                "d3-dispatch": "1 - 2",
+                "d3-selection": "2"
+            }
+        },
         "d3-dsv": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-1.2.0.tgz",
-            "integrity": "sha512-9yVlqvZcSOMhCYzniHE7EVUws7Fa1zgw+/EAV2BxJoG3ME19V6BQFBwI855XQDsxyOuG7NibqRMTtiF/Qup46g==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-2.0.0.tgz",
+            "integrity": "sha512-E+Pn8UJYx9mViuIUkoc93gJGGYut6mSDKy2+XaPwccwkRGlR+LO97L2VCCRjQivTwLHkSnAJG7yo00BWY6QM+w==",
             "requires": {
                 "commander": "2",
                 "iconv-lite": "0.4",
                 "rw": "1"
             }
         },
+        "d3-ease": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-2.0.0.tgz",
+            "integrity": "sha512-68/n9JWarxXkOWMshcT5IcjbB+agblQUaIsbnXmrzejn2O82n3p2A9R2zEB9HIEFWKFwPAEDDN8gR0VdSAyyAQ=="
+        },
         "d3-fetch": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-1.2.0.tgz",
-            "integrity": "sha512-yC78NBVcd2zFAyR/HnUiBS7Lf6inSCoWcSxFfw8FYL7ydiqe80SazNwoffcqOfs95XaLo7yebsmQqDKSsXUtvA==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-2.0.0.tgz",
+            "integrity": "sha512-TkYv/hjXgCryBeNKiclrwqZH7Nb+GaOwo3Neg24ZVWA3MKB+Rd+BY84Nh6tmNEMcjUik1CSUWjXYndmeO6F7sw==",
             "requires": {
-                "d3-dsv": "1"
+                "d3-dsv": "1 - 2"
+            }
+        },
+        "d3-force": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-2.1.1.tgz",
+            "integrity": "sha512-nAuHEzBqMvpFVMf9OX75d00OxvOXdxY+xECIXjW6Gv8BRrXu6gAWbv/9XKrvfJ5i5DCokDW7RYE50LRoK092ew==",
+            "requires": {
+                "d3-dispatch": "1 - 2",
+                "d3-quadtree": "1 - 2",
+                "d3-timer": "1 - 2"
             }
         },
         "d3-format": {
             "version": "1.4.4",
             "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.4.tgz",
             "integrity": "sha512-TWks25e7t8/cqctxCmxpUuzZN11QxIA7YrMbram94zMQ0PXjE4LVIMe/f6a4+xxL8HQ3OsAFULOINQi1pE62Aw=="
+        },
+        "d3-geo": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-2.0.1.tgz",
+            "integrity": "sha512-M6yzGbFRfxzNrVhxDJXzJqSLQ90q1cCyb3EWFZ1LF4eWOBYxFypw7I/NFVBNXKNqxv1bqLathhYvdJ6DC+th3A==",
+            "requires": {
+                "d3-array": ">=2.5"
+            },
+            "dependencies": {
+                "d3-array": {
+                    "version": "2.8.0",
+                    "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.8.0.tgz",
+                    "integrity": "sha512-6V272gsOeg7+9pTW1jSYOR1QE37g95I3my1hBmY+vOUNHRrk9yt4OTz/gK7PMkVAVDrYYq4mq3grTiZ8iJdNIw=="
+                }
+            }
+        },
+        "d3-hierarchy": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-2.0.0.tgz",
+            "integrity": "sha512-SwIdqM3HxQX2214EG9GTjgmCc/mbSx4mQBn+DuEETubhOw6/U3fmnji4uCVrmzOydMHSO1nZle5gh6HB/wdOzw=="
         },
         "d3-interpolate": {
             "version": "1.4.0",
@@ -1961,6 +2173,21 @@
             "version": "1.0.9",
             "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
             "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+        },
+        "d3-polygon": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-2.0.0.tgz",
+            "integrity": "sha512-MsexrCK38cTGermELs0cO1d79DcTsQRN7IWMJKczD/2kBjzNXxLUWP33qRF6VDpiLV/4EI4r6Gs0DAWQkE8pSQ=="
+        },
+        "d3-quadtree": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-2.0.0.tgz",
+            "integrity": "sha512-b0Ed2t1UUalJpc3qXzKi+cPGxeXRr4KU9YSlocN74aTzp6R/Ud43t79yLLqxHRWZfsvWXmbDWPpoENK1K539xw=="
+        },
+        "d3-random": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-2.2.2.tgz",
+            "integrity": "sha512-0D9P8TRj6qDAtHhRQn6EfdOtHMfsUWanl3yb/84C4DqpZ+VsgfI5iTVRNRbELCfNvRfpMr8OrqqUTQ6ANGCijw=="
         },
         "d3-scale": {
             "version": "2.2.2",
@@ -1976,18 +2203,18 @@
             }
         },
         "d3-scale-chromatic": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-1.5.0.tgz",
-            "integrity": "sha512-ACcL46DYImpRFMBcpk9HhtIyC7bTBR4fNOPxwVSl0LfulDAwyiHyPOTqcDG1+t5d4P9W7t/2NAuWu59aKko/cg==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-2.0.0.tgz",
+            "integrity": "sha512-LLqy7dJSL8yDy7NRmf6xSlsFZ6zYvJ4BcWFE4zBrOPnQERv9zj24ohnXKRbyi9YHnYV+HN1oEO3iFK971/gkzA==",
             "requires": {
-                "d3-color": "1",
-                "d3-interpolate": "1"
+                "d3-color": "1 - 2",
+                "d3-interpolate": "1 - 2"
             }
         },
         "d3-selection": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.4.1.tgz",
-            "integrity": "sha512-BTIbRjv/m5rcVTfBs4AMBLKs4x8XaaLkwm28KWu9S2vKNqXkXt2AH2Qf0sdPZHjFxcWg/YL53zcqAz+3g4/7PA=="
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-2.0.0.tgz",
+            "integrity": "sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA=="
         },
         "d3-shape": {
             "version": "1.3.7",
@@ -2008,6 +2235,35 @@
             "integrity": "sha512-RAHNnD8+XvC4Zc4d2A56Uw0yJoM7bsvOlJR33bclxq399Rak/b9bhvu/InjxdWhPtkgU53JJcleJTGkNRnN6IA==",
             "requires": {
                 "d3-time": "1"
+            }
+        },
+        "d3-timer": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-2.0.0.tgz",
+            "integrity": "sha512-TO4VLh0/420Y/9dO3+f9abDEFYeCUr2WZRlxJvbp4HPTQcSylXNiL6yZa9FIUvV1yRiFufl1bszTCLDqv9PWNA=="
+        },
+        "d3-transition": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-2.0.0.tgz",
+            "integrity": "sha512-42ltAGgJesfQE3u9LuuBHNbGrI/AJjNL2OAUdclE70UE6Vy239GCBEYD38uBPoLeNsOhFStGpPI0BAOV+HMxog==",
+            "requires": {
+                "d3-color": "1 - 2",
+                "d3-dispatch": "1 - 2",
+                "d3-ease": "1 - 2",
+                "d3-interpolate": "1 - 2",
+                "d3-timer": "1 - 2"
+            }
+        },
+        "d3-zoom": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-2.0.0.tgz",
+            "integrity": "sha512-fFg7aoaEm9/jf+qfstak0IYpnesZLiMX6GZvXtUSdv8RH2o4E2qeelgdU09eKS6wGuiGMfcnMI0nTIqWzRHGpw==",
+            "requires": {
+                "d3-dispatch": "1 - 2",
+                "d3-drag": "2",
+                "d3-interpolate": "1 - 2",
+                "d3-selection": "2",
+                "d3-transition": "2"
             }
         },
         "debug": {
@@ -2132,6 +2388,11 @@
                     "dev": true
                 }
             }
+        },
+        "delaunator": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-4.0.1.tgz",
+            "integrity": "sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag=="
         },
         "depd": {
             "version": "1.1.2",
@@ -2763,6 +3024,13 @@
             "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
             "integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==",
             "dev": true
+        },
+        "file-uri-to-path": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+            "dev": true,
+            "optional": true
         },
         "filename-reserved-regex": {
             "version": "1.0.0",
@@ -3900,11 +4168,6 @@
             "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
             "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
         },
-        "lodash.get": {
-            "version": "4.4.2",
-            "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-            "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
-        },
         "lodash.throttle": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
@@ -4274,6 +4537,13 @@
             "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
             "dev": true
         },
+        "nan": {
+            "version": "2.14.2",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+            "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+            "dev": true,
+            "optional": true
+        },
         "nanomatch": {
             "version": "1.2.13",
             "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -4292,6 +4562,11 @@
                 "snapdragon": "^0.8.1",
                 "to-regex": "^3.0.1"
             }
+        },
+        "native-dash": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/native-dash/-/native-dash-1.6.1.tgz",
+            "integrity": "sha512-XMWEB8AS3NsXk/ZdBGFCad9Fbj48Kt9cGODYJI0dUOv8Xcpq7lPdpdfpM9h83xSG1J+fhJMfk8UaL+KJTnXjwQ=="
         },
         "negotiator": {
             "version": "0.6.2",
@@ -5458,42 +5733,6 @@
             "resolved": "https://registry.npmjs.org/rn-host-detect/-/rn-host-detect-1.1.5.tgz",
             "integrity": "sha512-ufk2dFT3QeP9HyZ/xTuMtW27KnFy815CYitJMqQm+pgG3ZAtHBsrU8nXizNKkqXGy3bQmhEoloVbrfbvMJMqkg==",
             "dev": true
-        },
-        "rough-viz": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/rough-viz/-/rough-viz-1.0.6.tgz",
-            "integrity": "sha512-6Vplj7xFDAuGsybDdU2L7mj36OSJKhNNpm4QSlJ9tW6ps8a0zz1ZTECz75Kb+n2JNVhvmMCqDQlCKCTAfHn6Rg==",
-            "requires": {
-                "d3-array": "^2.3.1",
-                "d3-axis": "^1.0.12",
-                "d3-fetch": "^1.1.2",
-                "d3-format": "^1.4.1",
-                "d3-scale": "^3.2.0",
-                "d3-scale-chromatic": "^1.5.0",
-                "d3-selection": "^1.4.0",
-                "d3-shape": "^1.3.5",
-                "lodash.get": "^4.4.2",
-                "roughjs": "^4.0.0"
-            },
-            "dependencies": {
-                "d3-array": {
-                    "version": "2.4.0",
-                    "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.4.0.tgz",
-                    "integrity": "sha512-KQ41bAF2BMakf/HdKT865ALd4cgND6VcIztVQZUTt0+BH3RWy6ZYnHghVXf6NFjt2ritLr8H1T8LreAAlfiNcw=="
-                },
-                "d3-scale": {
-                    "version": "3.2.1",
-                    "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.2.1.tgz",
-                    "integrity": "sha512-huz5byJO/6MPpz6Q8d4lg7GgSpTjIZW/l+1MQkzKfu2u8P6hjaXaStOpmyrD6ymKoW87d2QVFCKvSjLwjzx/rA==",
-                    "requires": {
-                        "d3-array": "1.2.0 - 2",
-                        "d3-format": "1",
-                        "d3-interpolate": "^1.2.0",
-                        "d3-time": "1",
-                        "d3-time-format": "2"
-                    }
-                }
-            }
         },
         "roughjs": {
             "version": "4.3.1",
@@ -6871,7 +7110,11 @@
                     "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
                     "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
                     "dev": true,
-                    "optional": true
+                    "optional": true,
+                    "requires": {
+                        "bindings": "^1.5.0",
+                        "nan": "^2.12.1"
+                    }
                 },
                 "glob-parent": {
                     "version": "3.1.0",
@@ -7135,7 +7378,11 @@
                     "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
                     "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
                     "dev": true,
-                    "optional": true
+                    "optional": true,
+                    "requires": {
+                        "bindings": "^1.5.0",
+                        "nan": "^2.12.1"
+                    }
                 },
                 "glob-parent": {
                     "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
         "webpack-dev-server": "^3.11.0"
     },
     "dependencies": {
+        "@inocan/rough-viz": "^1.2.0",
         "pigeon-maps": "^0.15.0",
         "react": "^16.13.1",
         "react-dom": "^16.13.1",
@@ -38,7 +39,6 @@
         "react-markdown": "^4.3.1",
         "react-popover": "^0.5.10",
         "recharts": "^1.8.5",
-        "rough-viz": "^1.0.6",
         "use-resize-observer": "^6.1.0"
     }
 }

--- a/public/RoughViz/Index.md
+++ b/public/RoughViz/Index.md
@@ -11,7 +11,7 @@ femto install Feliz.RoughViz
 Manual installation:
 ```
 dotnet add package Feliz.RoughViz
-npm install --save rough-viz
+npm install --save @inocan/rough-viz
 ```
 
 ### Bar Chart
@@ -71,6 +71,32 @@ let roughHorizontalBarChart = React.functionComponent(fun () ->
         barChart.axisFontSize 18
         barChart.fillStyle.crossHatch
         barChart.highlight color.lightGreen
+    ])
+```
+
+### Pie Chart
+
+```fsharp:rough-pie-chart
+open Feliz
+open Feliz.RoughViz
+
+let fruitSales = [
+    ("Oranges", 5.0)
+    ("Apples", 8.2)
+    ("Strawberry", 10.0)
+    ("Peach", 2.0)
+    ("Pineapple", 17.0)
+    ("Bananas", 10.0)
+    ("Mango", 6.4)
+]
+
+let roughPieChart = React.functionComponent(fun () ->
+    RoughViz.pieChart [
+        pieChart.title "Fruit Sales"
+        pieChart.data fruitSales
+        pieChart.roughness 3
+        pieChart.fillStyle.crossHatch
+        pieChart.highlight color.lightGreen
     ])
 ```
 


### PR DESCRIPTION
I've added pie charts support for roughViz. While doing this I found that roughViz has had quite a few bugs fixed over the last year or so, but the new npm packages still contain the old minified bundle, I've raised an issue, but this repo looks dead.

I've switched over to a recently active version that works really well (I've abandoned my own fork).