### PR TITLE
[Feliz.Template] Generate CSS with contenthash

### DIFF
--- a/Feliz.Template/Content/webpack.config.js
+++ b/Feliz.Template/Content/webpack.config.js
@@ -93,7 +93,7 @@ module.exports = {
     //      - HotModuleReplacementPlugin: Enables hot reloading when code changes without refreshing
     plugins: isProduction ?
         commonPlugins.concat([
-            new MiniCssExtractPlugin({ filename: 'style.css' }),
+            new MiniCssExtractPlugin({ filename: 'style.[contenthash].css' }),
             new CopyWebpackPlugin({
                 patterns: [
                     { from: resolve(CONFIG.assetsDir) }


### PR DESCRIPTION
Hi man,

I had regular annoyances where my CSS would not be instantly refreshed in browsers without having to manually delete the cache in Chrome, when deploying in prod :).

Do you mind having this by default for Prod, just like JS scripts?

Thanks