### PR TITLE
Use stable Fable.AST 4

### DIFF
--- a/Feliz.CompilerPlugins/AstUtils.fs
+++ b/Feliz.CompilerPlugins/AstUtils.fs
@@ -70,9 +70,9 @@ let rec flattenList (head: Fable.Expr) (tail: Fable.Expr) =
     ]
 
 let makeImport (selector: string) (path: string) =
-    Fable.Import({ Selector = selector
-                   Path = path
-                   Kind = Fable.LibraryImport }, Fable.Any, None)
+    Fable.Import({ Selector = selector.Trim()
+                   Path = path.Trim()
+                   Kind = Fable.UserImport(false) }, Fable.Any, None)
 
 let isRecord (compiler: PluginHelper) (fableType: Fable.Type) =
     match fableType with

--- a/Feliz.CompilerPlugins/Feliz.CompilerPlugins.fsproj
+++ b/Feliz.CompilerPlugins/Feliz.CompilerPlugins.fsproj
@@ -15,7 +15,7 @@
     <Compile Include="PrimitiveElementWithChildren.fs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Fable.AST" Version="4.0.0-snake-island-alpha-001" />
+    <PackageReference Include="Fable.AST" Version="4.0.0" />
     <PackageReference Update="FSharp.Core" Version="4.7.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Sorry for this @Zaid-Ajaj but as expected we broke the AST just two days after publishing the new plugins 😅 

Anyways, we've already locked and published Fable.AST 4.0.0 stable so we won't make any modification until the release of Fable 4.

Would it be possible to publish a new version of the plugins with the fix? Thanks and sorry again!