### PR TITLE
Added extra capture options

### DIFF
--- a/Feliz/Properties.fs
+++ b/Feliz/Properties.fs
@@ -2478,6 +2478,15 @@ module prop =
         /// points for each interval are defined in the keySplines attribute.
         static member inline spline = Interop.mkAttr "calcMode" "spline"
 
+    /// Specifies that new files should be captured by the device
+    [<Erase>]
+    type capture =
+        /// The user-facing camera and/or microphone should be used.
+        static member inline user = Interop.mkAttr "capture" "user" 
+        ///
+        /// The outward-facing camera and/or microphone should be used
+        static member inline environment = Interop.mkAttr "capture" "environment" 
+
     [<Erase>]
     type charset =
         static member inline utf8 = Interop.mkAttr "charset" "UTF-8"


### PR DESCRIPTION
This allows the file input type to make use of the devices camera to capture images and videos without the needs to access the camera directly via JS. Pretty much required if you need to take pictures in a web app on iOS.

Details are here: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/capture