### PR TITLE
Use Elmish.Program in useElmish

### DIFF
--- a/Feliz.UseElmish/Feliz.UseElmish.fsproj
+++ b/Feliz.UseElmish/Feliz.UseElmish.fsproj
@@ -22,7 +22,6 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Update="FSharp.Core" Version="4.7.2" />
-        <PackageReference Include="Fable.Promise" Version="2.0.0" />
         <PackageReference Include="Fable.Elmish" Version="3.0.6" />
     </ItemGroup>
 </Project>

--- a/Feliz.UseElmish/UseElmish.fs
+++ b/Feliz.UseElmish/UseElmish.fs
@@ -3,65 +3,89 @@ namespace Feliz.UseElmish
 open Feliz
 open Elmish
 
-type private ElmishObservable<'State, 'Msg>() =
-    let mutable state: 'State option = None
-    let mutable listener: ('State -> unit) option = None
-    let mutable dispatcher: ('Msg -> unit) option = None
-
-    member _.Value = state
-
-    member _.SetState (model: 'State) (dispatch: 'Msg -> unit) =
-        state <- Some model
-        dispatcher <- Some dispatch
-        match listener with
-        | None -> ()
-        | Some listener -> listener model
-
-    member _.Dispatch(msg) =
-        match dispatcher with
-        | None -> () // Error?
-        | Some dispatch -> dispatch msg
-
-    member _.Subscribe(f) =
-        match listener with
-        | Some _ -> ()
-        | None -> listener <- Some f
-
 [<AutoOpen>]
 module UseElmishExtensions =
+    type private ElmishObservable<'Model, 'Msg>() =
+        let mutable hasDisposedOnce = false
+        let mutable state: 'Model option = None
+        let mutable listener: ('Model -> unit) option = None
+        let mutable dispatcher: ('Msg -> unit) option = None
+
+        member _.Value = state
+        member _.HasDisposedOnce = hasDisposedOnce
+
+        member _.SetState (model: 'Model) (dispatch: 'Msg -> unit) =
+            state <- Some model
+            dispatcher <- Some dispatch
+            match listener with
+            | None -> ()
+            | Some listener -> listener model
+
+        member _.Dispatch(msg) =
+            match dispatcher with
+            | None -> () // Error?
+            | Some dispatch -> dispatch msg
+
+        member _.Subscribe(f) =
+            match listener with
+            | Some _ -> ()
+            | None -> listener <- Some f
+
+        /// Disposes state (and dispatcher) but keeps subscription
+        member _.DisposeState() =
+            match state with
+            | Some state ->
+                match box state with
+                | :? System.IDisposable as disp -> disp.Dispose()
+                | _ -> ()
+            | _ -> ()
+            dispatcher <- None
+            state <- None
+            hasDisposedOnce <- true
+
+    let private runProgram (program: unit -> Program<'Arg, 'Model, 'Msg, unit>) (arg: 'Arg) (obs: ElmishObservable<'Model, 'Msg>) () =
+        program()
+        |> Program.withSetState obs.SetState
+        |> Program.runWith arg
+
+        match obs.Value with
+        | None -> failwith "Elmish program has not initialized"
+        | Some v -> v        
+
+    let disposeState (state: obj) =
+        match box state with
+        | :? System.IDisposable as disp -> disp.Dispose()
+        | _ -> ()
+
     type React with
         [<Hook>]
-        static member useElmish(program: unit -> Program<'arg, 'State, 'Msg, unit>, arg: 'arg) =
+        static member useElmish(program: unit -> Program<'Arg, 'Model, 'Msg, unit>, arg: 'Arg, ?dependencies: obj array) =
             // Don't use useMemo here because React doesn't guarantee it won't recreate it again
-            let obs, _ = React.useState(fun () -> ElmishObservable())
+            let obs, _ = React.useState(fun () -> ElmishObservable<'Model, 'Msg>())
 
-            let state, setState = React.useState(fun () ->
-                program()
-                |> Program.withSetState obs.SetState
-                |> Program.runWith arg
+            let state, setState = React.useState(runProgram program arg obs)
 
-                match obs.Value with
-                | None -> failwith "Elmish program has not initialized"
-                | Some v -> v)
-
-            React.useEffectOnce(fun () ->
-                React.createDisposable(fun () ->
-                        match box state with
-                        | :? System.IDisposable as disp -> disp.Dispose()
-                        | _ -> ()))
+            React.useEffect((fun () ->
+                if obs.HasDisposedOnce then
+                    runProgram program arg obs () |> setState
+                React.createDisposable(obs.DisposeState)
+            ), defaultArg dependencies [||])
 
             obs.Subscribe(setState)
             state, obs.Dispatch
 
         [<Hook>]
-        static member useElmish(program: unit -> Program<unit, 'State, 'Msg, unit>) =
-            React.useElmish(program, ())
+        static member useElmish(program: unit -> Program<unit, 'Model, 'Msg, unit>, ?dependencies: obj array) =
+            React.useElmish(program, (), ?dependencies=dependencies)
 
-        static member useElmish(init, update, arg, ?dependencies: obj array) =
-            React.useElmish((fun () -> Program.mkProgram init update (fun _ _ -> ())), arg)
+        [<Hook>]
+        static member useElmish(init: 'Arg -> 'Model * Cmd<'Msg>, update: 'Msg -> 'Model -> 'Model * Cmd<'Msg>, arg: 'Arg, ?dependencies: obj array) =
+            React.useElmish((fun () -> Program.mkProgram init update (fun _ _ -> ())), arg, ?dependencies=dependencies)
 
-        static member useElmish(init, update, ?dependencies: obj array) =
-            React.useElmish(fun () -> Program.mkProgram init update (fun _ _ -> ()))
+        [<Hook>]
+        static member useElmish(init: unit -> 'Model * Cmd<'Msg>, update: 'Msg -> 'Model -> 'Model * Cmd<'Msg>, ?dependencies: obj array) =
+            React.useElmish((fun () -> Program.mkProgram init update (fun _ _ -> ())), ?dependencies=dependencies)
 
-        static member useElmish(initial, update, ?dependencies: obj array) =
-            React.useElmish(fun () -> Program.mkProgram (fun () -> initial) update (fun _ _ -> ()))
+        [<Hook>]
+        static member useElmish(init: 'Model * Cmd<'Msg>, update: 'Msg -> 'Model -> 'Model * Cmd<'Msg>, ?dependencies: obj array) =
+            React.useElmish((fun () -> Program.mkProgram (fun () -> init) update (fun _ _ -> ())), ?dependencies=dependencies)

--- a/Feliz.UseElmish/UseElmish.fs
+++ b/Feliz.UseElmish/UseElmish.fs
@@ -2,117 +2,58 @@ namespace Feliz.UseElmish
 
 open Feliz
 open Elmish
-open Fable.Core
 
-[<Struct>]
-type internal RingState<'item> =
-    | Writable of wx:'item array * ix:int
-    | ReadWritable of rw:'item array * wix:int * rix:int
+type private ElmishObservable<'State, 'Msg>() =
+    let mutable state: 'State option = None
+    let mutable listener: ('State -> unit) option = None
+    let mutable dispatcher: ('Msg -> unit) option = None
 
-type internal RingBuffer<'item>(size) =
-    let doubleSize ix (items: 'item array) =
-        seq { yield! items |> Seq.skip ix
-              yield! items |> Seq.take ix
-              for _ in 0..items.Length do
-                yield Unchecked.defaultof<'item> }
-        |> Array.ofSeq
+    member _.Value = state
 
-    let mutable state : 'item RingState =
-        Writable (Array.zeroCreate (max size 10), 0)
+    member _.SetState (model: 'State) (dispatch: 'Msg -> unit) =
+        state <- Some model
+        dispatcher <- Some dispatch
+        match listener with
+        | None -> ()
+        | Some listener -> listener model
 
-    member _.Pop() =
-        match state with
-        | ReadWritable (items, wix, rix) ->
-            let rix' = (rix + 1) % items.Length
-            match rix' = wix with
-            | true ->
-                state <- Writable(items, wix)
-            | _ ->
-                state <- ReadWritable(items, wix, rix')
-            Some items.[rix]
-        | _ ->
-            None
+    member _.Dispatch(msg) =
+        match dispatcher with
+        | None -> () // Error?
+        | Some dispatch -> dispatch msg
 
-    member _.Push (item:'item) =
-        match state with
-        | Writable (items, ix) ->
-            items.[ix] <- item
-            let wix = (ix + 1) % items.Length
-            state <- ReadWritable(items, wix, ix)
-        | ReadWritable (items, wix, rix) ->
-            items.[wix] <- item
-            let wix' = (wix + 1) % items.Length
-            match wix' = rix with
-            | true ->
-                state <- ReadWritable(items |> doubleSize rix, items.Length, 0)
-            | _ ->
-                state <- ReadWritable(items, wix', rix)
+    member _.Subscribe(f) =
+        match listener with
+        | Some _ -> ()
+        | None -> listener <- Some f
 
 [<AutoOpen>]
 module UseElmishExtensions =
-    let inline internal getDisposable (record: 'State) =
-        match box record with
-        | :? System.IDisposable as disposable -> Some disposable
-        | _ -> None
-
     type React with
         [<Hook>]
-        static member useElmish<'State,'Msg> (init: 'State * Cmd<'Msg>, update: 'Msg -> 'State -> 'State * Cmd<'Msg>, dependencies: obj[]) =
-            let state = React.useRef(fst init)
-            let ring = React.useRef(RingBuffer(10))
-            let childState, setChildState = React.useState(fst init)
-            let token = React.useCancellationToken()
-            let setChildState () =
-                JS.setTimeout(fun () ->
-                    if not token.current.IsCancellationRequested then
-                        setChildState state.current
-                ) 0 |> ignore
+        static member useElmish(program: unit -> Program<unit, 'State, 'Msg, unit>) =
+            // Don't use useMemo here because React doesn't guarantee it won't recreate it again
+            let obs, _ = React.useState(fun () -> ElmishObservable())
 
-            let rec dispatch (msg: 'Msg) =
-                promise {
-                    let mutable nextMsg = Some msg
+            let state, setState = React.useState(fun () ->
+                program()
+                |> Program.withSetState obs.SetState
+                |> Program.run
 
-                    while nextMsg.IsSome && not (token.current.IsCancellationRequested) do
-                        let msg = nextMsg.Value
-                        let (state', cmd') = update msg state.current
-                        cmd' |> List.iter (fun sub -> sub dispatch)
-                        nextMsg <- ring.current.Pop()
-                        state.current <- state'
-                        setChildState()
-                }
-                |> Promise.start
+                match obs.Value with
+                | None -> failwith "Elmish program has not initialized"
+                | Some v -> v)
 
-            let dispatch = React.useCallbackRef(dispatch)
-
-            React.useEffect((fun () ->
+            React.useEffectOnce(fun () ->
                 React.createDisposable(fun () ->
-                    getDisposable state.current
-                    |> Option.iter (fun o -> o.Dispose())
-                )
-            ), dependencies)
+                        match box state with
+                        | :? System.IDisposable as disp -> disp.Dispose()
+                        | _ -> ()))
 
-            React.useEffect((fun () ->
-                state.current <- fst init
-                setChildState()
+            obs.Subscribe(setState)
+            state, obs.Dispatch
 
-                snd init
-                |> List.iter (fun sub -> sub dispatch)
-            ), dependencies)
-
-            React.useEffect(fun () -> ring.current.Pop() |> Option.iter dispatch)
-
-            (childState, dispatch)
-
-        [<Hook>]
-        static member inline useElmish<'State,'Msg> (init: 'State * Cmd<'Msg>, update: 'Msg -> 'State -> 'State * Cmd<'Msg>) =
-            React.useElmish(init, update, [||])
-
-        [<Hook>]
-        static member useElmish<'State,'Msg> (init: unit -> 'State * Cmd<'Msg>, update: 'Msg -> 'State -> 'State * Cmd<'Msg>, dependencies: obj[]) =
-            let init = React.useMemo(init, dependencies)
-
-            React.useElmish(init, update, dependencies)
-
-        [<Hook>]
-        static member inline useElmish<'State,'Msg> (init: unit -> 'State * Cmd<'Msg>, update: 'Msg -> 'State -> 'State * Cmd<'Msg>) =
-            React.useElmish(init, update, [||])
+        static member useElmish(update, init) =
+            React.useElmish(fun () ->
+                let view _ _ = ()
+                Program.mkProgram init update view)

--- a/Feliz.UseElmish/UseElmish.fs
+++ b/Feliz.UseElmish/UseElmish.fs
@@ -53,7 +53,13 @@ module UseElmishExtensions =
             obs.Subscribe(setState)
             state, obs.Dispatch
 
-        static member useElmish(update, init) =
+        static member useElmish(init, update, ?dependencies: obj array) =
             React.useElmish(fun () ->
                 let view _ _ = ()
+                Program.mkProgram init update view)
+
+        static member useElmish(initial, update, ?dependencies: obj array) =
+            React.useElmish(fun () ->
+                let view _ _ = ()
+                let init () = initial
                 Program.mkProgram init update view)

--- a/docs/paket.references
+++ b/docs/paket.references
@@ -5,3 +5,4 @@ Fable.React
 Fable.SimpleHttp
 FSharp.Core
 Zanaptak.TypedCssClasses
+Fable.Promise

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -9,6 +9,7 @@ group Main
     nuget Fable.Mocha
     nuget Fable.React
     nuget Fable.SimpleHttp
+    nuget Fable.Promise >= 3.1
     nuget FSharp.Core ~> 4.7.2
     nuget Zanaptak.TypedCssClasses
     

--- a/paket.lock
+++ b/paket.lock
@@ -36,6 +36,9 @@ NUGET
     Fable.Mocha (2.9.1)
       Fable.Core (>= 3.0) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.7) - restriction: >= netstandard2.0
+    Fable.Promise (3.1)
+      Fable.Core (>= 3.1.5) - restriction: >= netstandard2.0
+      FSharp.Core (>= 4.7.2) - restriction: >= netstandard2.0
     Fable.React (7.4)
       Fable.Browser.Dom (>= 2.0.1) - restriction: >= netstandard2.0
       Fable.Core (>= 3.1.5) - restriction: >= netstandard2.0

--- a/tests/paket.references
+++ b/tests/paket.references
@@ -1,3 +1,4 @@
 Fable.Browser.Dom
 Fable.Mocha
 FSharp.Core
+Fable.Promise


### PR DESCRIPTION
This fixes https://github.com/fable-compiler/fable-promise/issues/24 following @MangelMaxime suggestion to use the Elmish.Program implementation instead of adding a custom one.

I've tested this in a project of mine and also in Fable.Lit and it seems to work. Feliz tests are also passing. The PR is still missing the dependencies, but if you're open to merge this @Zaid-Ajaj I can add them too.