### PR TITLE
Added `menu` HTML element to Html.fs

### DIFF
--- a/Feliz/Html.fs
+++ b/Feliz/Html.fs
@@ -490,6 +490,9 @@ type Html =
 
     static member inline meta xs = Interop.createElement "meta" xs
 
+    static member inline menu xs = Interop.createElement "menu" xs
+    static member inline menu (children: #seq<ReactElement>) = Interop.reactElementWithChildren "menu" children
+
     static member inline metadata xs = Interop.createElement "metadata" xs
     static member inline metadata (children: #seq<ReactElement>) = Interop.reactElementWithChildren "metadata" children
 


### PR DESCRIPTION
Added the missing `menu` element to Html.fs so it behaves the same as  the `ul` element, as it is a *semantic* alternative: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/menu