### PR TITLE
Fixed AppVeyor pipeline

### DIFF
--- a/HeadlessTestsRunner/HeadlessTestsRunner.fsproj
+++ b/HeadlessTestsRunner/HeadlessTestsRunner.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net5;net6</TargetFrameworks>
+    <TargetFramework>net6</TargetFramework>
     <RunWorkingDirectory>$(MSBuildProjectDirectory)</RunWorkingDirectory>
   </PropertyGroup>
 

--- a/HeadlessTestsRunner/HeadlessTestsRunner.fsproj
+++ b/HeadlessTestsRunner/HeadlessTestsRunner.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5;net6</TargetFrameworks>
     <RunWorkingDirectory>$(MSBuildProjectDirectory)</RunWorkingDirectory>
   </PropertyGroup>
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ install:
   # Get the latest stable version of Node.js
   - ps: Install-Product node $env:nodejs_version
 
-os: Visual Studio 2017
+os: Visual Studio 2022
 
 build_script:
   - cmd: build.cmd Build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ cache:
 # Install scripts. (runs after repo cloning)
 install:
   # install latest dotnet core sdk
-  - cmd: choco install dotnetcore-sdk
+  - cmd: choco install dotnet-sdk
   # Get the latest stable version of Node.js
   - ps: Install-Product node $env:nodejs_version
 

--- a/build.cmd
+++ b/build.cmd
@@ -1,7 +1,7 @@
 @echo off
 cls
-
-.paket\paket.exe restore
+dotnet tool restore
+dotnet paket restore
 if errorlevel 1 (
   exit /b %errorlevel%
 )

--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,8 @@ set -eu
 
 cd "$(dirname "$0")"
 
-PAKET_EXE=.paket/paket.exe
+DOTNET_EXE=dotnet.exe
+PAKET_EXE=$DOTNET_EXE paket
 FAKE_EXE=packages/build/FAKE/tools/FAKE.exe
 
 FSIARGS=""
@@ -27,6 +28,9 @@ run() {
     "$@"
   fi
 }
+
+echo "Executing Dotnet..."
+run $DOTNET_EXE tool restore
 
 echo "Executing Paket..."
 

--- a/paket-install.sh
+++ b/paket-install.sh
@@ -1,1 +1,1 @@
-mono .paket/paket.exe install
+dotnet paket install


### PR DESCRIPTION
- In a previous version, the checked-in binary was removed but is still required by the build scripts
    -> Updated scripts to use the dotnet tool version