### PR TITLE
Add Elmish Subscription Support and Tests to Feliz.UseElmish

### DIFF
--- a/src/Feliz.UseElmish/UseElmish.fs
+++ b/src/Feliz.UseElmish/UseElmish.fs
@@ -133,3 +133,18 @@ type React =
 
     static member inline useElmish(init: 'Model * Cmd<'Msg>, update: 'Msg -> 'Model -> 'Model * Cmd<'Msg>, ?dependencies: obj array) =
         React.useElmish((fun () -> Program.mkProgram (fun () -> init) update (fun _ _ -> ())), ?dependencies=dependencies)
+
+    static member inline useElmish(init: 'Arg -> 'Model * Cmd<'Msg>, update: 'Msg -> 'Model -> 'Model * Cmd<'Msg>, subscribe: 'Model -> Sub<'Msg>, arg: 'Arg, ?dependencies: obj array) =
+        React.useElmish((fun () -> 
+            Program.mkProgram init update (fun _ _ -> ())
+            |> Program.withSubscription subscribe), arg, ?dependencies=dependencies)
+
+    static member inline useElmish(init: unit -> 'Model * Cmd<'Msg>, update: 'Msg -> 'Model -> 'Model * Cmd<'Msg>, subscribe: 'Model -> Sub<'Msg>, ?dependencies: obj array) =
+        React.useElmish((fun () -> 
+            Program.mkProgram init update (fun _ _ -> ())
+            |> Program.withSubscription subscribe), ?dependencies=dependencies)
+
+    static member inline useElmish(init: 'Model * Cmd<'Msg>, update: 'Msg -> 'Model -> 'Model * Cmd<'Msg>, subscribe: 'Model -> Sub<'Msg>, ?dependencies: obj array) =
+        React.useElmish((fun () -> 
+            Program.mkProgram (fun () -> init) update (fun _ _ -> ())
+            |> Program.withSubscription subscribe), ?dependencies=dependencies)

--- a/tests/Feliz.UseElmish/Main.test.fs
+++ b/tests/Feliz.UseElmish/Main.test.fs
@@ -181,14 +181,12 @@ module Subscriber =
                 100
         { new System.IDisposable with member _.Dispose() = clearInterval subscriptionId }
 
-    let makeProgram initialValue =
-        Program.mkProgram (fun () -> init initialValue) update (fun _ _ -> ())
-        |> Program.withSubscription (fun _model ->
-            [ ["timer"], subscribeToTimer ])
+    let subscribe _model =
+        [ ["timer"], subscribeToTimer ]
 
     [<ReactComponent>]
     let render (props: {| initialValue: int |}) =
-        let model, dispatch = React.useElmish((fun () -> makeProgram props.initialValue), (), [||])
+        let model, dispatch = React.useElmish((fun () -> init props.initialValue), update, subscribe, [||])
 
         Html.div [
             Html.h1 [
@@ -220,7 +218,7 @@ describe "UseElmish with subscriptions" <| fun () ->
 
         do!
             RTL.waitFor (fun () ->
-                let ticks = render.getByTestId("subscriber-ticks").innerText |> int
+                let ticks = render.getByTestId("subscriber-ticks").textContent |> int
                 expect(ticks >= 3).toBeTruthy() //"Subscriber should have ticked at least 3 times"
             )
 


### PR DESCRIPTION
(Note: This is my second attempt at a PR, as the first was on the main branch, not feliz_v3.0)

This PR addresses #570, where it was reported that Elmish subscriptions did not work with Feliz.UseElmish. While later versions have already resolved the underlying issue, this PR adds a test and with additional API overloads to `React.useElmish`.

Previously, to use subscriptions, developers had to use `Program.mkProgram`, which is a bit fiddly and not commonly used (from my experience).

```fsharp
let makeProgram initialValue =
    Program.mkProgram (fun () -> init initialValue) update (fun _ _ -> ())
    |> Program.withSubscription subscribe
    
let model, dispatch = React.useElmish((fun () -> makeProgram props.initialValue), [||])
```

I propose that we create additional overloads for `React.useElmish` to accept subscriptions, aligning with how Elmish is commonly used within components. Whish would make the experience look something like this:

```fsharp
let model, dispatch = React.useElmish((fun () -> init props.initialValue), update, subscribe, [||])
```

Regarding testing, I've added a basic test of a subscriber using the new overload.

I'm happy to add to the docs if we think this is a good approach, so please let me know what you think.




