### PR TITLE
WIP: Hot reloading with useElmish

### DIFF
--- a/Feliz.UseElmish/UseElmish.fs
+++ b/Feliz.UseElmish/UseElmish.fs
@@ -4,50 +4,6 @@ open Feliz
 open Elmish
 open Fable.Core
 
-[<Struct>]
-type internal RingState<'item> =
-    | Writable of wx:'item array * ix:int
-    | ReadWritable of rw:'item array * wix:int * rix:int
-
-type internal RingBuffer<'item>(size) =
-    let doubleSize ix (items: 'item array) =
-        seq { yield! items |> Seq.skip ix
-              yield! items |> Seq.take ix
-              for _ in 0..items.Length do
-                yield Unchecked.defaultof<'item> }
-        |> Array.ofSeq
-
-    let mutable state : 'item RingState =
-        Writable (Array.zeroCreate (max size 10), 0)
-
-    member _.Pop() =
-        match state with
-        | ReadWritable (items, wix, rix) ->
-            let rix' = (rix + 1) % items.Length
-            match rix' = wix with
-            | true ->
-                state <- Writable(items, wix)
-            | _ ->
-                state <- ReadWritable(items, wix, rix')
-            Some items.[rix]
-        | _ ->
-            None
-
-    member _.Push (item:'item) =
-        match state with
-        | Writable (items, ix) ->
-            items.[ix] <- item
-            let wix = (ix + 1) % items.Length
-            state <- ReadWritable(items, wix, ix)
-        | ReadWritable (items, wix, rix) ->
-            items.[wix] <- item
-            let wix' = (wix + 1) % items.Length
-            match wix' = rix with
-            | true ->
-                state <- ReadWritable(items |> doubleSize rix, items.Length, 0)
-            | _ ->
-                state <- ReadWritable(items, wix', rix)
-
 [<AutoOpen>]
 module UseElmishExtensions =
     let inline internal getDisposable (record: 'State) =
@@ -59,7 +15,6 @@ module UseElmishExtensions =
         [<Hook>]
         static member useElmish<'State,'Msg> (init: 'State * Cmd<'Msg>, update: 'Msg -> 'State -> 'State * Cmd<'Msg>, dependencies: obj[]) =
             let state = React.useRef(fst init)
-            let ring = React.useRef(RingBuffer(10))
             let childState, setChildState = React.useState(fst init)
             let token = React.useCancellationToken()
             let setChildState () =
@@ -70,13 +25,9 @@ module UseElmishExtensions =
 
             let rec dispatch (msg: 'Msg) =
                 promise {
-                    let mutable nextMsg = Some msg
-
-                    while nextMsg.IsSome && not (token.current.IsCancellationRequested) do
-                        let msg = nextMsg.Value
+                    if not (token.current.IsCancellationRequested) then
                         let (state', cmd') = update msg state.current
                         cmd' |> List.iter (fun sub -> sub dispatch)
-                        nextMsg <- ring.current.Pop()
                         state.current <- state'
                         setChildState()
                 }
@@ -98,8 +49,6 @@ module UseElmishExtensions =
                 snd init
                 |> List.iter (fun sub -> sub dispatch)
             ), dependencies)
-
-            React.useEffect(fun () -> ring.current.Pop() |> Option.iter dispatch)
 
             (childState, dispatch)
 


### PR DESCRIPTION
I've never been able to get hot reloading to work with `useElmish` so I usually just use regular global style Elmish.

However I wanted to try out vite and [Elmish.HMR doesn't currently work with vite](https://github.com/elmish/hmr/issues/29) so I decided to have another look at `useElmish`. This PR makes it work as expected with hot reloading, at least when testing a simple counter with vite+**preact** (which uses prefresh).

From my testing it seems like state in `useState` is preserved between hot reloads but `useRef` is not. The `useEffect` which resets the state and runs cmds also gets executed when doing a hot reload. This change makes it so that the `state` ref is initialised to `childState` so that it is preserved between hot reloads. `useEffect` checks `isFirstRender` before reinitialising state; because isFirstRender is a useRef, it will get reset to true during a hot reload so that it doesn't reset the state.

I tried testing it with **react** as well but had so many other issues with react-refresh and using hooks and fable. I think something to do with having extra `export function ...` in the same js file as the component might be messing up react-refresh somehow. So if anyone can get it working with react let me know :). So that is to say IDK if the behaviour of useRef and useState is the same with react-refresh as it is with prefresh but hopefully it is.


I've marked it as WIP because I need help on making it handle the initial `Cmd` correctly. See, the current behaviour on hot reloads is to reset the state and run inital Cmd (from init). This PR currently changes it so that on hot reloads it doesn't reset the state but **does** still run the initial Cmd which is (probably?) not good.