### PR TITLE
Add sourcelink support!

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,10 @@
+<Project>
+    <PropertyGroup>
+        <PackageProjectUrl>https://zaid-ajaj.github.io/Feliz/</PackageProjectUrl>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1" PrivateAssets="all" />
+    </ItemGroup>
+</Project>

--- a/Feliz.CompilerPlugins/Feliz.CompilerPlugins.fsproj
+++ b/Feliz.CompilerPlugins/Feliz.CompilerPlugins.fsproj
@@ -1,14 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Provides compile-time transformation for React components</Description>
-    <RepositoryUrl>https://github.com/Zaid-Ajaj/Feliz.git</RepositoryUrl>
-    <PackageProjectUrl>https://github.com/Zaid-Ajaj/Feliz</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/Zaid-Ajaj/Feliz/blob/master/LICENSE</PackageLicenseUrl>
     <PackageTags>fsharp;fable;react;html</PackageTags>
     <Authors>Zaid Ajaj</Authors>
     <Version>1.8.0</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageReleaseNotes>Added ReactMemoComponent attribute</PackageReleaseNotes>
   </PropertyGroup>
   <ItemGroup>

--- a/Feliz.Delay/Feliz.Delay.fsproj
+++ b/Feliz.Delay/Feliz.Delay.fsproj
@@ -5,8 +5,6 @@
     <PackageVersion>0.3.1</PackageVersion>
     <Authors>Cody Johnson, Zaid Ajaj</Authors>
     <Description>Adds easy to use delayed rendering</Description>
-    <PackageLicenseUrl>https://github.com/Zaid-Ajaj/Feliz/blob/master/LICENSE</PackageLicenseUrl>
-    <RepositoryUrl>https://github.com/Zaid-Ajaj/Feliz</RepositoryUrl>
     <PackageTags>fsharp;fable;react;html;feliz</PackageTags>
     <PackageReleaseNotes>Remove generated JS artifacts from the nuget package</PackageReleaseNotes>
   </PropertyGroup>

--- a/Feliz.ElmishComponents/Feliz.ElmishComponents.fsproj
+++ b/Feliz.ElmishComponents/Feliz.ElmishComponents.fsproj
@@ -1,8 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Description>Elmish components as React elements without the boilerplate based on the Feliz API</Description>
-        <RepositoryUrl>https://github.com/Zaid-Ajaj/Feliz</RepositoryUrl>
-        <PackageLicenseUrl>https://github.com/Zaid-Ajaj/Feliz/blob/master/LICENSE</PackageLicenseUrl>
         <PackageIconUrl></PackageIconUrl>
         <PackageTags>fsharp;fable;react;html</PackageTags>
         <Authors>Zaid Ajaj</Authors>

--- a/Feliz.Kawaii/Feliz.Kawaii.fsproj
+++ b/Feliz.Kawaii/Feliz.Kawaii.fsproj
@@ -2,14 +2,11 @@
 
   <PropertyGroup>
     <Description>react-kawaii bindings based on the Feliz API</Description>
-    <RepositoryUrl>https://github.com/Zaid-Ajaj/Feliz</RepositoryUrl>
-    <PackageLicenseUrl>https://github.com/Zaid-Ajaj/Feliz/blob/master/LICENSE</PackageLicenseUrl>
     <PackageIconUrl></PackageIconUrl>
     <PackageTags>fsharp;fable;react;html</PackageTags>
     <Authors>Zaid Ajaj</Authors>
     <Version>1.0.0</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageReleaseNotes>Initial release</PackageReleaseNotes>
   </PropertyGroup>
 

--- a/Feliz.Markdown/Feliz.Markdown.fsproj
+++ b/Feliz.Markdown/Feliz.Markdown.fsproj
@@ -1,14 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Description>React-Markdown bindings based on the Feliz API</Description>
-        <RepositoryUrl>https://github.com/Zaid-Ajaj/Feliz</RepositoryUrl>
-        <PackageLicenseUrl>https://github.com/Zaid-Ajaj/Feliz/blob/master/LICENSE</PackageLicenseUrl>
         <PackageIconUrl></PackageIconUrl>
         <PackageTags>fsharp;fable;react;html</PackageTags>
         <Authors>Zaid Ajaj</Authors>
         <Version>1.3.1</Version>
         <TargetFramework>netstandard2.0</TargetFramework>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
     <PropertyGroup>
         <NpmDependencies>

