### PR TITLE
Add yAxis tickFormatter

### DIFF
--- a/Feliz.Recharts/YAxis.fs
+++ b/Feliz.Recharts/YAxis.fs
@@ -34,6 +34,7 @@ type yAxis =
     static member inline allowDuplicatedCategory (value: bool) = Interop.mkYAxisAttr "allowDuplicatedCategory" value
     /// The count of axis ticks. Not used if 'type' is 'category'. Default is `5`.
     static member inline tickCount (value: int) = Interop.mkYAxisAttr "tickCount" value
+    static member inline tickFormatter (f: int -> string) = Interop.mkYAxisAttr "tickFormatter" f
     static member inline domain (min: IAxisDomain, max: IAxisDomain) = Interop.mkYAxisAttr "domain" [| min; max |]
     static member inline interval (value: int) = Interop.mkYAxisAttr "interval" value
     /// Specify the padding of y-axis. Default is `yAxis.padding(top=0, bottom=0)`.


### PR DESCRIPTION
Fixes https://github.com/Zaid-Ajaj/Feliz/issues/436

Example usage:
```fsharp
Recharts.yAxis [
   yAxis.yAxisId "moneyFlow"
   yAxis.padding (bottom = opts.YAxisPaddingBottom)
   yAxis.tickCount opts.AmountInterval
   yAxis.tickFormatter (decimal >> Money.formatShort)
]
```

Demo of representing ticks as formatted short-form money instead of integers:
<img width="1316" alt="Screenshot 2024-10-11 at 4 38 09 PM" src="https://github.com/user-attachments/assets/d9d27f05-1436-45fb-96de-a7432e07d7b5">
