### PR TITLE
Update plugins to Fable 4

### DIFF
--- a/Feliz.CompilerPlugins/AstUtils.fs
+++ b/Feliz.CompilerPlugins/AstUtils.fs
@@ -33,18 +33,21 @@ let makeStrConst (x: string) =
 
 let nullValue = Fable.Expr.Value(Fable.ValueKind.Null(Fable.Type.Any), None)
 
+let makeCallInfo args: Fable.CallInfo = {
+    ThisArg = None
+    Args = args
+    SignatureArgTypes = []
+    GenericArgs = []
+    MemberRef = None
+    Tags = []
+}
+
 let emitJs macro args  =
-    let callInfo: Fable.CallInfo =
-        { ThisArg = None
-          Args = args
-          SignatureArgTypes = []
-          HasSpread = false
-          IsJsConstructor = false
-          CallMemberInfo = None }
+    let callInfo = makeCallInfo args
 
     let emitInfo : Fable.AST.Fable.EmitInfo =
         { Macro = macro
-          IsJsStatement = false
+          IsStatement = false
           CallInfo = callInfo }
 
     Fable.Expr.Emit(emitInfo, Fable.Type.Any, None)
@@ -69,7 +72,7 @@ let rec flattenList (head: Fable.Expr) (tail: Fable.Expr) =
 let makeImport (selector: string) (path: string) =
     Fable.Import({ Selector = selector
                    Path = path
-                   IsCompilerGenerated = true }, Fable.Any, None)
+                   Kind = Fable.LibraryImport }, Fable.Any, None)
 
 let isRecord (compiler: PluginHelper) (fableType: Fable.Type) =
     match fableType with
@@ -100,7 +103,7 @@ let isReactElement (fableType: Fable.Type) =
 
 let recordHasField name (compiler: PluginHelper) (fableType: Fable.Type) =
     match fableType with
-    | Fable.Type.AnonymousRecordType (fieldNames, genericArgs) ->
+    | Fable.Type.AnonymousRecordType (fieldNames, genericArgs, _isStruct) ->
         fieldNames
         |> Array.exists (fun field -> field = name)
 
@@ -112,65 +115,36 @@ let recordHasField name (compiler: PluginHelper) (fableType: Fable.Type) =
         false
 
 let makeCall callee args =
-    let callInfo: Fable.CallInfo =
-        { ThisArg = None
-          Args = args
-          SignatureArgTypes = []
-          HasSpread = false
-          IsJsConstructor = false
-          CallMemberInfo = None }
-
-    Fable.Call(callee, callInfo, Fable.Any, None)
+    Fable.Call(callee, makeCallInfo args, Fable.Any, None)
 
 let createElement reactElementType args =
     let callee = makeImport "createElement" "react"
-    let callInfo: Fable.CallInfo =
-        { ThisArg = None
-          Args = args
-          SignatureArgTypes = []
-          HasSpread = false
-          IsJsConstructor = false
-          CallMemberInfo = None }
-
-    Fable.Call(callee, callInfo, reactElementType, None)
+    Fable.Call(callee, makeCallInfo args, reactElementType, None)
 
 let emptyReactElement reactElementType =
     Fable.Expr.Value(Fable.Null(reactElementType), None)
 
-type MemberInfo(?info: Fable.MemberInfo,
-                ?isValue: bool) =
-    let infoOr f v =
-        match info with
-        | Some i -> f i
-        | None -> v
-    let argOrInfoOr arg f v =
-        match arg, info with
-        | Some arg, _ -> arg
-        | None, Some i -> f i
-        | None, None -> v
-    interface Fable.MemberInfo with
-        member _.IsValue = argOrInfoOr isValue (fun i -> i.IsValue) false
-        member _.Attributes = infoOr (fun i -> i.Attributes) Seq.empty
-        member _.HasSpread = infoOr (fun i -> i.HasSpread) false
-        member _.IsPublic = infoOr (fun i -> i.IsPublic) true
-        member _.IsInstance = infoOr (fun i -> i.IsInstance) true
-        member _.IsMutable = infoOr (fun i -> i.IsMutable) false
-        member _.IsGetter = infoOr (fun i -> i.IsGetter) false
-        member _.IsSetter = infoOr (fun i -> i.IsSetter) false
-        member _.IsEnumerator = infoOr (fun i -> i.IsEnumerator) false
-        member _.IsMangled = infoOr (fun i -> i.IsMangled) false
+let makeObjValueMemberInfo name typ: Fable.GeneratedMemberInfo = {
+    Name = name
+    ParamTypes = []
+    ReturnType = typ
+    IsInstance = true
+    HasSpread = false
+    IsMutable = false
+    DeclaringEntity = None
+}
 
