### PR TITLE
Addition of Scatter chart

### DIFF
--- a/Feliz.Recharts/Feliz.Recharts.fsproj
+++ b/Feliz.Recharts/Feliz.Recharts.fsproj
@@ -20,13 +20,13 @@
         <Compile Include="ErrorBar.fs" />
         <Compile Include="Brush.fs" />
         <Compile Include="Cell.fs" />
-        <Compile Include="XAxis.fs" />
-        <Compile Include="YAxis.fs" />
         <Compile Include="Text.fs" />
         <Compile Include="Tooltip.fs" />
         <Compile Include="Legend.fs" />
         <Compile Include="Label.fs" />
         <Compile Include="LabelList.fs" />
+        <Compile Include="XAxis.fs" />
+        <Compile Include="YAxis.fs" />
         <Compile Include="PolarAngleAxis.fs" />
         <Compile Include="PolarRadiusAxis.fs" />
         <Compile Include="AreaChart.fs" />

--- a/Feliz.Recharts/Interop.fs
+++ b/Feliz.Recharts/Interop.fs
@@ -18,6 +18,7 @@ module Interop =
     let inline mkBarAttr (key: string) (value: obj) : IBarProperty = unbox (key, value)
     let inline mkRadarAttr (key: string) (value: obj) : IRadarProperty = unbox (key, value)
     let inline mkScatterAttr (key: string) (value: obj) : IScatterProperty = unbox (key, value)
+    let inline mkScatterChartAttr (key: string) (value: obj): IScatterChartProperty = unbox (key, value)
     let inline mkBarChartAttr (key: string) (value: obj) : IBarChartProperty = unbox (key, value)
     let inline mkAreaAttr (key: string) (value: obj) : IAreaProperty = unbox (key, value)
     let inline mkAreaChartAttr (key: string) (value: obj) : IAreaChartProperty = unbox (key, value)

--- a/Feliz.Recharts/ScatterChart.fs
+++ b/Feliz.Recharts/ScatterChart.fs
@@ -5,6 +5,67 @@ open Feliz
 open Fable.Core
 open Fable.Core.JsInterop
 
