### PR TITLE
use valueAsNumber to get the actual number from the input

### DIFF
--- a/Feliz/Properties.fs
+++ b/Feliz/Properties.fs
@@ -1066,17 +1066,18 @@ type prop =
     /// instead of extracting it from the event arguments. Fractional numbers are rounded to the nearest integral value.
     static member inline onChange (handler: int -> unit) =
         Interop.mkAttr "onChange" (fun (ev: Event) ->
-            if Interop.isTypeofNumber (!!ev.target?value) then
-                // round the value to get only integers
-                let value : double = !!ev.target?value
+            // round the value to get only integers
+            let value : double = !!ev.target?valueAsNumber
+            if value <> Double.NaN then
                 handler (unbox<int> (Math.Round value))
         )
     /// Same as `onChange` that takes an event as input but instead lets you deal with the float changed from the `input` element directly when the input type is a number
     /// instead of extracting it from the event arguments.
     static member inline onChange (handler: float -> unit) =
         Interop.mkAttr "onChange" (fun (ev: Event) ->
-            if Interop.isTypeofNumber (!!ev.target?value)
-            then handler (!!ev.target?value)
+            let value : double = !!ev.target?valueAsNumber
+            if value <> Double.NaN then
+                handler (value)
         )
 
     /// Same as `onChange` but let's you deal with the `checked` value that has changed from the `input` element directly instead of extracting it from the event arguments.


### PR DESCRIPTION
This caught me out, the value from an input is always a string.

This uses the [valueAsNumber](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement) and checks for NAN if conversion fails.