### PR TITLE
Fix ChartMouseEvent.activeTooltipIndex

### DIFF
--- a/Feliz.Recharts/Types.fs
+++ b/Feliz.Recharts/Types.fs
@@ -103,7 +103,7 @@ type ChartMouseEvent<'label, 'payload> =
     abstract activeCoordinate : ChartCoordinate
     abstract activeLabel : 'label
     abstract activePayload : ChartDataPoint<'payload> array
-    abstract activeToolipIndex : int
+    abstract activeTooltipIndex : int
     abstract chartX : int
     abstract chartY : int
 


### PR DESCRIPTION
Technically a breaking change, but I don't think it would work with the typo right now.