+[<Erase>]
+type scatterChart =
+    /// The width of chart container.
+    static member inline width (value: int) = Interop.mkScatterChartAttr "width" value
+    /// The height of chart container.
+    static member inline height (value: int) = Interop.mkScatterChartAttr "height" value
+    /// The source data, in which each element is an object.
+    static member inline data (values: seq<'a>) = Interop.mkScatterChartAttr "data" (Seq.toArray values)
+    /// The source data, in which each element is an object.
+    static member inline data (values: 'a list) = Interop.mkScatterChartAttr "data" (List.toArray values)
+    /// The source data, in which each element is an object.
+    static member inline data (values: 'a array) = Interop.mkScatterChartAttr "data" values
+    static member inline children (elements: ReactElement list) = unbox<IScatterChartProperty> (prop.children elements)
+    
+    /// The sizes of whitespace around the container.
+    ///
+    /// Default value `{ top: 5, right: 5, bottom: 5, left: 5 }`
+    static member inline margin(?top: int, ?right: int, ?left: int, ?bottom: int) =
+        let margin = createObj [
+            "top" ==> Option.defaultValue 0 top
+            "right" ==> Option.defaultValue 0 right
+            "left" ==> Option.defaultValue 0 left
+            "bottom" ==> Option.defaultValue 0 bottom
+        ]
+
+        Interop.mkScatterChartAttr "margin" margin
+    static member inline onClick (handler: ChartMouseEvent<'label, 'payload> -> unit) =
+        Interop.mkScatterChartAttr "onClick" <|
+            fun eventArgs ->
+                if isNullOrUndefined eventArgs || Interop.objectHas [ "isTooltipActive" ] eventArgs
+                then ignore()
+                else handler eventArgs
+
+    static member inline onMouseEnter (handler: ChartMouseEvent<'label, 'payload> -> unit) =
+        Interop.mkScatterChartAttr "onMouseEnter" <|
+            fun eventArgs ->
+                if isNullOrUndefined eventArgs || Interop.objectHas [ "isTooltipActive" ] eventArgs
+                then ignore()
+                else handler eventArgs
+
+    static member inline onMouseMove (handler: ChartMouseEvent<'label, 'payload> -> unit) =
+        Interop.mkScatterChartAttr "onMouseMove" <|
+            fun eventArgs ->
+                if isNullOrUndefined eventArgs || Interop.objectHas [ "isTooltipActive" ] eventArgs
+                then ignore()
+                else handler eventArgs
+
+    static member inline onMouseLeave (handler: unit -> unit) = Interop.mkScatterChartAttr "onMouseLeave" handler
+    static member inline onMouseUp (handler: ChartMouseEvent<'label, 'payload> -> unit) =
+        Interop.mkScatterChartAttr "onMouseUp" <|
+            fun eventArgs ->
+                if isNullOrUndefined eventArgs || Interop.objectHas [ "isTooltipActive" ] eventArgs
+                then ignore()
+                else handler eventArgs
+
+    static member inline onMouseDown (handler: ChartMouseEvent<'label, 'payload> -> unit) =
+        Interop.mkScatterChartAttr "onMouseDown" <|
+            fun eventArgs ->
+                if isNullOrUndefined eventArgs || Interop.objectHas [ "isTooltipActive" ] eventArgs
+                then ignore()
+                else handler eventArgs
 
 [<Erase>]
 type scatter =
@@ -34,6 +95,7 @@ type scatter =
     /// The source data, in which each element is an object.
     static member inline data (values: 'a array) = Interop.mkScatterAttr "data" values 
     static member inline fill (color: string) = Interop.mkScatterAttr "fill" color 
+    static member inline children (elements: ReactElement list) = unbox<IScatterProperty> (prop.children elements)
     static member inline margin (?top: int, ?right: int, ?bottom: int, ?left: int) = 
         let margin = 
             createObj [ 

--- a/Feliz.Recharts/XAxis.fs
+++ b/Feliz.Recharts/XAxis.fs
@@ -61,6 +61,23 @@ type xAxis =
     static member inline width (value: float) = Interop.mkXAxisAttr "width" value
     static member inline reversed (value: bool) = Interop.mkXAxisAttr "reversed" value
 
+    static member inline label(value: int) = Interop.mkXAxisAttr "label" value
+    static member inline label(?value: string, ?angle: int, ?position: Label.Position) =
+        let label = createObj [
+          "value" ==> value
+          "angle" ==> angle
+          "position" ==> position
+        ]
+        Interop.mkXAxisAttr "label" label
+    static member inline label(?value: string, ?angle: int, ?position: label.position) =
+        let label = createObj [
+          "value" ==> value
+          "angle" ==> angle
+          "position" ==> position
+        ]
+        Interop.mkXAxisAttr "label" label
+    static member inline children (elements: ReactElement list) = unbox<IXAxisProperty> (prop.children elements)
+        
 module xAxis =
     /// The orientation of axis. Default is `bottom`.
     [<Erase>]

--- a/Feliz.Recharts/YAxis.fs
+++ b/Feliz.Recharts/YAxis.fs
@@ -1,6 +1,6 @@
 namespace Feliz.Recharts
 
-
+open Feliz
 open Fable.Core
 open Fable.Core.JsInterop
 
@@ -54,6 +54,23 @@ type yAxis =
     static member inline width (value: float) = Interop.mkYAxisAttr "width" value
     static member inline reversed (value: bool) = Interop.mkYAxisAttr "reversed" value
 
+    static member inline label(value: int) = Interop.mkYAxisAttr "label" value
+    static member inline label(?value: string, ?angle: int, ?position: Label.Position) =
+        let label = createObj [
+          "value" ==> value
+          "angle" ==> angle
+          "position" ==> position
+        ]
+        Interop.mkYAxisAttr "label" label
+    static member inline label(?value: string, ?angle: int, ?position: label.position) =
+        let label = createObj [
+          "value" ==> value
+          "angle" ==> angle
+          "position" ==> position
+        ]
+        Interop.mkYAxisAttr "label" label
+    static member inline children (elements: ReactElement list) = unbox<IYAxisProperty> (prop.children elements)
+        
 module yAxis =
     /// The orientation of axis. Default is `left`.
     [<Erase>]

--- a/docs/App.fs
+++ b/docs/App.fs
@@ -616,6 +616,8 @@ let samples = [
     "recharts-pie-straightangle", Samples.Recharts.PieCharts.StraightAngle.chart()
     "recharts-pie-customizedlabelpiechart", Samples.Recharts.PieCharts.CustomizedLabelPieChart.chart()
     "recharts-radar-simpleradarchart", Samples.Recharts.RadarCharts.SimpleRadarChart.chart()
+    "recharts-scatter-simplescatterchart", Samples.Recharts.ScatterCharts.SimpleScatterChart.chart()
+    "recharts-scatter-scatterchartwithlabels", Samples.Recharts.ScatterCharts.ScatterChartWithLabels.chart()
     "pigeonmaps-map-basic", Samples.PigeonMaps.Main.pigeonMap
     "pigeonmaps-map-cities", Samples.PigeonMaps.DynamicMarkers.citiesMap()
     "pigeonmaps-map-popover-hover", Samples.PigeonMaps.MarkerOverlaysOnHover.citiesMap()
@@ -1015,6 +1017,10 @@ let allItems = React.functionComponent(fun (input: {| state: State; dispatch: Ms
                     subNestedMenuList "Radar Charts" [ Urls.RadarCharts ] [
                         nestedMenuItem "Simple Radar Chart" [ Urls.SimpleRadarChart ]
                     ]
+                    subNestedMenuList "Scatter Charts" [ Urls.ScatterCharts ] [
+                        nestedMenuItem "Simple Scatter Chart" [ Urls.SimpleScatterChart ]
+                        nestedMenuItem "Scatter Chart With Labels" [ Urls.ScatterChartWithLabels ]
+                    ]
                 ]
             ]
         ]
@@ -1104,6 +1110,12 @@ let rechartsExamples (currentPath: string list) =
         | [ Urls.SimpleRadarChart ] -> [ "SimpleRadarChart.md" ]
         | _ -> []
         |> List.append [ Urls.RadarCharts ]
+    | Urls.ScatterCharts :: rest ->
+        match rest with
+        | [ Urls.SimpleScatterChart ] -> [ "SimpleScatterChart.md" ]
+        | [ Urls.ScatterChartWithLabels ] -> [ "ScatterChartWithLabels.md" ]
+        | _ -> []
+        |> List.append [ Urls.ScatterCharts ]
     | _ -> []
     |> fun path -> [ Urls.Recharts ] @ path
 

--- a/docs/App.fsproj
+++ b/docs/App.fsproj
@@ -44,6 +44,8 @@
     <Compile Include="Recharts/PieCharts/TwoLevelPieChart.fs" />
     <Compile Include="Recharts/PieCharts/StraightAngle.fs" />
     <Compile Include="Recharts/RadarCharts/SimpleRadarChart.fs" />
+    <Compile Include="Recharts/ScatterCharts/SimpleScatterChart.fs" />
+    <Compile Include="Recharts/ScatterCharts/ScatterChartWithLabels.fs" />
     <Compile Include="PigeonMaps.fs" />
     <Compile Include="Popover.fs" />
     <Compile Include="CodeSplitting.fs" />

--- a/docs/Recharts/ScatterCharts/ScatterChartWithLabels.fs
+++ b/docs/Recharts/ScatterCharts/ScatterChartWithLabels.fs
@@ -1,0 +1,50 @@
+[<RequireQualifiedAccess>]
+module Samples.Recharts.ScatterCharts.ScatterChartWithLabels
+
+open Feliz
+open Feliz.Recharts
+
+type Point = { x: int; y: int; z: int }
+
+let data = [
+    { x = 100; y = 200; z = 200 }
+    { x = 120; y = 100; z = 260 }
+    { x = 170; y = 300; z = 400 }
+    { x = 140; y = 250; z = 280 }
+    { x = 150; y = 400; z = 500 }
+    { x = 110; y = 280; z = 200 }
+]
+
+let chart = React.functionComponent(fun () -> [
+    Recharts.scatterChart [
+        scatterChart.margin(top=20, right=20, bottom=20, left=20)
+        scatterChart.children [
+            Recharts.cartesianGrid [ ]
+            Recharts.xAxis [
+                xAxis.dataKey (fun point -> point.x)
+                xAxis.type'.number
+                xAxis.name "stature"
+                xAxis.unit "cm"
+            ]
+            Recharts.yAxis [
+                yAxis.dataKey (fun point -> point.y)
+                yAxis.type'.number
+                yAxis.name "weight"
+                yAxis.unit "kg"
+            ]
+            Recharts.tooltip [
+                tooltip.cursor ("strokeDasharray", 3)
+            ]
+            Recharts.scatter [
+                scatter.name "A school"
+                scatter.data data
+                scatter.fill "#8884d8"
+                scatter.children [
+                    Recharts.labelList [
+                        labelList.dataKey (fun point -> point.x)
+                    ]
+                ]
+            ]
+        ]
+    ]
+])

--- a/docs/Recharts/ScatterCharts/SimpleScatterChart.fs
+++ b/docs/Recharts/ScatterCharts/SimpleScatterChart.fs
@@ -1,0 +1,45 @@
+[<RequireQualifiedAccess>]
+module Samples.Recharts.ScatterCharts.SimpleScatterChart
+
+open Feliz
+open Feliz.Recharts
+
+type Point = { x: int; y: int; z: int }
+
+let data = [
+    { x = 100; y = 200; z = 200 }
+    { x = 120; y = 100; z = 260 }
+    { x = 170; y = 300; z = 400 }
+    { x = 140; y = 250; z = 280 }
+    { x = 150; y = 400; z = 500 }
+    { x = 110; y = 280; z = 200 }
+]
+
+let chart = React.functionComponent(fun () -> [
+    Recharts.scatterChart [
+        scatterChart.margin(top=20, right=20, bottom=20, left=20)
+        scatterChart.children [
+            Recharts.cartesianGrid [ ]
+            Recharts.xAxis [
+                xAxis.dataKey (fun point -> point.x)
+                xAxis.type'.number
+                xAxis.name "stature"
+                xAxis.unit "cm"
+            ]
+            Recharts.yAxis [
+                yAxis.dataKey (fun point -> point.y)
+                yAxis.type'.number
+                yAxis.name "weight"
+                yAxis.unit "kg"
+            ]
+            Recharts.tooltip [
+                tooltip.cursor ("strokeDasharray", 3)
+            ]
+            Recharts.scatter [
+                scatter.name "A school"
+                scatter.data data
+                scatter.fill "#8884d8"
+            ]
+        ]
+    ]
+])

--- a/docs/Urls.fs
+++ b/docs/Urls.fs
@@ -75,6 +75,13 @@ let [<Literal>] WorkingWithDates = "WorkingWithDates"
 
 // ____________________________________________________
 
+let [<Literal>] ScatterCharts = "ScatterCharts"
+
+let [<Literal>] SimpleScatterChart = "ScatterCharts"
+let [<Literal>] ScatterChartWithLabels = "ScatterChartWithLabels"
+
+// ____________________________________________________
+
 let [<Literal>] React = "React"
 
 let [<Literal>] CodeSplitting = "CodeSplitting"


### PR DESCRIPTION
This PR adds the ReCharts.ScatterChart and an entry into the live-samples based on a translation of the original documentation. 

In addition I also added some of the missing props for `XAxis`, `YAxis` and `scatter` from the Recharts API page.