### PR TITLE
Added overloads for onChange

### DIFF
--- a/Feliz/Interop.fs
+++ b/Feliz/Interop.fs
@@ -78,3 +78,6 @@ module Interop =
         reactElement name (createObj !!properties)
     let inline createSvgElement name (properties: ISvgAttribute list) : ReactElement =
         reactElement name (createObj !!properties)
+
+    [<Emit "typeof $0 === 'number'">]
+    let isTypeofNumber (x: obj) : bool = jsNative

--- a/Feliz/Properties.fs
+++ b/Feliz/Properties.fs
@@ -1064,10 +1064,18 @@ type prop =
     
     /// Same as `onChange` that takes an event as input but instead let's you deal with the int changed from the `input` element directly
     /// instead of extracting it from the event arguments.
-    static member inline onChange (handler: int -> unit) = Interop.mkAttr "onChange" (fun (ev: Event) -> handler (!!ev.target?value))
+    static member inline onChange (handler: int -> unit) = 
+        Interop.mkAttr "onChange" (fun (ev: Event) -> 
+            if Interop.isTypeofNumber (!!ev.target?value)  
+            then handler (!!ev.target?value)
+        )     
     /// Same as `onChange` that takes an event as input but instead let's you deal with the float changed from the `input` element directly
     /// instead of extracting it from the event arguments.
-    static member inline onChange (handler: float -> unit) = Interop.mkAttr "onChange" (fun (ev: Event) -> handler (!!ev.target?value))
+    static member inline onChange (handler: float -> unit) = 
+        Interop.mkAttr "onChange" (fun (ev: Event) -> 
+            if Interop.isTypeofNumber (!!ev.target?value)  
+            then handler (!!ev.target?value)
+        )
 
     /// Same as `onChange` but let's you deal with the `checked` value that has changed from the `input` element directly instead of extracting it from the event arguments.
     static member inline onCheckedChange (handler: bool -> unit) = Interop.mkAttr "onChange" (fun (ev: Event) -> handler (!!ev.target?``checked``))


### PR DESCRIPTION
I needed to grab an int and float from an html input element with a type of "number" and created two overloads to grab the value directly.

Is this something useful for others?