### PR TITLE
Fixed Style.TransformOrigin

### DIFF
--- a/Feliz/Feliz.fsproj
+++ b/Feliz/Feliz.fsproj
@@ -30,6 +30,7 @@
     <Compile Include="TextDecorationStyle.fs" />
     <Compile Include="TextDecorationLine.fs" />
     <Compile Include="TransitionProperty.fs" />
+    <Compile Include="TransformOrigin.fs" />
     <Compile Include="GridTypes.fs" />
     <Compile Include="Styles.fs" />
     <Compile Include="Svg.fs" />

--- a/Feliz/TransformOrigin.fs
+++ b/Feliz/TransformOrigin.fs
@@ -1,14 +1,17 @@
 namespace Feliz
 
+open Fable.Core
+open Feliz.Styles
+
 [<Erase>]
 type origin =
-    static member inline left : ITransformOrigin = "left"
-    static member inline center : ITransformOrigin = "center"
-    static member inline right : ITransformOrigin = "right"
-    static member inline top : ITransformOrigin = "top"
-    static member inline bottom : ITransformOrigin = "bottom"
+    static member inline left : ITransformOrigin = unbox "left"
+    static member inline center : ITransformOrigin = unbox "center"
+    static member inline right : ITransformOrigin = unbox "right"
+    static member inline top : ITransformOrigin = unbox "top"
+    static member inline bottom : ITransformOrigin = unbox "bottom"
 
     static member inline percentage (value: int) : ITransformOrigin =
-        unbox<string> value + "%"
+        unbox (unbox<string> value + "%")
     static member inline percentage (value: float) : ITransformOrigin =
-        unbox<string> value + "%" 
+        unbox (unbox<string> value + "%") 


### PR DESCRIPTION
Currently, my recent change introducing `style.transformOrigin` doesn't properly work because the `origin` type isn't exposed properly (#503).

This change should allow it to be properly used by actually compiling the TransformOrigin type with the Project