### PR TITLE
Fix text overflow in docs

### DIFF
--- a/docs/App.fs
+++ b/docs/App.fs
@@ -1178,7 +1178,7 @@ let main = React.functionComponent(fun (input: {| state: State; dispatch: Msg ->
             ]
 
             Html.div [
-                prop.className Bulma.Tile
+                prop.className [ Bulma.Tile; Bulma.Is10 ]
                 prop.style [ style.paddingTop 30 ]
                 prop.children [ content {| state = input.state; dispatch = dispatch |} ]
             ]


### PR DESCRIPTION
It is a simple fix for https://github.com/Zaid-Ajaj/Feliz/issues/417 . I didn't create PR until now because I had problem with seeing docs pages after running npm command.
![overflow](https://user-images.githubusercontent.com/24713400/141049387-adf55980-2cc9-4d52-a159-58959b1154df.jpg)



