### PR TITLE
Handle key prop as argument

### DIFF
--- a/Feliz.CompilerPlugins/AstUtils.fs
+++ b/Feliz.CompilerPlugins/AstUtils.fs
@@ -17,6 +17,13 @@ let makeIdent name: Fable.Ident =
       IsMutable = false
       Range = None }
 
+let makeUniqueIdent (name: string) =
+    let hashToString (i: int) =
+        if i < 0
+        then "Z" + (abs i).ToString("X")
+        else i.ToString("X")
+    $"${name}{Guid.NewGuid().GetHashCode() |> hashToString}" |> makeIdent
+
 let makeValue r value =
     Fable.Value(value, r)
 

--- a/Feliz.CompilerPlugins/AstUtils.fs
+++ b/Feliz.CompilerPlugins/AstUtils.fs
@@ -22,7 +22,7 @@ let makeUniqueIdent (name: string) =
         if i < 0
         then "Z" + (abs i).ToString("X")
         else i.ToString("X")
-    $"${name}{Guid.NewGuid().GetHashCode() |> hashToString}" |> makeIdent
+    "$" + name + (Guid.NewGuid().GetHashCode() |> hashToString) |> makeIdent
 
 let makeValue r value =
     Fable.Value(value, r)


### PR DESCRIPTION
When using an argument named `key` React will complain that it cannot be accessed. This change avoids the warning by creating an extra prop `$key` in case we need to access it from code.