### PR TITLE
Play better with beta reduction

### DIFF
--- a/Feliz/Interop.fs
+++ b/Feliz/Interop.fs
@@ -13,10 +13,10 @@ module Interop =
     #else
     let reactElement (name: string) (props: 'a) : ReactElement = import "createElement" "react"
     #endif
-    let mkAttr (key: string) (value: obj) : IReactProperty = unbox (key, value)
-    let mkStyle (key: string) (value: obj) : IStyleAttribute = unbox (key, value)
+    let inline mkAttr (key: string) (value: obj) : IReactProperty = unbox (key, value)
+    let inline mkStyle (key: string) (value: obj) : IStyleAttribute = unbox (key, value)
     let inline reactElementWithChild (name: string) (child: 'a) =
-        reactElement name (createObj [ "children" ==> [| child |] ])
+        reactElement name (createObj [ "children" ==> ResizeArray [| child |] ])
     let inline reactElementWithChildren (name: string) (children: #seq<ReactElement>) =
         reactElement name (createObj [ "children" ==> reactApi.Children.toArray (Array.ofSeq children) ])
     let inline createElement name (properties: IReactProperty list) : ReactElement =


### PR DESCRIPTION
@Zaid-Ajaj I've been trying to improve the output of React and Feliz apps. With https://github.com/fable-compiler/Fable/pull/2300 I think we can finally get nice-looking code:

```fsharp
[<ReactComponent>]
let counter() =
    let (count, setCount) = React.useState(0)
    Html.div [
        prop.style [ style.padding 20 ]
        prop.children [
            Html.h1 count
            Html.button [
                prop.text "Increment"
                prop.onClick (fun _ -> setCount(count + 1))
            ]
        ]
    ]
```

Becomes:

```js
export function Counter() {
    const patternInput = useFeliz_React__React_useState_Static_1505(0);
    const setCount = patternInput[1];
    const count = patternInput[0] | 0;
    return createElement("div", {
        style: {
            padding: 20,
        },
        children: reactApi.Children.toArray([createElement("h1", {
            children: [count],
        }), createElement("button", {
            children: "Increment",
            onClick: (_arg1) => {
                setCount(count + 1);
            },
        })]),
    });
}
```

But `mkAttr` and `mkStyle` must be inlined in order to resolve `createObj` at compile-time, so this is what this PR does :)