--- a/Feliz.PigeonMaps/Feliz.PigeonMaps.fsproj
+++ b/Feliz.PigeonMaps/Feliz.PigeonMaps.fsproj
@@ -1,14 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Description>pigeon-maps bindings based on the Feliz API</Description>
-        <RepositoryUrl>https://github.com/Zaid-Ajaj/Feliz</RepositoryUrl>
-        <PackageLicenseUrl>https://github.com/Zaid-Ajaj/Feliz/blob/master/LICENSE</PackageLicenseUrl>
         <PackageIconUrl></PackageIconUrl>
         <PackageTags>fsharp;fable;react;html;feliz;maps</PackageTags>
         <Authors>Zaid Ajaj</Authors>
         <Version>2.5.0</Version>
         <TargetFramework>netstandard2.0</TargetFramework>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageReleaseNotes>Remove generated JS artifacts from the nuget package</PackageReleaseNotes>
     </PropertyGroup>
     <PropertyGroup>

--- a/Feliz.Popover/Feliz.Popover.fsproj
+++ b/Feliz.Popover/Feliz.Popover.fsproj
@@ -1,14 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Description>react-popover bindings based on the Feliz API</Description>
-        <RepositoryUrl>https://github.com/Zaid-Ajaj/Feliz</RepositoryUrl>
-        <PackageLicenseUrl>https://github.com/Zaid-Ajaj/Feliz/blob/master/LICENSE</PackageLicenseUrl>
         <PackageIconUrl></PackageIconUrl>
         <PackageTags>fsharp;fable;react;html</PackageTags>
         <Authors>Zaid Ajaj</Authors>
         <Version>2.3.0</Version>
         <TargetFramework>netstandard2.0</TargetFramework>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageReleaseNotes>Update Feliz dependency</PackageReleaseNotes>
     </PropertyGroup>
     <PropertyGroup>

--- a/Feliz.Recharts/Feliz.Recharts.fsproj
+++ b/Feliz.Recharts/Feliz.Recharts.fsproj
@@ -1,14 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Description>Recharts bindings based on the Feliz API</Description>
-        <RepositoryUrl>https://github.com/Zaid-Ajaj/Feliz</RepositoryUrl>
-        <PackageLicenseUrl>https://github.com/Zaid-Ajaj/Feliz/blob/master/LICENSE</PackageLicenseUrl>
         <PackageIconUrl></PackageIconUrl>
         <PackageTags>fsharp;fable;react;html</PackageTags>
         <Authors>Zaid Ajaj</Authors>
         <Version>3.11.0</Version>
         <TargetFramework>netstandard2.0</TargetFramework>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageReleaseNotes>Add Recharts binding for dot, tickLine, tick and textAnchor</PackageReleaseNotes>
     </PropertyGroup>
     <PropertyGroup>

--- a/Feliz.RoughViz/Feliz.RoughViz.fsproj
+++ b/Feliz.RoughViz/Feliz.RoughViz.fsproj
@@ -1,14 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Description>Feliz binding for the rough-viz library</Description>
-        <RepositoryUrl>https://github.com/Zaid-Ajaj/Feliz</RepositoryUrl>
-        <PackageLicenseUrl>https://github.com/Zaid-Ajaj/Feliz/blob/master/LICENSE</PackageLicenseUrl>
         <PackageIconUrl></PackageIconUrl>
         <PackageTags>fsharp;fable;react;html;feliz</PackageTags>
         <Authors>Zaid Ajaj</Authors>
         <Version>1.5.1</Version>
         <TargetFramework>netstandard2.0</TargetFramework>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageReleaseNotes>Remove generated JS artifacts from the nuget package</PackageReleaseNotes>
     </PropertyGroup>
     <ItemGroup>

--- a/Feliz.SelectSearch/Feliz.SelectSearch.fsproj
+++ b/Feliz.SelectSearch/Feliz.SelectSearch.fsproj
@@ -2,14 +2,11 @@
 
   <PropertyGroup>
     <Description>react-select-search bindings based on the Feliz API</Description>
-    <RepositoryUrl>https://github.com/Zaid-Ajaj/Feliz</RepositoryUrl>
-    <PackageLicenseUrl>https://github.com/Zaid-Ajaj/Feliz/blob/master/LICENSE</PackageLicenseUrl>
     <PackageIconUrl></PackageIconUrl>
     <PackageTags>fsharp;fable;react;html</PackageTags>
     <Authors>Zaid Ajaj</Authors>
     <Version>1.6.0</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageReleaseNotes>Fix option value when used in renderOption</PackageReleaseNotes>
   </PropertyGroup>
 

--- a/Feliz.Template/Feliz.Template.proj
+++ b/Feliz.Template/Feliz.Template.proj
@@ -2,9 +2,6 @@
   <PropertyGroup>
     <Description>Feliz application template with proper configuration and a unit test project</Description>
     <Authors>Zaid Ajaj</Authors>
