### PR TITLE
Add pointer events html support

### DIFF
--- a/Feliz/Styles.fs
+++ b/Feliz/Styles.fs
@@ -3655,10 +3655,6 @@ module style =
         static member inline contentBox = Interop.mkStyle "boxSizing" "content-box"
         /// The width and height properties include the content, padding, and border, but do not include the margin. Note that padding and border will be inside of the box.
         static member inline borderBox = Interop.mkStyle "boxSizing" "border-box"
-        /// Sets this property to its default value.
-        static member inline initial = Interop.mkStyle "boxSizing" "initial"
-        /// Inherits this property from its parent element.
-        static member inline inheritFromParent = Interop.mkStyle "boxSizing" "inherit"
 
     /// Sets whether an element is resizable, and if so, in which directions.
     [<Erase>]

--- a/Feliz/Styles.fs
+++ b/Feliz/Styles.fs
@@ -3656,6 +3656,19 @@ module style =
         /// The width and height properties include the content, padding, and border, but do not include the margin. Note that padding and border will be inside of the box.
         static member inline borderBox = Interop.mkStyle "boxSizing" "border-box"
 
+    /// Sets under what circumstances (if any) a particular graphics element can become the target of pointer events.
+    [<Erase>]
+    type pointerEvents =
+        /// Default value. The element behaves as it would if the pointer-events property were not specified.
+        static member inline auto = Interop.mkStyle "pointerEvents" "auto"
+        /// The element is never the target of pointer events; however, pointer events may target its descendant elements if those descendants have pointer-events set to some other value.
+        static member inline none = Interop.mkStyle "pointerEvents" "none"
+        static member inline initial = Interop.mkStyle "pointerEvents" "initial"
+        /// Inherits this property from its parent element
+        static member inline inheritFromParent = Interop.mkStyle "pointerEvents" "inherit"
+        /// Resets to its inherited value if the property naturally inherits from its parent, and to its initial value if not.
+        static member inline unset = Interop.mkStyle "pointerEvents" "unset"
+
     /// Sets whether an element is resizable, and if so, in which directions.
     [<Erase>]
     type resize =


### PR DESCRIPTION
Removes incorrect box-sizing inheritance properties introduced in #303 
Adds support for the pointer-events attribute for HTML elements as discussed in #309