### PR TITLE
Disable experimental attribute for well-supported max-content, min-content

### DIFF
--- a/Feliz/Styles.fs
+++ b/Feliz/Styles.fs
@@ -2315,11 +2315,9 @@ module style =
         static member inline fitContent = Interop.mkStyle "width" "fit-content"
 
         /// The intrinsic preferred width.
-        [<Experimental("This is an experimental API that should not be used in production code.")>]
         static member inline maxContent = Interop.mkStyle "width" "max-content"
 
         /// The intrinsic minimum width.
-        [<Experimental("This is an experimental API that should not be used in production code.")>]
         static member inline minContent = Interop.mkStyle "width" "min-content"
 
     [<Erase>]
@@ -2336,11 +2334,9 @@ module style =
         static member inline fitContent = Interop.mkStyle "minWidth" "fit-content"
 
         /// The intrinsic preferred width.
-        [<Experimental("This is an experimental API that should not be used in production code.")>]
         static member inline maxContent = Interop.mkStyle "minWidth" "max-content"
 
         /// The intrinsic minimum width.
-        [<Experimental("This is an experimental API that should not be used in production code.")>]
         static member inline minContent = Interop.mkStyle "minWidth" "min-content"
 
      [<Erase>]
@@ -2357,11 +2353,9 @@ module style =
         static member inline fitContent = Interop.mkStyle "maxWidth" "fit-content"
 
         /// The intrinsic preferred width.
-        [<Experimental("This is an experimental API that should not be used in production code.")>]
         static member inline maxContent = Interop.mkStyle "maxWidth" "max-content"
 
         /// The intrinsic minimum width.
-        [<Experimental("This is an experimental API that should not be used in production code.")>]
         static member inline minContent = Interop.mkStyle "maxWidth" "min-content"
 
     [<Erase>]
@@ -2378,11 +2372,9 @@ module style =
         static member inline fitContent = Interop.mkStyle "height" "fit-content"
 
         /// The intrinsic preferred height.
-        [<Experimental("This is an experimental API that should not be used in production code.")>]
         static member inline maxContent = Interop.mkStyle "height" "max-content"
 
         /// The intrinsic minimum height.
-        [<Experimental("This is an experimental API that should not be used in production code.")>]
         static member inline minContent = Interop.mkStyle "height" "min-content"
 
     [<Erase>]
@@ -2399,11 +2391,9 @@ module style =
         static member inline fitContent = Interop.mkStyle "minHeight" "fit-content"
 
         /// The intrinsic preferred height.
-        [<Experimental("This is an experimental API that should not be used in production code.")>]
         static member inline maxContent = Interop.mkStyle "minHeight" "max-content"
 
         /// The intrinsic minimum height.
-        [<Experimental("This is an experimental API that should not be used in production code.")>]
         static member inline minContent = Interop.mkStyle "minHeight" "min-content"
 
     [<Erase>]
@@ -2420,11 +2410,9 @@ module style =
         static member inline fitContent = Interop.mkStyle "maxHeight" "fit-content"
 
         /// The intrinsic preferred height.
-        [<Experimental("This is an experimental API that should not be used in production code.")>]
         static member inline maxContent = Interop.mkStyle "maxHeight" "max-content"
 
         /// The intrinsic minimum height.
-        [<Experimental("This is an experimental API that should not be used in production code.")>]
         static member inline minContent = Interop.mkStyle "maxHeight" "min-content"
 
     [<Erase>]


### PR DESCRIPTION
`max-content` and `min-content` are currently quite well supported properties on `width`, `min/max-width`, `height`, `min/max-height` according to _caniuse_. Therefore it makes sense to remove the Experimental attribute from them.

For `fit-content` this is not yet true as it still requires a prefix in Firefox, so I left it as is.

What follows are links to the corresponding caniuse pages. The browser support is about the same for all these properties.
- [width: max-content](https://caniuse.com/mdn-css_properties_width_max-content)
- [width, min-content](https://caniuse.com/mdn-css_properties_width_min-content)
- [min-width: max-content](https://caniuse.com/mdn-css_properties_width_max-content)
- [min-width: min-content](https://caniuse.com/mdn-css_properties_min-width_min-content)
- [max-width: max-content](https://caniuse.com/mdn-css_properties_max-width_max-content)
- [max-width: min-content](https://caniuse.com/mdn-css_properties_max-width_min-content)
- [height: max-content](https://caniuse.com/mdn-css_properties_height_max-content)
- [height: min-content](https://caniuse.com/mdn-css_properties_height_min-content)
- [min-height: max-content](https://caniuse.com/mdn-css_properties_min-height_max-content)
- [min-height: min-content](https://caniuse.com/mdn-css_properties_min-height_min-content)
- [max-height: max-content](https://caniuse.com/mdn-css_properties_max-height_max-content)
- [max-height: min-content](https://caniuse.com/mdn-css_properties_max-height_min-content)