-    <PackageProjectUrl>https://github.com/Zaid-Ajaj/Feliz</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/Zaid-Ajaj/Feliz/blob/master/LICENSE.md</PackageLicenseUrl>
-    <RepositoryUrl>https://github.com/Zaid-Ajaj/Feliz.git</RepositoryUrl>
     <PackageTags>fable;template;fsharp</PackageTags>
     <NeutralLanguage>en-US</NeutralLanguage>
     <PackageType>Template</PackageType>

--- a/Feliz.UseDeferred/Feliz.UseDeferred.fsproj
+++ b/Feliz.UseDeferred/Feliz.UseDeferred.fsproj
@@ -1,14 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Description>Hooks for dead-simple data fetching with Feliz</Description>
-        <RepositoryUrl>https://github.com/Zaid-Ajaj/Feliz</RepositoryUrl>
-        <PackageLicenseUrl>https://github.com/Zaid-Ajaj/Feliz/blob/master/LICENSE</PackageLicenseUrl>
         <PackageIconUrl></PackageIconUrl>
         <PackageTags>fsharp;fable;react;html;feliz</PackageTags>
         <Authors>Zaid Ajaj</Authors>
         <Version>1.4.1</Version>
         <TargetFramework>netstandard2.0</TargetFramework>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageReleaseNotes>Remove generated JS artifacts from the nuget package</PackageReleaseNotes>
     </PropertyGroup>
     <ItemGroup>

--- a/Feliz.UseElmish/Feliz.UseElmish.fsproj
+++ b/Feliz.UseElmish/Feliz.UseElmish.fsproj
@@ -1,14 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Description>useElmish hooks to build Elmish components as React components</Description>
-        <RepositoryUrl>https://github.com/Zaid-Ajaj/Feliz</RepositoryUrl>
-        <PackageLicenseUrl>https://github.com/Zaid-Ajaj/Feliz/blob/master/LICENSE</PackageLicenseUrl>
         <PackageIconUrl></PackageIconUrl>
         <PackageTags>fsharp;fable;react;html;feliz</PackageTags>
         <Authors>Zaid Ajaj</Authors>
         <Version>1.6.0</Version>
         <TargetFramework>netstandard2.0</TargetFramework>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageReleaseNotes>Use and accept a full Elmish program instead of re-implementing it</PackageReleaseNotes>
     </PropertyGroup>
     <ItemGroup>

--- a/Feliz.UseMediaQuery/Feliz.UseMediaQuery.fsproj
+++ b/Feliz.UseMediaQuery/Feliz.UseMediaQuery.fsproj
@@ -5,8 +5,6 @@
     <PackageVersion>1.4.1</PackageVersion>
     <Authors>Jonas Bösch, Zaid Ajaj</Authors>
     <Description>useMediaQuery hooks to build responsive websites </Description>
-    <PackageLicenseUrl>https://github.com/Zaid-Ajaj/Feliz/blob/master/LICENSE</PackageLicenseUrl>
-    <RepositoryUrl>https://github.com/Zaid-Ajaj/Feliz</RepositoryUrl>
     <PackageTags>fsharp;fable;react;html;feliz</PackageTags>
     <PackageReleaseNotes>Remove generated JS artifacts from the nuget package</PackageReleaseNotes>
   </PropertyGroup>

--- a/Feliz/Feliz.fsproj
+++ b/Feliz/Feliz.fsproj
@@ -2,14 +2,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>A fresh retake of the React API in Fable, optimized for happiness</Description>
-    <RepositoryUrl>https://github.com/Zaid-Ajaj/Feliz.git</RepositoryUrl>
-    <PackageProjectUrl>https://github.com/Zaid-Ajaj/Feliz</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/Zaid-Ajaj/Feliz/blob/master/LICENSE</PackageLicenseUrl>
     <PackageTags>fsharp;fable;react;html</PackageTags>
     <Authors>Zaid Ajaj</Authors>
     <Version>1.62.0</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageReleaseNotes>Added ReactMemoComponent attribute</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -12,7 +12,7 @@ group Main
     nuget Fable.Promise >= 3.1
     nuget FSharp.Core >= 4.7.2
     nuget Zanaptak.TypedCssClasses
-    
+
 group Build
   framework >= net45
   source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
This adds the Dotnet.ReproducibleBuilds package for drop-in sourcelink support! With this change, VS and Ionide can go-to-definition directly to the code that was packaged!

I also centralized some package parameters in a Directory.Build.props, which is a special MSBuild file that applies its properties to all projects beside or below the file.