### PR TITLE
Clarify need to install use-sync-external-store via npm or use femto

### DIFF
--- a/public/Feliz.UseElmish/Index.md
+++ b/public/Feliz.UseElmish/Index.md
@@ -8,7 +8,12 @@ The implementation of this approach is made possible using a React hook called `
 
 ### Install into your project
 ```bash
+npm install use-sync-external-store
 dotnet add package Feliz.UseElmish
+
+or
+
+dotnet femto install Feliz.UseElmish
 ```
 
 Here is an example to demonstrate how to build such component:


### PR DESCRIPTION
The documentation says to simply install Feliz.UseElmish via dotnet package add command. This will lead to an error about missing the use-sync-external-store dependency. The femto install handles this.

Updating the documentation to reflect this and avoid issues during install.