### PR TITLE
Proposal for representing static children and selectively avoid React warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,5 +209,6 @@ dist
 # JetBrains Rider
 .idea
 *.fs.js
+*.fs.js.map
 0.bundle.js
 .yarn

--- a/Feliz/Interop.fs
+++ b/Feliz/Interop.fs
@@ -8,8 +8,14 @@ open Feliz.ReactApi
 let reactApi : IReactApi = importDefault "react"
 #if FABLE_COMPILER_3 || FABLE_COMPILER_4
 let inline reactElement (name: string) (props: 'a) : ReactElement = import "createElement" "react"
+[<Emit "createElement.apply(null, [$0, $1, ...$2])">]
+let inline reactElementApply (name: string) (props: 'a) (nested: #seq<ReactElement>) : ReactElement = jsNative
+
 #else
 let reactElement (name: string) (props: 'a) : ReactElement = import "createElement" "react"
+[<Emit "createElement.apply(null, [$0, $1, ...$2])">]
+let inline reactElementApply (name: string) (props: 'a) (nested: #seq<ReactElement>) : ReactElement = jsNative
+
 #endif
 let inline mkAttr (key: string) (value: obj) : IReactProperty = unbox (key, value)
 [<Emit "undefined">]
@@ -17,11 +23,19 @@ let undefined : obj = jsNative
 let inline mkStyle (key: string) (value: obj) : IStyleAttribute = unbox (key, value)
 let inline svgAttribute (key: string) (value: obj) : ISvgAttribute = unbox (key, value)
 let inline reactElementWithChild (name: string) (child: 'a) =
+    // printfn "reactElementWithChild: %A" child
     reactElement name (createObj [ "children" ==> ResizeArray [| child |] ])
 let inline reactElementWithChildren (name: string) (children: #seq<ReactElement>) =
-    reactElement name (createObj [ "children" ==> reactApi.Children.toArray (Array.ofSeq children) ])
+    // printfn "reactElementWithChildren: %A" children
+    reactElement name  (createObj [ "children" ==> reactApi.Children.toArray (Array.ofSeq children) ])
+
 let inline createElement name (properties: IReactProperty list) : ReactElement =
-    reactElement name (createObj !!properties)
+    // printfn "createElement: %A" properties
+    let obj : (string * obj) list = !!properties
+    let nested = obj |> List.tryFind (fun (k, v) -> k = "nested")
+    let others = obj |> List.filter (fun (k, v) -> k <> "nested")
+    let props = createObj others
+    reactElementApply name props !!others
 let inline createSvgElement name (properties: ISvgAttribute list) : ReactElement =
     reactElement name (createObj !!properties)
 

--- a/Feliz/Interop.fs
+++ b/Feliz/Interop.fs
@@ -5,6 +5,7 @@ open Fable.Core.JsInterop
 open Fable.React
 open Feliz.ReactApi
 
+
 let reactApi : IReactApi = importDefault "react"
 #if FABLE_COMPILER_3 || FABLE_COMPILER_4
 let inline reactElement (name: string) (props: 'a) : ReactElement = import "createElement" "react"
@@ -29,13 +30,15 @@ let inline reactElementWithChildren (name: string) (children: #seq<ReactElement>
     // printfn "reactElementWithChildren: %A" children
     reactElement name  (createObj [ "children" ==> reactApi.Children.toArray (Array.ofSeq children) ])
 
+[<Emit "console.log($0,$1)">]
+let inline log (x: obj) : unit = jsNative
 let inline createElement name (properties: IReactProperty list) : ReactElement =
     // printfn "createElement: %A" properties
     let obj : (string * obj) list = !!properties
-    let nested = obj |> List.tryFind (fun (k, v) -> k = "nested")
+    let nested = obj |> List.tryPick (function ("nested", v) -> Some v | _ -> None) |> Option.defaultValue []
     let others = obj |> List.filter (fun (k, v) -> k <> "nested")
     let props = createObj others
-    reactElementApply name props !!others
+    reactElementApply name props !!nested
 let inline createSvgElement name (properties: ISvgAttribute list) : ReactElement =
     reactElement name (createObj !!properties)
 

--- a/Feliz/Interop.fs
+++ b/Feliz/Interop.fs
@@ -30,15 +30,11 @@ let inline reactElementWithChildren (name: string) (children: #seq<ReactElement>
     // printfn "reactElementWithChildren: %A" children
     reactElement name  (createObj [ "children" ==> reactApi.Children.toArray (Array.ofSeq children) ])
 
-[<Emit "console.log($0,$1)">]
-let inline log (x: obj) : unit = jsNative
 let inline createElement name (properties: IReactProperty list) : ReactElement =
-    // printfn "createElement: %A" properties
-    let obj : (string * obj) list = !!properties
-    let nested = obj |> List.tryPick (function ("nested", v) -> Some v | _ -> None) |> Option.defaultValue []
-    let others = obj |> List.filter (fun (k, v) -> k <> "nested")
-    let props = createObj others
-    reactElementApply name props !!nested
+    let props = createObj !!properties
+    let nested = emitJsExpr (props) "$0.nested || []"
+    emitJsStatement  (props)"delete $0.nested"
+    reactElementApply name props nested
 let inline createSvgElement name (properties: ISvgAttribute list) : ReactElement =
     reactElement name (createObj !!properties)
 

--- a/Feliz/Interop.fs
+++ b/Feliz/Interop.fs
@@ -7,14 +7,19 @@ open Feliz.ReactApi
 
 
 let reactApi : IReactApi = importDefault "react"
+
 #if FABLE_COMPILER_3 || FABLE_COMPILER_4
 let inline reactElement (name: string) (props: 'a) : ReactElement = import "createElement" "react"
-[<Emit "createElement.apply(null, [$0, $1, ...$2])">]
-let inline reactElementApply (name: string) (props: 'a) (nested: #seq<ReactElement>) : ReactElement = jsNative
+
+[<Import("createElement", "react")>]
+[<Emit "$0.apply(null, [$1, $2, ...$3])">]
+let inline reactElementApply (name: string) (props: 'a) (nested: #seq<ReactElement>) : ReactElement = jsNative 
 
 #else
 let reactElement (name: string) (props: 'a) : ReactElement = import "createElement" "react"
-[<Emit "createElement.apply(null, [$0, $1, ...$2])">]
+
+[<Import("createElement", "react")>]
+[<Emit "$0.apply(null, [$1, $2, ...$3])">]
 let inline reactElementApply (name: string) (props: 'a) (nested: #seq<ReactElement>) : ReactElement = jsNative
 
 #endif

--- a/Feliz/Properties.fs
+++ b/Feliz/Properties.fs
@@ -999,6 +999,11 @@ type prop =
     /// For example used by the server to identify the fields in form submits.
     static member inline name (value: string) = Interop.mkAttr "name" value
 
+    /// Includes static nested elements
+    static member inline nested (elems: Fable.React.ReactElement seq) = 
+      Interop.mkAttr "nested" (Interop.reactApi.Children.toArray (Array.ofSeq elems))
+
+
     /// This Boolean attribute is set to indicate that the script should not be executed in
     /// browsers that support ES2015 modules — in effect, this can be used to serve fallback
     /// scripts to older browsers that do not support modular JavaScript code.


### PR DESCRIPTION
This PR aims at solving the issue of not currently having a way to distinguish a static list of children from a dynamic one (e.g. a List.map).
Any solution that suppresses React warnings for lists without key is IMHO bad and it would be better to provide a way to express a static list of children; this should not be the default and using it will be a conscious choice, so we will never hide the warnings to the developers so they will realize when they missed to pass the keys.
More details and the logic behind it are in the discussion of the Issue #21 
