### PR TITLE
let the doc comment for imported render correctly

### DIFF
--- a/Feliz/React.fs
+++ b/Feliz/React.fs
@@ -77,7 +77,7 @@ type React =
     static member inline keyedFragment(key: System.Guid, xs) =
         Fable.React.ReactBindings.React.createElement(Fable.React.ReactBindings.React.Fragment, createObj ["key" ==> string key], xs)
 
-    /// Placeholder empty React element to be used when importing external React components with the [<ReactComponent>] attribute.
+    /// Placeholder empty React element to be used when importing external React components with the `[<ReactComponent>]` attribute.
     static member inline imported() = Html.none
 
     /// The `useState` hook that creates a state variable for React function components from an initialization function.


### PR DESCRIPTION
This let's doc comment about the attribute render correctly.
![image](https://user-images.githubusercontent.com/3221269/226477789-c19e9122-c692-4c49-8094-23d69dd582a2.png)

