### PR TITLE
DON'T MERGE: Remove Fable.React dependency

### DIFF
--- a/Feliz/Html.fs
+++ b/Feliz/Html.fs
@@ -309,8 +309,8 @@ type Html =
     static member inline form xs = Interop.createElement "form" xs
     static member inline form (children: #seq<ReactElement>) = Interop.reactElementWithChildren "form" children
 
-    [<Obsolete("Html.fragment is obsolete, use React.fragment instead. This function will be removed in the coming v1.0 release")>]
-    static member inline fragment xs = Fable.React.Helpers.fragment [] xs
+    // [<Obsolete("Html.fragment is obsolete, use React.fragment instead. This function will be removed in the coming v1.0 release")>]
+    // static member inline fragment xs = Fable.React.Helpers.fragment [] xs
 
     static member inline g xs = Interop.createElement "g" xs
     static member inline g (children: #seq<ReactElement>) = Interop.reactElementWithChildren "g" children
@@ -398,12 +398,12 @@ type Html =
     static member inline kbd (value: string) = Interop.reactElementWithChild "kbd" value
     static member inline kbd (children: #seq<ReactElement>) = Interop.reactElementWithChildren "kbd" children
 
-    [<Obsolete("Html.keyedFragment is obsolete, use React.keyedFragment instead. This function will be removed in the coming v1.0 release")>]
-    static member inline keyedFragment (key: int, xs) = Fable.React.Helpers.fragment [ !!("key", key) ] xs
-    [<Obsolete("Html.keyedFragment is obsolete, use React.keyedFragment instead. This function will be removed in the coming v1.0 release")>]
-    static member inline keyedFragment (key: string, xs) = Fable.React.Helpers.fragment [ !!("key", key) ] xs
-    [<Obsolete("Html.keyedFragment is obsolete, use React.keyedFragment instead. This function will be removed in the coming v1.0 release")>]
-    static member inline keyedFragment (key: System.Guid, xs) = Fable.React.Helpers.fragment [ !!("key", string key) ] xs
+    // [<Obsolete("Html.keyedFragment is obsolete, use React.keyedFragment instead. This function will be removed in the coming v1.0 release")>]
+    // static member inline keyedFragment (key: int, xs) = Fable.React.Helpers.fragment [ !!("key", key) ] xs
+    // [<Obsolete("Html.keyedFragment is obsolete, use React.keyedFragment instead. This function will be removed in the coming v1.0 release")>]
+    // static member inline keyedFragment (key: string, xs) = Fable.React.Helpers.fragment [ !!("key", key) ] xs
+    // [<Obsolete("Html.keyedFragment is obsolete, use React.keyedFragment instead. This function will be removed in the coming v1.0 release")>]
+    // static member inline keyedFragment (key: System.Guid, xs) = Fable.React.Helpers.fragment [ !!("key", string key) ] xs
 
     static member inline label xs = Interop.createElement "label" xs
     static member inline label (children: #seq<ReactElement>) = Interop.reactElementWithChildren "label" children

--- a/Feliz/React.fs
+++ b/Feliz/React.fs
@@ -62,14 +62,14 @@ type React =
         { new IDisposable with member _.Dispose() = dispose() }
 
     /// The `React.fragment` component lets you return multiple elements in your `render()` method without creating an additional DOM element.
-    static member inline fragment xs = Fable.React.Helpers.fragment [] xs
+    static member inline fragment xs = Interop.reactElementWithChildren "fragment" xs
 
     /// The `React.fragment` component lets you return multiple elements in your `render()` method without creating an additional DOM element.
-    static member inline keyedFragment(key: int, xs) = Fable.React.Helpers.fragment [ !!("key", key) ] xs
+    static member inline keyedFragment(key: int, xs) = Interop.createElement "fragment" [ Interop.mkAttr "key" (string key); Interop.mkAttr "children" xs ]
     /// The `React.fragment` component lets you return multiple elements in your `render()` method without creating an additional DOM element.
-    static member inline keyedFragment(key: string, xs) = Fable.React.Helpers.fragment [ !!("key", key) ] xs
+    static member inline keyedFragment(key: string, xs) = Interop.createElement "fragment" [ Interop.mkAttr "key" key; Interop.mkAttr "children" xs ]
     /// The `React.fragment` component lets you return multiple elements in your `render()` method without creating an additional DOM element.
-    static member inline keyedFragment(key: System.Guid, xs) = Fable.React.Helpers.fragment [ !!("key", string key) ] xs
+    static member inline keyedFragment(key: System.Guid, xs) = Interop.createElement "fragment" [ Interop.mkAttr "key" (string key); Interop.mkAttr "children" xs ]
 
     /// The `useState` hook that create a state variable for React function components from a initialization function.
     [<Hook>]

--- a/Feliz/paket.references
+++ b/Feliz/paket.references
@@ -1,3 +1,4 @@
 FSharp.Core
 Fable.Core
-Fable.React
+Fable.React.Types
+Fable.Browser.Dom

--- a/docs/paket.references
+++ b/docs/paket.references
@@ -1,7 +1,7 @@
 Fable.Browser.Dom
 Fable.Core
 Fable.Elmish.React
-Fable.React
+Fable.React.Types
 Fable.SimpleHttp
 FSharp.Core
 Zanaptak.TypedCssClasses

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -6,7 +6,7 @@ group Main
     nuget Fable.Core
     nuget Fable.Elmish.React
     nuget Fable.Mocha
-    nuget Fable.React
+    nuget Fable.React.Types
     nuget Fable.SimpleHttp
     nuget FSharp.Core
     nuget Zanaptak.TypedCssClasses

--- a/paket.lock
+++ b/paket.lock
@@ -4,7 +4,7 @@ NUGET
     Fable.Browser.Blob (1.1) - restriction: >= netstandard2.0
       Fable.Core (>= 3.0) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.6.2) - restriction: >= netstandard2.0
-    Fable.Browser.Dom (2.1) - restriction: >= netstandard2.0
+    Fable.Browser.Dom (2.1)
       Fable.Browser.Blob (>= 1.1) - restriction: >= netstandard2.0
       Fable.Browser.Event (>= 1.2.1) - restriction: >= netstandard2.0
       Fable.Browser.WebStorage (>= 1.0) - restriction: >= netstandard2.0
@@ -35,30 +35,21 @@ NUGET
     Fable.Mocha (2.9.1)
       Fable.Core (>= 3.0) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7) - restriction: >= netstandard2.0
-    Fable.React (7.0.1)
+    Fable.React (7.0.1) - restriction: >= netstandard2.0
       Fable.Browser.Dom (>= 2.0.1) - restriction: >= netstandard2.0
       Fable.Core (>= 3.1.5) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7.1) - restriction: >= netstandard2.0
+    Fable.React.Types (1.0)
+      FSharp.Core (>= 5.0) - restriction: >= netstandard2.0
     Fable.SimpleHttp (3.0)
       Fable.Browser.Dom (>= 1.0) - restriction: >= netstandard2.0
       Fable.Browser.XMLHttpRequest (>= 1.1) - restriction: >= netstandard2.0
       Fable.Core (>= 3.0) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.6.2) - restriction: >= netstandard2.0
