### PR TITLE
Fix prop.charset.utf8

### DIFF
--- a/Feliz/Properties.fs
+++ b/Feliz/Properties.fs
@@ -2493,7 +2493,7 @@ module prop =
 
     [<Erase>]
     type charset =
-        static member inline utf8 = Interop.mkAttr "charset" "UTF-8"
+        static member inline utf8 = Interop.mkAttr "charSet" "UTF-8"
 
     /// Indicates which coordinate system to use for the contents of the <clipPath> element.
     [<Erase>]


### PR DESCRIPTION
Hello this PR fix the casing of `prop.charset.utf8`. I missed it in my previous PR

> Invalid DOM property `charset`. Did you mean `charSet`?