-let objValue (k, v): Fable.MemberDecl =
+let objValue (k, v): Fable.ObjectExprMember =
     {
         Name = k
-        FullDisplayName = k
         Args = []
         Body = v
-        UsedNames = Set.empty
-        Info = MemberInfo(isValue=true)
-        ExportDefault = false
+        MemberRef =
+            makeObjValueMemberInfo k v.Type
+            |> Fable.GeneratedValue
+            |> Fable.GeneratedMemberRef
+        IsMangled = false
     }
-
 
 let objExpr kvs = Fable.ObjectExpr(List.map objValue kvs, Fable.Any, None)
 

--- a/Feliz.CompilerPlugins/Feliz.CompilerPlugins.fsproj
+++ b/Feliz.CompilerPlugins/Feliz.CompilerPlugins.fsproj
@@ -15,7 +15,7 @@
     <Compile Include="PrimitiveElementWithChildren.fs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Fable.AST" Version="3.0.0" />
+    <PackageReference Include="Fable.AST" Version="4.0.0-snake-island-alpha-001" />
     <PackageReference Update="FSharp.Core" Version="4.7.2" />
   </ItemGroup>
 </Project>

--- a/Feliz.CompilerPlugins/Hook.fs
+++ b/Feliz.CompilerPlugins/Hook.fs
@@ -6,7 +6,7 @@ open Fable.AST
 /// <summary>Applies to custom defined React hooks to ensure the generated code starts with "use" in order for fast-refresh to pick it up</summary>
 type HookAttribute() =
     inherit MemberDeclarationPluginAttribute()
-    override _.FableMinimumVersion = "3.0"
+    override _.FableMinimumVersion = "4.0"
 
     /// <summary>Transforms call-site into createElement calls</summary>
     override _.TransformCall(compiler, memb, expr) =
@@ -38,7 +38,8 @@ type HookAttribute() =
             expr
 
     override this.Transform(compiler, file, decl) =
-        if decl.Info.IsValue || decl.Info.IsGetter || decl.Info.IsSetter then
+        let info = compiler.GetMember(decl.MemberRef)
+        if info.IsValue || info.IsGetter || info.IsSetter then
             // Invalid attribute usage
             let errorMessage = sprintf "Expecting a function declation for %s when using [<Hook>]" decl.Name
             compiler.LogWarning(errorMessage, ?range=decl.Body.Range)

--- a/Feliz.CompilerPlugins/PrimitiveElement.fs
+++ b/Feliz.CompilerPlugins/PrimitiveElement.fs
@@ -5,7 +5,7 @@ open Fable.AST
 
 //type PrimitiveElementAttribute(tagName:string) =
 //    inherit MemberDeclarationPluginAttribute()
-//    override _.FableMinimumVersion = "3.0"
+//    override _.FableMinimumVersion = "4.0"
 //
 //    override _.TransformCall(logger, memb, expr) =
 //        match expr with

--- a/Feliz.CompilerPlugins/PrimitiveElementWithChildren.fs
+++ b/Feliz.CompilerPlugins/PrimitiveElementWithChildren.fs
@@ -5,7 +5,7 @@ open Fable.AST
 
 //type PrimitiveElementWithChildrenAttribute(tagName:string) =
 //    inherit MemberDeclarationPluginAttribute()
-//    override _.FableMinimumVersion = "3.0"
+//    override _.FableMinimumVersion = "4.0"
 //
 //    member this.TransformChildren(args) =
 //        let element = AstUtils.makeStrConst tagName


### PR DESCRIPTION
Hi @Zaid-Ajaj! We want to release Fable 4 beta soon so users can update their Feliz apps and check there are no regressions. The AST for Fable 4 should be locked by now, so I've updated the plugins to use it. How do you want to go with this? I think the easiest way for now would be to publish an alpha/beta release of Feliz.CompilerPlugins and then either:

1. Publish a prerelease of Feliz that depends on the new plugins
2. Just ask users to add the dependency of the new Feliz.CompilerPlugins. I think this should make Feliz work without a new release, but I need to test it. I'll try to do it using a local feed for the plugins.

Thanks!