-    FSharp.Core (4.7.2)
+    FSharp.Core (5.0)
     Zanaptak.TypedCssClasses (0.4)
       FSharp.Core (>= 4.3.4) - restriction: >= netstandard2.0
-GITHUB
-  remote: Shmew/Fable.Jester
-    src/Fable.ReactTestingLibrary/Bindings.fs (8949a7a8e430d719c822c2f7a1019b4fe3b92513)
-    src/Fable.ReactTestingLibrary/Events.fs (8949a7a8e430d719c822c2f7a1019b4fe3b92513)
-    src/Fable.ReactTestingLibrary/Interop.fs (8949a7a8e430d719c822c2f7a1019b4fe3b92513)
-    src/Fable.ReactTestingLibrary/RTL.fs (8949a7a8e430d719c822c2f7a1019b4fe3b92513)
-    src/Fable.ReactTestingLibrary/Types.fs (8949a7a8e430d719c822c2f7a1019b4fe3b92513)
-  remote: Shmew/Feliz.UseListener
-    src/Feliz.UseListener/Listener.fs (d883476e3a4208e707fa6ee2d28b9cc881f515ea)
-    src/Feliz.UseListener/PromiseRejectionEvent.fs (d883476e3a4208e707fa6ee2d28b9cc881f515ea)
-  remote: Zaid-Ajaj/Feliz.Router
-    src/Router.fs (3d3e882bcd3fbf8dff9d5470928734b644dc9a4d)
+
 GROUP Build
 RESTRICTION: >= net45
 NUGET


### PR DESCRIPTION
As we've discussed sometimes. This removes Fable.React dependency and instead replaces it with a lightweight Fable.React.Types package that only contains the necessary interfaces.