### PR TITLE
Add Recharts binding for dot, tickLine, tick and textAnchor

### DIFF
--- a/Feliz.Recharts/Area.fs
+++ b/Feliz.Recharts/Area.fs
@@ -2,6 +2,7 @@ namespace Feliz.Recharts
 
 open System
 open Fable.Core
+open Feliz
 open Fable.Core.JsInterop
 
 [<Erase>]
@@ -50,6 +51,8 @@ type area =
     static member inline stepAfter = Interop.mkAreaAttr "type" "stepAfter"
     static member inline monotoneY = Interop.mkAreaAttr "type" "monotoneY"
     static member inline stackId(value: string) = Interop.mkAreaAttr "stackId" value
+    static member inline dot(value: bool) = Interop.mkAreaAttr "dot" value
+    static member inline dot(render: IDotProperties<'a> -> ReactElement) = Interop.mkAreaAttr "dot" render
 
 [<Erase>]
 module area =

--- a/Feliz.Recharts/XAxis.fs
+++ b/Feliz.Recharts/XAxis.fs
@@ -49,9 +49,11 @@ type xAxis =
         Interop.mkXAxisAttr "padding" padding
     static member inline tickMargin (value: int) = Interop.mkXAxisAttr "tickMargin" value
     static member inline tickMargin (value: float) = Interop.mkXAxisAttr "tickMargin" value
+    static member inline tickLine (value: bool) = Interop.mkXAxisAttr "tickLine" value
     static member inline unit (value: string) = Interop.mkXAxisAttr "unit" value
     static member inline name (value: string) = Interop.mkXAxisAttr "name" value
     static member inline tick (tickRenderer : IXAxisTickProperties -> ReactElement) = Interop.mkXAxisAttr "tick" tickRenderer
+    static member inline tick (value : obj) = Interop.mkXAxisAttr "tick" value
     static member inline height (value: int) = Interop.mkXAxisAttr "height" value
     static member inline height (value: float) = Interop.mkXAxisAttr "height" value
     static member inline width (value: int) = Interop.mkXAxisAttr "width" value
@@ -69,6 +71,12 @@ module xAxis =
         static member inline preserveStart = Interop.mkXAxisAttr "interval" "preserveStart"
         static member inline preserveEnd = Interop.mkXAxisAttr "interval" "preserveEnd"
         static member inline preserveStartEnd = Interop.mkXAxisAttr "interval" "preserveStartEnd"
+        
+    [<Erase>]
+    type textAnchor =
+        static member inline textAnchorStart = Interop.mkXAxisAttr "textAnchor" "start"
+        static member inline textAnchorEnd = Interop.mkXAxisAttr "textAnchor" "end"
+        static member inline textAnchorMiddle = Interop.mkXAxisAttr "textAnchor" "middle"
 
     [<Erase>]
     type scale =


### PR DESCRIPTION
This pull request adds Recharts binding for Area and XAxis.

**Area**

- dot: To display dot on curve of area chart [https://recharts.org/en-US/api/Area#dot](https://recharts.org/en-US/api/Area#dot)
- dot: To create custom  dot [https://recharts.org/en-US/api/Area#dot](https://recharts.org/en-US/api/Area#dot)

**XAxis**

- tickLine: To display ticks or not [https://recharts.org/en-US/api/XAxis#tickLine](https://recharts.org/en-US/api/XAxis#tickLine)
- tick: To style xAxis labels [https://recharts.org/en-US/api/XAxis#tick](https://recharts.org/en-US/api/XAxis#tick)
- textAnchor: To configure the orientation of the labels [https://github.com/recharts/recharts/issues/2227#issuecomment-672366512](https://github.com/recharts/recharts/issues/2227#issuecomment-672366512)