### PR TITLE
ReactMemoComponent

### DIFF
--- a/docs/App.fs
+++ b/docs/App.fs
@@ -183,6 +183,23 @@ type MoreExamples() =
             if showAge then Html.h1 count
         ]
 
+    [<ReactMemoComponent>]
+    static member Memoized (value: int) =
+        printfn "Rendering Memoized..."
+        Html.p (sprintf "Value: %i" value)
+
+    [<ReactComponent>]
+    static member Parent () =
+        printfn "Rendering Parent..."
+        let count, setCount = React.useState 0
+        React.fragment [
+            Html.button [
+                prop.onClick (fun _ -> setCount(count + 1))
+                prop.text "+"
+            ]
+            Html.p (sprintf "Count: %i" count)
+            MoreExamples.Memoized 5
+        ]
 
 type KeyedCounterProps = { Key: string; Name: string }
 

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
         "test:live": "webpack-dev-server --config webpack.tests.js",
         "pretest": "webpack --config webpack.tests.js",
         "test": "dotnet run --project ./HeadlessTestsRunner/HeadlessTestsRunner.fsproj",
-        "start:nagareyama": "dotnet tool restore && dotnet fable watch docs --forcePkgs --exclude Feliz.CompilerPlugins --run webpack-dev-server --config webpack.nagareyama.js",
-        "build:nagareyama": "dotnet tool restore && dotnet fable docs --forcePkgs --exclude Feliz.CompilerPlugins --run webpack --config webpack.nagareyama.js --mode production",
+        "start:nagareyama": "dotnet tool restore && dotnet fable watch docs --noCache --exclude Feliz.CompilerPlugins --run webpack-dev-server --config webpack.nagareyama.js",
+        "build:nagareyama": "dotnet tool restore && dotnet fable docs --noCache --exclude Feliz.CompilerPlugins --run webpack --config webpack.nagareyama.js --mode production",
         "test:nagareyama": "dotnet tool restore && dotnet fable tests --exclude Feliz.CompilerPlugins --run webpack --config webpack.nagareyama.tests.js --mode production && dotnet run --project ./HeadlessTestsRunner/HeadlessTestsRunner.fsproj"
     },
     "repository": {


### PR DESCRIPTION
I don't remember if we had this discussion before but it would be very useful to have the option to use `React.memo` with `ReactComponent` attribute. This seems to work, I had to use another type because `new(memo: bool)` constructor conflicted with `new(exportDefault: bool)`. To my surprise F# optional arguments are not compatible with attribute constructors, the other option would be to use .NET optional arguments, as in `[<Optional; DefaultParameterValue(false)>] memo`

If this looks good, it'd be great to have a release so I can use it in my project :)