### PR TITLE
Add getOptions and debounce

### DIFF
--- a/Feliz.SelectSearch/SelectSearch.fs
+++ b/Feliz.SelectSearch/SelectSearch.fs
@@ -149,6 +149,97 @@ type selectSearch =
 
         unbox<ISelectSearchAttribute> ("options", selectOptions)
 
+    /// <summary>Get options through a function call, can return a promise for async usage</summary>
+    static member getOptions (computation: string -> Async<seq<SelectItem>>) =
+        let toSelectOptions items = [|
+            for item in items -> createObj [
+                "value" ==> item.value
+                "name" ==> item.name
+                "disabled" ==> item.disabled
+            ]
+        |]
+
+        let map f x = 
+            async {
+                let! y = x
+                return f y
+            }
+
+        let promise = 
+            computation 
+            >> map toSelectOptions 
+            >> Async.StartAsPromise
+        
+        unbox<ISelectSearchAttribute> ("getOptions", promise)
+
+    /// <summary>Get options through a function call, can return a promise for async usage</summary>
+    static member getOptions (computation: string -> Async<seq<SelectGroup>>) =
+        let toSelectOptions groups = [|
+            for group in groups -> createObj [
+                "type" ==> "group"
+                "name" ==> group.name
+                "items" ==> [|
+                    for item in group.items -> createObj [
+                        "value" ==> item.value
+                        "name" ==> item.name
+                    ]
+                |]
+            ]
+        |]
+
+        let map f x = 
+            async {
+                let! y = x
+                return f y
+            }
+
+        let promise = 
+            computation 
+            >> map toSelectOptions 
+            >> Async.StartAsPromise
+        
+        unbox<ISelectSearchAttribute> ("getOptions", promise)
+
+    /// <summary>Get options through a function call, can return a promise for async usage</summary>
+    static member getOptions (computation: string -> Async<seq<SelectOption>>) =
+        let toSelectOptions mixedOptions = [|
+            for option in mixedOptions ->
+                match option with
+                | SelectOption.Item item ->
+                    createObj [
+                        "value" ==> item.value
+                        "name" ==> item.name
+                        "disabled" ==> item.disabled
+                    ]
+                | SelectOption.Group group ->
+                    createObj [
+                        "type" ==> "group"
+                        "name" ==> group.name
+                        "items" ==> [|
+                            for item in group.items -> createObj [
+                                "value" ==> item.value
+                                "name" ==> item.name
+                                "disabled" ==> item.disabled
+                            ]
+                        |]
+                    ]
+        |]
+
+        let map f x = 
+            async {
+                let! y = x
+                return f y
+            }
+
+        let promise = 
+            computation 
+            >> map toSelectOptions 
+            >> Async.StartAsPromise
+        
+        unbox<ISelectSearchAttribute> ("getOptions", promise)
+
+    /// <summary>Number of ms to wait until calling get options when searching</summary>
+    static member inline debounce(debounceValue: int) = unbox<ISelectSearchAttribute> ("debounce", debounceValue)
     /// <summary>Sets the currently selected value when in controlled mode</summary>
     static member inline value(currentValue: string) = unbox<ISelectSearchAttribute> ("value", currentValue)
     /// <summary>Sets the currently selected values when in controlled mode and multiple is enabled</summary>


### PR DESCRIPTION
I tested it with this little module...

```FSharp
module Main

open Browser.Dom
open Elmish
open Elmish.React
open Feliz
open Feliz.Recharts
open Feliz.Markdown
open Feliz.PigeonMaps
open Feliz.Router
open Fable.Core.JsInterop
open Fable.SimpleHttp
open Zanaptak.TypedCssClasses
open Feliz.UseElmish
open Feliz.SelectSearch
open Fable.Core

type State = {
    Message: string
}

let init () =
    { Message = "Hello" }, Cmd.none

let update msg state =
    state, Cmd.none

let render (state: State) dispatch = 
    Html.div [
        prop.style [ style.width 400; style.padding 10 ]
        prop.children [
            SelectSearch.selectSearch [
                selectSearch.placeholder "Select an item"                
                selectSearch.search true     
                selectSearch.debounce 3000
                selectSearch.options (Seq.empty<SelectItem>)
                selectSearch.getOptions (fun query -> async {
                    console.log query

                    let items =
                        Seq.init 100 (fun index -> { value = index.ToString(); name = "Item " + index.ToString(); disabled = false })
                        |> Seq.filter (fun x -> x.name.Contains query)

                    return items 
                })
            ]
        ]
    ]

Program.mkProgram init update render
|> Program.withReactSynchronous "root"
|> Program.withConsoleTrace
|> Program.run
```